### PR TITLE
Fix pre-commit warning for scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
       "prettier --write",
       "eslint"
     ],
-    "*.{scss}": [
+    "*.scss": [
       "prettier --write"
     ]
   }


### PR DESCRIPTION
Fix warning
⚠ Detected incorrect braces with only single value: `*.{scss}`. Reformatted as: `*.scss`