### PR TITLE
Load from url encoded json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,13 +67,57 @@ AFRAME.registerComponent('streetmix-loader', {
     streetmixStreetURL: { type: 'string' },
     streetmixAPIURL: { type: 'string' },
     showBuildings: { default: true },
-    name: { default: '' }
+    name: { default: '' },
+    streetmixJSON: { type: 'string', default: '' }
+  },
+  loadFromJSON: function (streetmixResponseObject) {
+    if (!streetmixResponseObject) {
+      console.log("No JSON provided")
+      return;
+    }
+    const data = this.data;
+    const el = this.el;
+
+    // convert units of measurement if necessary
+    const streetData = streetmixUtils.convertStreetValues(streetmixResponseObject.data.street);
+    const streetmixSegments = streetData.segments;
+
+    const streetmixName = streetmixResponseObject.name;
+    console.log('streetmixName', streetmixName);
+    //el.setAttribute('streetmix-loader', 'name', streetmixName);
+
+    let currentSceneTitle;
+    if (AFRAME.scenes[0] && AFRAME.scenes[0].getAttribute('metadata')) {
+      currentSceneTitle = AFRAME.scenes[0].getAttribute('metadata').sceneTitle;
+    }
+    if (!currentSceneTitle) { // only set title from streetmix if none exists
+      AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', streetmixName);
+      console.log('therefore setting metadata sceneTitle as streetmixName', streetmixName);
+    }
+
+    el.setAttribute('data-layer-name', 'Streetmix • ' + streetmixName);
+
+    if (data.showBuildings) {
+      el.setAttribute('street', 'right', streetData.rightBuildingVariant);
+      el.setAttribute('street', 'left', streetData.leftBuildingVariant);
+    }
+    el.setAttribute('street', 'type', 'streetmixSegmentsMetric');
+    // set JSON attribute last or it messes things up
+    el.setAttribute('street', 'JSON', JSON.stringify({ streetmixSegmentsMetric: streetmixSegments }));
+    el.emit('streetmix-loader-street-loaded');
   },
   update: function (oldData) { // fired at start and at each subsequent change of any schema value
     // This method may fire a few times when viewing a streetmix street in 3dstreet:
     // First to find the proper path, once to actually load the street, and then subsequent updates such as street name
     var data = this.data;
     var el = this.el;
+
+    // load street from provided JSON with streetmix format
+    if (data.streetmixJSON !== '') {
+      this.loadFromJSON(data.streetmixJSON);
+      data.streetmixJSON == '';
+      return;
+    }
 
     // if the loader has run once already, and upon update neither URL has changed, do not take action
     if ((oldData.streetmixStreetURL === data.streetmixStreetURL) && (oldData.streetmixAPIURL === data.streetmixAPIURL)) {
@@ -95,39 +139,17 @@ AFRAME.registerComponent('streetmix-loader', {
 
     var request = new XMLHttpRequest();
     console.log('[streetmix-loader]', 'GET ' + data.streetmixAPIURL);
+    
+    // for using inside request callback function 
+    const loadFromJSON = this.loadFromJSON.bind(this);
 
     request.open('GET', data.streetmixAPIURL, true);
     request.onload = function () {
       if (this.status >= 200 && this.status < 400) {
         // Connection success
         const streetmixResponseObject = JSON.parse(this.response);
-        // convert units of measurement if necessary
-        const streetData = streetmixUtils.convertStreetValues(streetmixResponseObject.data.street);
-        const streetmixSegments = streetData.segments;
-
-        const streetmixName = streetmixResponseObject.name;
-        console.log('streetmixName', streetmixName);
-        el.setAttribute('streetmix-loader', 'name', streetmixName);
-
-        let currentSceneTitle;
-        if (AFRAME.scenes[0] && AFRAME.scenes[0].getAttribute('metadata')) {
-          currentSceneTitle = AFRAME.scenes[0].getAttribute('metadata').sceneTitle;
-        }
-        if (!currentSceneTitle) { // only set title from streetmix if none exists
-          AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', streetmixName);
-          console.log('therefore setting metadata sceneTitle as streetmixName', streetmixName);
-        }
-
-        el.setAttribute('data-layer-name', 'Streetmix • ' + streetmixName);
-
-        if (data.showBuildings) {
-          el.setAttribute('street', 'right', streetData.rightBuildingVariant);
-          el.setAttribute('street', 'left', streetData.leftBuildingVariant);
-        }
-        el.setAttribute('street', 'type', 'streetmixSegmentsMetric');
-        // set JSON attribute last or it messes things up
-        el.setAttribute('street', 'JSON', JSON.stringify({ streetmixSegmentsMetric: streetmixSegments }));
-        el.emit('streetmix-loader-street-loaded');
+        
+        loadFromJSON(streetmixResponseObject);
       } else {
         // We reached our target server, but it returned an error
         console.log('[streetmix-loader]', 'Loading Error: We reached the target server, but it returned an error');

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -543,6 +543,11 @@ AFRAME.registerComponent('set-loader-from-hash', {
         const streetmixJSON = JSON.parse(JSONString);
         console.log(streetmixJSON);
         this.el.setAttribute('streetmix-loader', 'streetmixJSON', streetmixJSON);
+      } else if (streetURL.startsWith('3dstreet-json:')){
+
+        const JSONString = decodeURIComponent(streetURL.split('3dstreet-json:')[1]);
+        console.log(JSONString)
+        this.createStreetFromJSONData(JSONString);
       } else {
         // try to load JSON file from remote resource
         console.log(


### PR DESCRIPTION
to load from url encoded streetmix json you need:
1. Url encoded streetmix JSON. JSON can be obtained from the Editor, `StreetmixAPIURL` parameter in the `streetmix-loader` component of the #default-street element. String can be encoded through encodeURIComponent func in console or here for example: https://www.urlencoder.org/
2. Paste encoded string after `http://localhost:7001/#streetmix-json:` or `http://localhost:7001/#3dstreet-json:` for 3dstreet data