### PR TITLE
Use document.readyState !== 'complete' to be sure startObserving is always executed

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -360,7 +360,7 @@ function startObserving() {
 }
 
 // Wait for the DOM to be fully loaded before starting the observer
-if (document.readyState === 'loading') {
+if (document.readyState !== 'complete') {
   document.addEventListener('DOMContentLoaded', startObserving);
 } else {
   // DOMContentLoaded has already fired


### PR DESCRIPTION
Following #734
`readyState` could also be in the `interactive` state before the `DOMContentLoaded` event is fired.
`if (document.readyState !== 'complete') {`
would be more adequate here.

https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState