### PR TITLE
remove parent elements if they exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,14 @@ AFRAME.registerComponent('street', {
     }
 
     const streetmixSegments = JSON.parse(data.JSON);
+
+    // remove .street-parent element, if it exists, with old scene elements. 
+    // Because it will be created next in the processSegments function
+    const streetParent = this.el.querySelector('.street-parent');
+    if (streetParent) {
+      streetParent.remove();
+    }
+
     const streetEl = streetmixParsers.processSegments(streetmixSegments.streetmixSegmentsFeet, data.showStriping, data.length, data.globalAnimated, data.showVehicles);
     this.el.append(streetEl);
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,15 @@ AFRAME.registerComponent('street', {
 
     const streetmixSegments = JSON.parse(data.JSON);
 
-    // remove .street-parent element, if it exists, with old scene elements. 
-    // Because it will be created next in the processSegments function
+    // remove .street-parent and .buildings-parent elements, if they exists, with old scene elements. 
+    // Because they will be created next in the processSegments and processBuildings functions
     const streetParent = this.el.querySelector('.street-parent');
     if (streetParent) {
       streetParent.remove();
+    }
+    const buildingParent = this.el.querySelector('buildings-parent');
+    if (buildingParent) {
+      buildingParent.remove();
     }
 
     const streetEl = streetmixParsers.processSegments(streetmixSegments.streetmixSegmentsFeet, data.showStriping, data.length, data.globalAnimated, data.showVehicles);


### PR DESCRIPTION
Now, when changing the parameters of the `street` component, such as global-animated, show-ground, show-vehicles and others, the scene is reloaded with the new parameters. I noticed one problem - when the length of the street changes, the length of the buildings is also changes, but the length of the ground element always remains equal to 60. Also, switching the showGround parameter does not work yet