### PR TITLE
check for isSceneAuthor before saving scene title to firestore

### DIFF
--- a/src/editor/components/components/SceneEditTitle/SceneEditTitle.component.jsx
+++ b/src/editor/components/components/SceneEditTitle/SceneEditTitle.component.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import styles from './SceneEditTitle.module.scss';
-import { updateSceneIdAndTitle } from '../../../api/scene';
+import { useAuthContext } from '../../../contexts/index.js';
+import { updateSceneIdAndTitle, isSceneAuthor } from '../../../api/scene';
 
 const SceneEditTitle = ({ sceneData }) => {
   const [title, setTitle] = useState(sceneData?.sceneTitle);
+  const { currentUser } = useAuthContext();
 
   const sceneId = STREET.utils.getCurrentSceneId();
 
@@ -33,7 +35,13 @@ const SceneEditTitle = ({ sceneData }) => {
   const saveNewTitle = async (newTitle) => {
     try {
       if (sceneData?.sceneId) {
-        await updateSceneIdAndTitle(sceneData?.sceneId, newTitle);
+        const isCurrentUserTheSceneAuthor = await isSceneAuthor({
+          sceneId: sceneData.sceneId,
+          authorId: currentUser.uid
+        });
+        if (isCurrentUserTheSceneAuthor) {
+          await updateSceneIdAndTitle(sceneData?.sceneId, newTitle);
+        }
       }
       AFRAME.scenes[0].setAttribute('metadata', 'sceneTitle', newTitle);
       AFRAME.scenes[0].setAttribute('metadata', 'sceneId', sceneData?.sceneId);


### PR DESCRIPTION
Added check for `isSceneAuthor` before update title to firestore to fix this issue: https://github.com/3DStreet/3dstreet/issues/662
if the user is not the author of the scene, then the title changes only on his side. If he saves the scene on the server with a new title, then it will be saved with the new title.