### PR TITLE
move posthog auth to auth context rather than signin

### DIFF
--- a/src/editor/api/auth.js
+++ b/src/editor/api/auth.js
@@ -6,10 +6,6 @@ import posthog from 'posthog-js';
 const signIn = async () => {
   try {
     const { user } = await signInWithPopup(auth, new GoogleAuthProvider());
-    posthog.identify(user.uid, {
-      email: user.email,
-      name: user.displayName
-    });
     // first signIn to ga
     if (user.metadata.creationTime !== user.metadata.lastSignInTime) return;
     sendMetric('Auth', 'newAccountCreation');

--- a/src/editor/contexts/Auth.context.js
+++ b/src/editor/contexts/Auth.context.js
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { auth } from '../services/firebase';
 import PropTypes from 'prop-types';
 import { isUserPro, isUserBeta } from '../api/user';
+import posthog from 'posthog-js';
 
 const AuthContext = createContext({
   currentUser: null,
@@ -24,6 +25,12 @@ const AuthProvider = ({ children }) => {
       const isPro = await isUserPro(user);
       const isBeta = await isUserBeta(user);
       const enrichedUser = { ...user, isPro, isBeta };
+
+      posthog.identify(user.uid, {
+        email: user.email,
+        name: user.displayName,
+        isPro: isPro
+      });
 
       setCurrentUser(enrichedUser);
     };


### PR DESCRIPTION
want to call `posthog.identify` every time rather than only on signin