### PR TITLE
Fix development build to be in memory

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     editor: { import: './src/editor/index.js', filename: '3dstreet-editor.js' }
   },
   output: {
+    publicPath: '/dist/',
     path: path.join(__dirname, 'dist'),
     libraryTarget: 'umd'
   },


### PR DESCRIPTION
Set publicPath to /dist in webpack.config.js for development build to be in memory.