### PR TITLE
Change street component parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
         <!-- uncomment the line below to load all possible asset categories -->
         <!-- <street-assets categories="sidewalk-props people people-rigged vehicles vehicles-rigged buildings intersection-props segment-textures segment-colors lane-separator stencils vehicles-transit dividers sky grounds"></street-assets>   -->
         <!-- a reduced set of assets for non-animated streetmix streets without intersections -->
-        <street-assets categories="loud-bicycle sidewalk-props people vehicles vehicles-rigged buildings segment-textures segment-colors lane-separator stencils vehicles-transit dividers sky grounds"></street-assets>
+        <street-assets categories="cyclists sidewalk-props people vehicles vehicles-rigged buildings segment-textures segment-colors lane-separator stencils vehicles-transit dividers sky grounds"></street-assets>
       </a-assets>
   
       <a-entity id="street-container" data-layer-name="3D Street Layers" data-layer-show-children>

--- a/mapbox.html
+++ b/mapbox.html
@@ -10,9 +10,6 @@
     <!-- mapbox -->
     <script src="https://github.3dstreet.org/src/lib/aframe-mapbox-component.min.js"></script>
 
-    <!-- save / load -->
-    <script src="./src/json-utils.js"></script>
-
     <title>3DStreet</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/x-icon" href="ui_assets/favicon.ico">
@@ -126,8 +123,9 @@
     </a-scene>
   </body>
   <script>
+
     document.getElementById('inputfile')
-            .addEventListener('change', fileJSON);
+            .addEventListener('change', STREET.utils.fileJSON);
 
     function buttonScreenshotTock() {
       const screenshotEl = document.getElementById('screenshot');
@@ -149,6 +147,7 @@
         }, this.data * 1000)
       }
     });  
+    
   </script>
 
   <!-- Google Analytics - Global site tag (gtag.js) -->

--- a/src/assets.js
+++ b/src/assets.js
@@ -231,14 +231,16 @@ function buildAssetHTML (assetUrl, categories) {
         <a-asset-item id="fence-model" src="${assetUrl}sets/fences/gltf-exports/draco/fence4.glb"></a-asset-item>
         <a-mixin shadow id="fence" gltf-model="#fence-model" scale="0.1 0.1 0.1"></a-mixin>
       `,
-    'loud-bicycle': `
-        <!-- loud-bicycle-game -->
+    cyclists: `
         <a-mixin shadow id="cyclist-cargo" gltf-model="url(${assetUrl}sets/cargo-bike-animation/gltf-exports/draco/cargo_bike_animation_v1.glb)"></a-mixin>
         <a-mixin shadow id="cyclist1" gltf-model="url(${assetUrl}sets/cyclist-animation/gltf-exports/draco/cyclist-1-animation-v1.glb)"></a-mixin>
         <a-mixin shadow id="cyclist2" gltf-model="url(${assetUrl}sets/cyclist-animation/gltf-exports/draco/cyclist-2-animation-v1.glb)"></a-mixin>
         <a-mixin shadow id="cyclist3" gltf-model="url(${assetUrl}sets/cyclist-animation/gltf-exports/draco/cyclist-3-animation-v1.glb)"></a-mixin>
         <a-mixin shadow id="cyclist-kid" gltf-model="url(${assetUrl}sets/cyclist-animation/gltf-exports/draco/Kid_cyclist_animation_v01.glb)"></a-mixin>
         <a-mixin shadow id="cyclist-dutch" gltf-model="url(${assetUrl}sets/cyclist-animation/gltf-exports/draco/Dutch_cyclist_animation_v01.glb)"></a-mixin>
+      `,
+    'loud-bicycle': `
+        <!-- loud-bicycle-game -->
         <a-mixin shadow id="loud-bicycle-mini" gltf-model="url(${assetUrl}sets/cycle-horn/gltf-exports/draco/loud-bicycle-mini-horn.glb)"></a-mixin>
         <a-mixin shadow id="loud-bicycle-classic" gltf-model="url(${assetUrl}sets/cycle-horn/gltf-exports/draco/loud-bicycle-classic-horn.glb)"></a-mixin>
         <a-mixin shadow id="building-school" gltf-model="url(${assetUrl}sets/school-building/gltf-exports/draco/school-building.glb)"></a-mixin>

--- a/src/components/streetplan-loader.js
+++ b/src/components/streetplan-loader.js
@@ -75,6 +75,8 @@ AFRAME.registerComponent('streetplan-loader', {
       return;
     }
 
+    STREET.sourceType = 'streetplanURL'; // it also could be jsonFile/streetmixURL
+    
     var request = new XMLHttpRequest();
     console.log('[streetplan-loader]', 'GET ' + data.streetplanAPIURL);
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ if (typeof VERSION !== 'undefined') { console.log(`3DStreet Version: ${VERSION}`
 var streetmixParsers = require('./aframe-streetmix-parsers');
 var streetmixUtils = require('./tested/streetmix-utils');
 require('./json-utils_1.1.js');
+require('./street-utils.js');
 require('./components/gltf-part');
 require('./components/ocean');
 require('./components/svg-extruder.js');

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ if (typeof VERSION !== 'undefined') { console.log(`3DStreet Version: ${VERSION}`
 var streetmixParsers = require('./aframe-streetmix-parsers');
 var streetmixUtils = require('./tested/streetmix-utils');
 require('./json-utils_1.1.js');
-require('./street-utils.js');
 require('./components/gltf-part');
 require('./components/ocean');
 require('./components/svg-extruder.js');
@@ -39,17 +38,6 @@ AFRAME.registerComponent('street', {
     }
 
     const streetmixSegments = JSON.parse(data.JSON);
-
-    // remove .street-parent and .buildings-parent elements, if they exists, with old scene elements.
-    // Because they will be created next in the processSegments and processBuildings functions
-    const streetParent = this.el.querySelector('.street-parent');
-    if (streetParent) {
-      streetParent.remove();
-    }
-    const buildingParent = this.el.querySelector('.buildings-parent');
-    if (buildingParent) {
-      buildingParent.remove();
-    }
 
     const streetEl = streetmixParsers.processSegments(streetmixSegments.streetmixSegmentsMetric, data.showStriping, data.length, data.globalAnimated, data.showVehicles);
     this.el.append(streetEl);
@@ -109,6 +97,7 @@ AFRAME.registerComponent('streetmix-loader', {
 
         const streetmixName = streetmixResponseObject.name;
         console.log('streetmixName', streetmixName);
+
         el.setAttribute('streetmix-loader', 'name', streetmixName);
 
         let currentSceneTitle;

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,18 @@ AFRAME.registerComponent('street', {
       return;
     }
 
+    // remove .street-parent and .buildings-parent elements, if they exists, with old scene elements.
+    // Because they will be created next in the processSegments and processBuildings functions.
+    // this is also necessary when changing the parameters of the street component to reload the scene    const streetParent = this.el.querySelector('.street-parent');
+    const streetParent = this.el.querySelector('.street-parent');
+    if (streetParent) {
+      streetParent.remove();
+    }
+    const buildingParent = this.el.querySelector('.buildings-parent');
+    if (buildingParent) {
+      buildingParent.remove();
+    }
+
     const streetmixSegments = JSON.parse(data.JSON);
 
     const streetEl = streetmixParsers.processSegments(streetmixSegments.streetmixSegmentsMetric, data.showStriping, data.length, data.globalAnimated, data.showVehicles);

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -181,9 +181,6 @@ const removeProps = {
 };
 // a list of component_name:new_component_name pairs to rename in JSON string
 const renameProps = {
-  'streetmix-loader': 'not-streetmix-loader',
-  street: 'not-street',
-  intersection: 'not-intersection'
 };
 
 function filterJSONstreet (streetJSON) {

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -517,7 +517,7 @@ AFRAME.registerComponent('set-loader-from-hash', {
   },
   play: function () {
     // using play instead of init method so scene loads before setting its metadata component
-    if (!this.runOnce) {
+    if (!this.runOnce) {      
       this.runOnce = true;
       // get hash from window
       const streetURL = window.location.hash.substring(1);
@@ -530,6 +530,9 @@ AFRAME.registerComponent('set-loader-from-hash', {
           'Set streetmix-loader streetmixStreetURL to',
           streetURL
         );
+
+        STREET.utils.newScene(true, false);
+
         this.el.setAttribute(
           'streetmix-loader',
           'streetmixStreetURL',
@@ -542,6 +545,9 @@ AFRAME.registerComponent('set-loader-from-hash', {
           'Set streetplan-loader streetplanAPIURL to',
           streetURL
         );
+
+        STREET.utils.newScene(true, false);
+
         this.el.setAttribute(
           'streetplan-loader',
           'streetplanAPIURL',
@@ -620,19 +626,17 @@ function inputStreetmix () {
     'Please enter a Streetmix URL',
     'https://streetmix.net/kfarr/3/example-street'
   );
+  // clrear scene data, create new blank scene.
+  // clearMetadata = true, clearUrlHash = false
+  STREET.utils.newScene(true, false);
+
   setTimeout(function () {
     window.location.hash = streetmixURL;
   });
-  streetContainerEl = document.getElementById('street-container');
-  while (streetContainerEl.firstChild) {
-    streetContainerEl.removeChild(streetContainerEl.lastChild);
-  }
-  AFRAME.scenes[0].setAttribute('metadata', 'sceneId', '');
-  AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', '');
-  streetContainerEl.innerHTML =
-    '<a-entity street streetmix-loader="streetmixStreetURL: ' +
-    streetmixURL +
-    '""></a-entity>';
+  
+  defaultStreetEl = document.getElementById('default-street');
+  defaultStreetEl.setAttribute('streetmix-loader', 'streetmixStreetURL', streetmixURL);
+
 }
 
 STREET.utils.inputStreetmix = inputStreetmix;
@@ -656,6 +660,10 @@ function createElementsFromJSON (streetJSON) {
     streetObject = streetJSON;
   }
 
+  // clrear scene data, create new blank scene.
+  // clearMetadata = true, clearUrlHash = true, addDefaultStreet = false
+  STREET.utils.newScene(true, false, false);
+
   const sceneTitle = streetObject.title;
   if (sceneTitle) {
     console.log('sceneTitle from createElementsFromJSON', sceneTitle);
@@ -663,9 +671,6 @@ function createElementsFromJSON (streetJSON) {
   }
 
   streetContainerEl = document.getElementById('street-container');
-  while (streetContainerEl.firstChild) {
-    streetContainerEl.removeChild(streetContainerEl.lastChild);
-  }
 
   createEntities(streetObject.data, streetContainerEl);
   STREET.notify.successMessage('Scene loaded from JSON');
@@ -685,8 +690,6 @@ function inputJSON () {
 function fileJSON () {
   const reader = new FileReader();
   reader.onload = function () {
-    AFRAME.scenes[0].setAttribute('metadata', 'sceneId', '');
-    AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', '');
     createElementsFromJSON(reader.result);
   };
   reader.readAsText(this.files[0]);

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -630,6 +630,8 @@ function inputStreetmix () {
   // clearMetadata = true, clearUrlHash = false
   STREET.utils.newScene(true, false);
 
+  STREET.sourceType = 'streetmixURL'; // it also could be jsonFile/streetplanURL
+
   setTimeout(function () {
     window.location.hash = streetmixURL;
   });
@@ -663,6 +665,8 @@ function createElementsFromJSON (streetJSON) {
   // clrear scene data, create new blank scene.
   // clearMetadata = true, clearUrlHash = true, addDefaultStreet = false
   STREET.utils.newScene(true, false, false);
+
+  STREET.sourceType = 'jsonFile'; // it also could be streetmix/streetplan
 
   const sceneTitle = streetObject.title;
   if (sceneTitle) {

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -19,7 +19,7 @@ function checkOrCreateEntity(elementId, outerHTML) {
 /* 
 clear old scene elements and data. Create blank scene 
 */
-function newScene(clearMetaData=true, clearUrlHash=true) {
+function newScene(clearMetaData=true, clearUrlHash=true, addDefaultStreet=true) {
 
     const environmentHTML = 
     `<a-entity id="environment" data-layer-name="Environment" street-environment="preset: day;"></a-entity>`;
@@ -34,7 +34,7 @@ function newScene(clearMetaData=true, clearUrlHash=true) {
 	// clear street-container element
 	const streetContainerArray = Array.from(streetContainerEl.children);
 	for (childEl of streetContainerArray) {
-		if (childEl.id !== 'default-street') {
+		if (!addDefaultStreet || childEl.id !== 'default-street') {
 			streetContainerEl.removeChild(childEl);
 		} else {
 			// clear default-street element
@@ -48,7 +48,7 @@ function newScene(clearMetaData=true, clearUrlHash=true) {
 		}
 	}
 
-	if (!streetContainerEl.querySelector("#default-street")) {
+	if (!streetContainerEl.querySelector("#default-street") && addDefaultStreet) {
 		// create default-street element
 		const defaultStreet = document.createElement("a-entity");
 		defaultStreet.id = "default-street";
@@ -58,6 +58,9 @@ function newScene(clearMetaData=true, clearUrlHash=true) {
 
 	checkOrCreateEntity("environment", environmentHTML);
 	checkOrCreateEntity("reference-layers", referenceLayersHTML);
+
+	// update sceneGraph
+	Events.emit('entitycreated', streetContainerEl.sceneEl);
 
 	// clear metadata
 	if (clearMetaData) {

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -1,0 +1,45 @@
+/* global AFRAME, THREE */
+/* 3DStreet utils functions */
+
+/* 
+clear old scene elements and data. Create blank scene 
+*/
+function newScene() {
+	
+	const streetContainerEl = document.querySelector("#street-container");
+	const environmentEl = document.querySelector("#environment");
+	const referenceLayersEl = document.querySelector("#reference-layers");
+
+	// clear street-container element
+	while (streetContainerEl.firstChild) {
+		streetContainerEl.removeChild(streetContainerEl.lastChild);
+	}
+	//	streetContainerEl.innerHTML = '';
+	// create default-street element
+	const defaultStreet = document.createElement("a-entity");
+	defaultStreet.id = "default-street";
+	streetContainerEl.appendChild(defaultStreet);
+
+	// clear environment element
+	while (environmentEl.firstChild) {
+		environmentEl.removeChild(environmentEl.lastChild);
+	}	
+	// set default preset:day  
+	environmentEl.setAttribute('street-environment', 'preset', 'day');
+
+	// clear reference layers
+	while (referenceLayersEl.firstChild) {
+		referenceLayersEl.removeChild(referenceLayersEl.lastChild);
+	}
+
+	// clear metadata
+	AFRAME.scenes[0].setAttribute('metadata', 'sceneId', '');
+	AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', '');
+
+	// clear url hash
+	setTimeout(function () {
+		window.location.hash = '';
+	});
+}
+
+STREET.utils.newScene = newScene;

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -43,6 +43,8 @@ function newScene(clearMetaData=true, clearUrlHash=true, addDefaultStreet=true) 
 			for (defaultStreetChild of defaultStreetArray) {
 				defaultStreet.removeChild(defaultStreetChild);
 			}
+			// clear data from previous scene
+			defaultStreet.removeAttribute('data-layer-name');
 			defaultStreet.removeAttribute('street');
 			defaultStreet.removeAttribute('streetmix-loader');
 		}
@@ -59,8 +61,10 @@ function newScene(clearMetaData=true, clearUrlHash=true, addDefaultStreet=true) 
 	checkOrCreateEntity("environment", environmentHTML);
 	checkOrCreateEntity("reference-layers", referenceLayersHTML);
 
-	// update sceneGraph
-	streetContainerEl.emit('entitycreated', streetContainerEl.sceneEl);
+	if (AFRAME.INSPECTOR && AFRAME.INSPECTOR.opened) {
+		// update sceneGraph
+		
+	}
 
 	// clear metadata
 	if (clearMetaData) {

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -1,45 +1,76 @@
 /* global AFRAME, THREE */
 /* 3DStreet utils functions */
 
+function checkOrCreateEntity(elementId, outerHTML) {
+	// clear old element data and replace with new HTML string
+	let newElement = document.getElementById(elementId);
+	if (!newElement) {
+		newElement = document.createElement('a-entity');
+		newElement.id = elementId;
+		AFRAME.scenes[0].appendChild(newElement);
+	}
+	if (outerHTML.length > 0) {
+		// replace element HTML data
+		newElement.outerHTML = outerHTML;
+	}
+	return newElement;
+}
+
 /* 
 clear old scene elements and data. Create blank scene 
 */
-function newScene() {
-	
+function newScene(clearMetaData=true, clearUrlHash=true) {
+
+    const environmentHTML = 
+    `<a-entity id="environment" data-layer-name="Environment" street-environment="preset: day;"></a-entity>`;
+
+    const referenceLayersHTML = 
+    `<a-entity id="reference-layers" data-layer-name="Reference Layers" data-layer-show-children></a-entity>`;
+
 	const streetContainerEl = document.querySelector("#street-container");
 	const environmentEl = document.querySelector("#environment");
 	const referenceLayersEl = document.querySelector("#reference-layers");
 
 	// clear street-container element
-	while (streetContainerEl.firstChild) {
-		streetContainerEl.removeChild(streetContainerEl.lastChild);
+	const streetContainerArray = Array.from(streetContainerEl.children);
+	for (childEl of streetContainerArray) {
+		if (childEl.id !== 'default-street') {
+			streetContainerEl.removeChild(childEl);
+		} else {
+			// clear default-street element
+			const defaultStreet = childEl;
+			const defaultStreetArray = Array.from(defaultStreet.children);
+			for (defaultStreetChild of defaultStreetArray) {
+				defaultStreet.removeChild(defaultStreetChild);
+			}
+			defaultStreet.removeAttribute('street');
+			defaultStreet.removeAttribute('streetmix-loader');
+		}
 	}
-	//	streetContainerEl.innerHTML = '';
-	// create default-street element
-	const defaultStreet = document.createElement("a-entity");
-	defaultStreet.id = "default-street";
-	streetContainerEl.appendChild(defaultStreet);
 
-	// clear environment element
-	while (environmentEl.firstChild) {
-		environmentEl.removeChild(environmentEl.lastChild);
-	}	
-	// set default preset:day  
-	environmentEl.setAttribute('street-environment', 'preset', 'day');
-
-	// clear reference layers
-	while (referenceLayersEl.firstChild) {
-		referenceLayersEl.removeChild(referenceLayersEl.lastChild);
+	if (!streetContainerEl.querySelector("#default-street")) {
+		// create default-street element
+		const defaultStreet = document.createElement("a-entity");
+		defaultStreet.id = "default-street";
+		streetContainerEl.appendChild(defaultStreet);
+		defaultStreet.setAttribute('set-loader-from-hash');
 	}
+
+	checkOrCreateEntity("environment", environmentHTML);
+	checkOrCreateEntity("reference-layers", referenceLayersHTML);
 
 	// clear metadata
-	AFRAME.scenes[0].setAttribute('metadata', 'sceneId', '');
-	AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', '');
+	if (clearMetaData) {
+		AFRAME.scenes[0].setAttribute('metadata', 'sceneId', '');
+		AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', '');
+	}
 
 	// clear url hash
-	setTimeout(function () {
-		window.location.hash = '';
-	});
+	if (clearUrlHash) {
+		setTimeout(function () {
+			window.location.hash = '';
+		});		
+	}	
 }
 
 STREET.utils.newScene = newScene;

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -81,3 +81,24 @@ function newScene(clearMetaData=true, clearUrlHash=true, addDefaultStreet=true) 
 }
 
 STREET.utils.newScene = newScene;
+
+function getVehicleEntities() {
+	return getEntitiesByCategories(['vehicles', 'vehicles-rigged', 'vehicles-transit', 'cyclists']);
+}
+
+module.exports.getVehicleEntities = getVehicleEntities;
+
+function getStripingEntities() {
+	return getEntitiesByCategories(['lane-separator']);
+}
+
+module.exports.getStripingEntities = getStripingEntities;
+
+function getEntitiesByCategories(categoriesArray) {
+	// get entity Nodes by array of their mixin categories
+	const queryForCategoriesMixins = categoriesArray.map(categoryName => `a-mixin[category="${categoryName}"]`).join(',');
+	const allCategoriesMixins = document.querySelectorAll(queryForCategoriesMixins);
+	const categoriesMixinIds = Array.from(allCategoriesMixins).map(el => el.id);
+	const queryForAllElements = categoriesMixinIds.map(mixinId => `a-entity[mixin~="${mixinId}"]`).join(',');
+	return document.querySelectorAll(queryForAllElements);
+}

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -60,7 +60,7 @@ function newScene(clearMetaData=true, clearUrlHash=true, addDefaultStreet=true) 
 	checkOrCreateEntity("reference-layers", referenceLayersHTML);
 
 	// update sceneGraph
-	Events.emit('entitycreated', streetContainerEl.sceneEl);
+	streetContainerEl.emit('entitycreated', streetContainerEl.sceneEl);
 
 	// clear metadata
 	if (clearMetaData) {


### PR DESCRIPTION
Added the ability to change the parameters of the street component (showGround, showVehicles, showStriping) without reloading the scene. It remains to add globalAnimated. So this PR not ready yet.
Also, now there is no need to rename street to not-street, like streetmix-loader and intersection. I added a check that the scene is loaded from jsonFile and do not run the update function in these components