### PR TITLE
Screenshot button

### DIFF
--- a/src/editor/components/components/ActionBar/ActionBar.component.jsx
+++ b/src/editor/components/components/ActionBar/ActionBar.component.jsx
@@ -1,7 +1,8 @@
 import {
   faHand,
   faHandPointer,
-  faPlusSquare
+  faPlusSquare,
+  faImage
 } from '@fortawesome/free-regular-svg-icons';
 import { AwesomeIcon } from '../AwesomeIcon';
 import classNames from 'classnames';
@@ -28,6 +29,19 @@ const ActionBar = ({ handleAddClick, isAddLayerPanelOpen }) => {
     setCursorEnabled(true);
   };
 
+  const handleCameraCLick = () => {
+    Events.emit('camera_clicked');
+    const screenshotEl = document.getElementById('screenshot');
+    screenshotEl.play();
+
+    posthog.capture('screenshot_taken', {
+      scene_id: STREET.utils.getCurrentSceneId()
+    });
+
+    screenshotEl.setAttribute('screentock', 'type', 'png');
+    screenshotEl.setAttribute('screentock', 'takeScreenshot', true);
+  };
+
   return (
     <div>
       {!isAddLayerPanelOpen && (
@@ -48,6 +62,9 @@ const ActionBar = ({ handleAddClick, isAddLayerPanelOpen }) => {
           </Button>
           <Button variant="toolbtn" onClick={handleAddClick}>
             <AwesomeIcon icon={faPlusSquare} />
+          </Button>
+          <Button variant="toolbtn" onClick={handleCameraCLick}>
+            <AwesomeIcon icon={faImage} />
           </Button>
         </div>
       )}


### PR DESCRIPTION
#706 

<img width="338" alt="Screenshot 2024-07-12 at 2 38 06 PM" src="https://github.com/user-attachments/assets/9a1eff1a-a401-4b18-8b58-dc70c06fbf57">

clicking the image button takes a PNG.

Defaulting to PNG (dont see the need for JPG, but lmk).

Question: What should we do w/ the existing share functionality?
- thinking we remove the PNG and JPG options and add a notify or we just add a notify and remove it in a couple weeks?