### PR TITLE
Don't select entity on raycaster click if we used one of the controls take 2

### DIFF
--- a/src/editor/lib/raycaster.js
+++ b/src/editor/lib/raycaster.js
@@ -46,7 +46,6 @@ export function initRaycaster(inspector) {
   mouseCursor.addEventListener('mouseleave', onMouseLeave);
   inspector.container.addEventListener('mousedown', onMouseDown);
   inspector.container.addEventListener('mouseup', onMouseUp);
-  // inspector.container.addEventListener('dblclick', onDoubleClick);
 
   inspector.sceneEl.canvas.addEventListener('mouseleave', () => {
     setTimeout(() => {
@@ -56,7 +55,6 @@ export function initRaycaster(inspector) {
 
   const onDownPosition = new THREE.Vector2();
   const onUpPosition = new THREE.Vector2();
-  // const onDoubleClickPosition = new THREE.Vector2();
 
   function onMouseEnter() {
     Events.emit(
@@ -106,23 +104,6 @@ export function initRaycaster(inspector) {
     );
     onUpPosition.fromArray(array);
   }
-
-  /**
-   * Focus on double click.
-   */
-  // function onDoubleClick(event) {
-  //   const array = getMousePosition(
-  //     inspector.container,
-  //     event.clientX,
-  //     event.clientY
-  //   );
-  //   onDoubleClickPosition.fromArray(array);
-  //   const intersectedEl = mouseCursor.components.cursor.intersectedEl;
-  //   if (!intersectedEl) {
-  //     return;
-  //   }
-  //   Events.emit('objectfocus', intersectedEl.object3D);
-  // }
 
   return {
     el: mouseCursor,

--- a/src/editor/lib/raycaster.js
+++ b/src/editor/lib/raycaster.js
@@ -72,11 +72,9 @@ export function initRaycaster(inspector) {
 
   function handleClick(evt) {
     // Check to make sure not dragging.
-    const DRAG_THRESHOLD = 0.03;
-    if (onDownPosition.distanceTo(onUpPosition) >= DRAG_THRESHOLD) {
-      return;
+    if (onDownPosition.distanceTo(onUpPosition) === 0) {
+      inspector.selectEntity(evt.detail.intersectedEl);
     }
-    inspector.selectEntity(evt.detail.intersectedEl);
   }
 
   function onMouseDown(event) {

--- a/src/editor/lib/raycaster.js
+++ b/src/editor/lib/raycaster.js
@@ -44,6 +44,8 @@ export function initRaycaster(inspector) {
   mouseCursor.addEventListener('click', handleClick);
   mouseCursor.addEventListener('mouseenter', onMouseEnter);
   mouseCursor.addEventListener('mouseleave', onMouseLeave);
+  inspector.container.addEventListener('mousedown', onMouseDown);
+  inspector.container.addEventListener('mouseup', onMouseUp);
   // inspector.container.addEventListener('dblclick', onDoubleClick);
 
   inspector.sceneEl.canvas.addEventListener('mouseleave', () => {
@@ -51,6 +53,10 @@ export function initRaycaster(inspector) {
       Events.emit('raycastermouseleave', null);
     });
   });
+
+  const onDownPosition = new THREE.Vector2();
+  const onUpPosition = new THREE.Vector2();
+  // const onDoubleClickPosition = new THREE.Vector2();
 
   function onMouseEnter() {
     Events.emit(
@@ -67,13 +73,50 @@ export function initRaycaster(inspector) {
   }
 
   function handleClick(evt) {
-    Events.emit('raycasterclick', evt.detail.intersectedEl);
+    // Check to make sure not dragging.
+    const DRAG_THRESHOLD = 0.03;
+    if (onDownPosition.distanceTo(onUpPosition) >= DRAG_THRESHOLD) {
+      return;
+    }
+    inspector.selectEntity(evt.detail.intersectedEl);
+  }
+
+  function onMouseDown(event) {
+    if (event instanceof CustomEvent) {
+      return;
+    }
+    event.preventDefault();
+    const array = getMousePosition(
+      inspector.container,
+      event.clientX,
+      event.clientY
+    );
+    onDownPosition.fromArray(array);
+  }
+
+  function onMouseUp(event) {
+    if (event instanceof CustomEvent) {
+      return;
+    }
+    event.preventDefault();
+    const array = getMousePosition(
+      inspector.container,
+      event.clientX,
+      event.clientY
+    );
+    onUpPosition.fromArray(array);
   }
 
   /**
    * Focus on double click.
    */
   // function onDoubleClick(event) {
+  //   const array = getMousePosition(
+  //     inspector.container,
+  //     event.clientX,
+  //     event.clientY
+  //   );
+  //   onDoubleClickPosition.fromArray(array);
   //   const intersectedEl = mouseCursor.components.cursor.intersectedEl;
   //   if (!intersectedEl) {
   //     return;
@@ -85,11 +128,18 @@ export function initRaycaster(inspector) {
     el: mouseCursor,
     enable: () => {
       mouseCursor.setAttribute('raycaster', 'enabled', true);
-      // inspector.container.addEventListener('dblclick', onDoubleClick);
+      inspector.container.addEventListener('mousedown', onMouseDown);
+      inspector.container.addEventListener('mouseup', onMouseUp);
     },
     disable: () => {
       mouseCursor.setAttribute('raycaster', 'enabled', false);
-      // inspector.container.removeEventListener('dblclick', onDoubleClick);
+      inspector.container.removeEventListener('mousedown', onMouseDown);
+      inspector.container.removeEventListener('mouseup', onMouseUp);
     }
   };
+}
+
+function getMousePosition(dom, x, y) {
+  const rect = dom.getBoundingClientRect();
+  return [(x - rect.left) / rect.width, (y - rect.top) / rect.height];
 }

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -136,15 +136,6 @@ export function Viewport(inspector) {
     hoverBox.visible = false;
   });
 
-  let lastControlsEventTime = 0;
-  Events.on('raycasterclick', (el) => {
-    if (Date.now() - lastControlsEventTime < 500) {
-      // Ignore click if we used EditorControls or TransformControls in the last 500ms.
-      return;
-    }
-    inspector.selectEntity(el);
-  });
-
   function updateHelpers(object) {
     object.traverse((node) => {
       if (inspector.helpers[node.uuid] && inspector.helpers[node.uuid].update) {
@@ -160,7 +151,6 @@ export function Viewport(inspector) {
   );
   transformControls.size = 0.75;
   transformControls.addEventListener('objectChange', (evt) => {
-    lastControlsEventTime = Date.now();
     const object = transformControls.object;
     if (object === undefined) {
       return;
@@ -224,9 +214,6 @@ export function Viewport(inspector) {
   controls.rotationSpeed = 0.0035;
   controls.zoomSpeed = 0.05;
   controls.setAspectRatio(sceneEl.canvas.width / sceneEl.canvas.height);
-  controls.addEventListener('change', () => {
-    lastControlsEventTime = Date.now();
-  });
 
   Events.on('cameratoggle', (data) => {
     controls.setCamera(data.camera);


### PR DESCRIPTION
Better fix for #645, revert #709 
With further testing while backporting it to aframe-inspector, I still reproduced the issue sometimes when just waiting long enough after moving the mouse and release the mouse button. Actually the fix is simpler, I just used the exact condition as the three.js editor, just compare if mouse distance is zero to do the select entity, that's it.
https://github.com/aframevr/aframe-inspector/pull/734