### PR TITLE
fix NaN issue with pedestrians

### DIFF
--- a/src/aframe-streetmix-parsers.js
+++ b/src/aframe-streetmix-parsers.js
@@ -233,7 +233,7 @@ function createSidewalkClonedVariants (BasePositionX, segmentWidthInMeters, dens
     // y = 0.2 for sidewalk elevation
     const placedObjectEl = document.createElement('a-entity');
     let animationDirection = 'inbound';
-    placedObjectEl.setAttribute('position', `${xVal}' '${yVal}' '${zVal}`);
+    placedObjectEl.setAttribute('position', `${xVal} ${yVal} ${zVal}`);
     placedObjectEl.setAttribute('mixin', variantName);
     // Roughly 50% of traffic will be incoming
     if (Math.random() < 0.5 && direction === 'random') {


### PR DESCRIPTION
I noticed that the pedestrians do not appear after the last merge due to the fact that NaN values were passed to their position. I made a typo in the penultimate commit when I changed object3D.set to setAttribute. I fixed a typo in this commit.