### PR TITLE
Pass the entity in entityclone event and register loaded listener once

### DIFF
--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -128,10 +128,14 @@ export function cloneEntity(entity) {
   entity.flushToDOM();
 
   const clone = prepareForSerialization(entity);
-  clone.addEventListener('loaded', function () {
-    AFRAME.INSPECTOR.selectEntity(clone);
-    Events.emit('entityclone');
-  });
+  clone.addEventListener(
+    'loaded',
+    function () {
+      AFRAME.INSPECTOR.selectEntity(clone);
+      Events.emit('entityclone', clone);
+    },
+    { once: true }
+  );
 
   // Get a valid unique ID for the entity
   if (entity.id) {
@@ -593,10 +597,14 @@ export function createEntity(definition, cb) {
   }
 
   // Ensure the components are loaded before update the UI
-  entity.addEventListener('loaded', () => {
-    Events.emit('entitycreated', entity);
-    cb(entity);
-  });
+  entity.addEventListener(
+    'loaded',
+    () => {
+      Events.emit('entitycreated', entity);
+      cb(entity);
+    },
+    { once: true }
+  );
 
   AFRAME.scenes[0].appendChild(entity);
 


### PR DESCRIPTION
Pass the entity in entityclone event similar to entitycreated and entityidchange, register loaded listener once.

same as https://github.com/aframevr/aframe-inspector/pull/710