### PR TITLE
New json export

### DIFF
--- a/src/editor/components/scenegraph/Toolbar.js
+++ b/src/editor/components/scenegraph/Toolbar.js
@@ -20,7 +20,7 @@ import { uploadThumbnailImage } from '../modals/ScreenshotModal/ScreenshotModal.
 import { sendMetric } from '../../services/ga.js';
 import posthog from 'posthog-js';
 import { UndoRedo } from '../components/UndoRedo';
-// const LOCALSTORAGE_MOCAP_UI = "aframeinspectormocapuienabled";
+import { downloadJSON, exportSceneToJSON } from '../../lib/entity.js';
 
 function filterHelpers(scene, visible) {
   scene.traverse((o) => {
@@ -128,7 +128,7 @@ export default class Toolbar extends Component {
     }
   };
 
-  static convertToObject = () => {
+  static convertToObjectOld = () => {
     try {
       posthog.capture('convert_to_json_clicked', {
         scene_id: STREET.utils.getCurrentSceneId()
@@ -147,6 +147,23 @@ export default class Toolbar extends Component {
 
       link.click();
       link.remove();
+      STREET.notify.successMessage('3DStreet JSON file saved successfully.');
+    } catch (error) {
+      STREET.notify.errorMessage(
+        `Error trying to save 3DStreet JSON file. Error: ${error}`
+      );
+      console.error(error);
+    }
+  };
+
+  static convertToObject = () => {
+    try {
+      const rootEntity = document.getElementById('street-container');
+      const exportedScene = exportSceneToJSON(rootEntity, {
+        title: STREET.utils.getCurrentSceneTitle()
+      });
+      // download the file
+      downloadJSON(exportedScene, 'data.json');
       STREET.notify.successMessage('3DStreet JSON file saved successfully.');
     } catch (error) {
       STREET.notify.errorMessage(

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -249,6 +249,17 @@ function optimizeComponents(copy, source) {
       var value = stringifyComponentValue(schema, optimalUpdate);
       setAttribute.call(copy, name, value);
     }
+
+    // Remove special components if they use the default value
+    if (
+      value === '' &&
+      (name === 'visible' ||
+        name === 'position' ||
+        name === 'rotation' ||
+        name === 'scale')
+    ) {
+      removeAttribute.call(copy, name);
+    }
   });
 }
 
@@ -697,16 +708,6 @@ export function elementToObject(element) {
     const components = {};
 
     for (const attribute of element.attributes) {
-      if (
-        attribute.value === '' &&
-        (attribute.name === 'visible' ||
-          attribute.name === 'position' ||
-          attribute.name === 'rotation' ||
-          attribute.name === 'scale')
-      ) {
-        continue;
-      }
-
       if (
         NOT_COMPONENTS.includes(attribute.name) ||
         attribute.name.startsWith('data-')

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -195,7 +195,10 @@ export function prepareForSerialization(entity, filterFunc = () => true) {
         !child.hasAttribute('data-aframe-inspector') &&
         !child.hasAttribute('data-aframe-canvas'))
     ) {
-      clone.appendChild(prepareForSerialization(children[i], filterFunc));
+      const childClone = prepareForSerialization(children[i], filterFunc);
+      if (childClone !== null) {
+        clone.appendChild(childClone);
+      }
     }
   }
   optimizeComponents(clone, entity);

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -699,7 +699,8 @@ export function elementToObject(element) {
     for (const attribute of element.attributes) {
       if (
         attribute.value === '' &&
-        (attribute.name === 'position' ||
+        (attribute.name === 'visible' ||
+          attribute.name === 'position' ||
           attribute.name === 'rotation' ||
           attribute.name === 'scale')
       ) {

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -722,11 +722,7 @@ export function elementToObject(element) {
         attribute.name === 'scale'
       ) {
         const values = attribute.value.split(' ').map(parseFloat);
-        /// Round rotation values to 1 degree, position and scale to 0.001
-        const precision = attribute.name === 'rotation' ? 1 : 1000;
-        const roundedValues = values.map(
-          (v) => Math.round(v * precision) / precision
-        );
+        const roundedValues = values.map((v) => Math.round(v * 1000) / 1000);
         components[attribute.name] = roundedValues.join(' ');
         continue;
       }

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -721,7 +721,11 @@ export function elementToObject(element) {
         attribute.name === 'scale'
       ) {
         const values = attribute.value.split(' ').map(parseFloat);
-        const roundedValues = values.map((v) => Math.round(v * 1000) / 1000);
+        /// Round rotation values to 1 degree, position and scale to 0.001
+        const precision = attribute.name === 'rotation' ? 1 : 1000;
+        const roundedValues = values.map(
+          (v) => Math.round(v * precision) / precision
+        );
         components[attribute.name] = roundedValues.join(' ');
         continue;
       }

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -750,7 +750,7 @@ export function elementToObject(element) {
 }
 
 const blacklistedEntityProperties = {
-  id: [],
+  id: ['environment'],
   classList: ['autocreated'],
   tagName: [],
   attributes: []


### PR DESCRIPTION
Main differences between the previous implementation and the new implementation:
Previous implementation has its own `toPropString` function that does its own thing and using `AFRAME.utils.coordinates.stringify(propData)` only for vectors instead of using `stringifyComponentValue` from entity.js that uses `schema.stringify` that have the implementation of stringify for each property types. 

In the new export I'm doing the filters early while doing `prepareForSerialization`, that's cloning the entity (but not attached to the DOM) and then call `removeAttribute` if needed.
In previous implementation, it's iterating over the existing DOM, serialize each component with the "not include default values logic" that exists in entity.js but functions were copied from entity.js (not sure if there are some changes to those), and do a filter afterwards on the json with `filterJSONstreet`.