### PR TITLE
allow saving scenes after initial save as

### DIFF
--- a/src/editor/components/scenegraph/Toolbar.js
+++ b/src/editor/components/scenegraph/Toolbar.js
@@ -58,7 +58,8 @@ export default class Toolbar extends Component {
       savedNewDocument: false,
       isSavingScene: false,
       pendingSceneSave: false,
-      signInSuccess: false
+      signInSuccess: false,
+      isAuthor: props.isAuthor
     };
     this.saveButtonRef = React.createRef();
   }
@@ -244,7 +245,7 @@ export default class Toolbar extends Component {
       );
       console.error(error);
     } finally {
-      this.setState({ isSavingScene: false });
+      this.setState({ isSavingScene: false, isAuthor: true });
     }
   };
 
@@ -391,7 +392,7 @@ export default class Toolbar extends Component {
                   <Button
                     variant="white"
                     onClick={this.cloudSaveHandler}
-                    disabled={this.state.isSavingScene || !this.props.isAuthor}
+                    disabled={this.state.isSavingScene || !this.state.isAuthor}
                   >
                     <div
                       className="icon"


### PR DESCRIPTION
Quick fix to allow for saving scenes. There is an edge case where if the user decides to open another community scene after saving, the save button will show clickable. However, when it's clicked, it creates a separate scene, so i think we're ok here. In order to resolve that issue, i think it would require some decent refactoring of save logic.

fixes #636 