### PR TITLE
Remove double spaces when copying component representation

### DIFF
--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -514,9 +514,7 @@ export function getComponentClipboardRepresentation(entity, componentName) {
   }
 
   const diff = getModifiedProperties(entity, componentName);
-  const attributes = AFRAME.utils.styleParser
-    .stringify(diff)
-    .replace(/;|:/g, '$& ');
+  const attributes = AFRAME.utils.styleParser.stringify(diff);
   return `${componentName}="${attributes}"`;
 }
 


### PR DESCRIPTION
same fix as https://github.com/aframevr/aframe-inspector/pull/671