### PR TITLE
Properly update the UI when adding or removing a mixin

### DIFF
--- a/src/editor/components/components/CommonComponents.js
+++ b/src/editor/components/components/CommonComponents.js
@@ -34,13 +34,12 @@ export default class CommonComponents extends React.Component {
       if (detail.entity !== this.props.entity) {
         return;
       }
-      if (DEFAULT_COMPONENTS.indexOf(detail.component) !== -1) {
+      if (
+        DEFAULT_COMPONENTS.indexOf(detail.component) !== -1 ||
+        detail.component === 'mixin'
+      ) {
         this.forceUpdate();
       }
-    });
-
-    Events.on('refreshsidebarobject3d', () => {
-      this.forceUpdate();
     });
 
     var clipboard = new Clipboard('[data-action="copy-entity-to-clipboard"]', {

--- a/src/editor/components/components/ComponentsContainer.js
+++ b/src/editor/components/components/ComponentsContainer.js
@@ -4,14 +4,22 @@ import Component from './Component';
 import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Events from '../../lib/Events';
 export default class ComponentsContainer extends React.Component {
   static propTypes = {
     entity: PropTypes.object
   };
 
-  refresh = () => {
-    this.forceUpdate();
-  };
+  componentDidMount() {
+    Events.on('entityupdate', (detail) => {
+      if (detail.entity !== this.props.entity) {
+        return;
+      }
+      if (detail.component === 'mixin') {
+        this.forceUpdate();
+      }
+    });
+  }
 
   render() {
     const entity = this.props.entity;

--- a/src/editor/components/components/PropertyRow.js
+++ b/src/editor/components/components/PropertyRow.js
@@ -2,8 +2,6 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import debounce from 'lodash-es/debounce';
-import Events from '../../lib/Events';
 
 import BooleanWidget from '../widgets/BooleanWidget';
 import ColorWidget from '../widgets/ColorWidget';
@@ -36,19 +34,6 @@ export default class PropertyRow extends React.Component {
   constructor(props) {
     super(props);
     this.id = props.componentname + ':' + props.name;
-
-    if (
-      ['position', 'rotation', 'scale'].indexOf(this.props.componentname) !== -1
-    ) {
-      Events.on(
-        'entitytransformed',
-        debounce((entity) => {
-          if (entity === props.entity) {
-            this.forceUpdate();
-          }
-        }, 250)
-      );
-    }
   }
 
   getWidget() {

--- a/src/editor/components/components/Sidebar.js
+++ b/src/editor/components/components/Sidebar.js
@@ -24,6 +24,15 @@ export default class Sidebar extends React.Component {
   }
 
   componentDidMount() {
+    Events.on('entityupdate', (detail) => {
+      if (detail.entity !== this.props.entity) {
+        return;
+      }
+      if (detail.component === 'mixin') {
+        this.forceUpdate();
+      }
+    });
+
     Events.on('componentremove', (event) => {
       this.forceUpdate();
     });

--- a/src/editor/components/scenegraph/SceneGraph.js
+++ b/src/editor/components/scenegraph/SceneGraph.js
@@ -52,6 +52,11 @@ export default class SceneGraph extends React.Component {
     Events.on('entityidchange', this.rebuildEntityOptions);
     Events.on('entitycreated', this.rebuildEntityOptions);
     Events.on('entityclone', this.rebuildEntityOptions);
+    Events.on('entityupdate', (detail) => {
+      if (detail.component === 'mixin') {
+        this.rebuildEntityOptions();
+      }
+    });
   }
 
   /**

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -106,8 +106,6 @@ export function Viewport(inspector) {
 
     updateHelpers(object);
 
-    Events.emit('refreshsidebarobject3d', object);
-
     // Emit update event for watcher.
     let component;
     let value;
@@ -135,8 +133,6 @@ export function Viewport(inspector) {
       property: '',
       value: value
     });
-
-    Events.emit('entitytransformed', transformControls.object.el);
   });
 
   transformControls.addEventListener('mouseDown', () => {


### PR DESCRIPTION
From this list: https://github.com/3DStreet/3dstreet/issues/519#issuecomment-2133712167
moved from aframe-inspector repository: https://github.com/aframevr/aframe-inspector/pull/699
Now UI is still not updating with the mixin name at the top of the right panel when you update a mixin, only after close/open right panel. But UI updating in the left panel. 