### PR TITLE
Clean up code in AddLayerPanel component and drag and drop

### DIFF
--- a/src/editor/components/Main.js
+++ b/src/editor/components/Main.js
@@ -341,7 +341,7 @@ export default class Main extends Component {
             <Compass32Icon />
           </Button>
         )}
-        {this.state.inspectorEnabled && this.state.isAddLayerPanelOpen && (
+        {this.state.inspectorEnabled && (
           <AddLayerPanel
             onClose={this.toggleAddLayerPanel}
             isAddLayerPanelOpen={this.state.isAddLayerPanelOpen}

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -14,6 +14,7 @@ import { LayersOptions } from './LayersOptions.js';
 import mixinCatalog from '../../../../catalog.json';
 import posthog from 'posthog-js';
 import Events from '../../../lib/Events';
+import pickPointOnGroundPlane from '../../../lib/pick-point-on-ground-plane';
 
 // get all mixin data divided into groups, from a-mixin DOM elements
 const getGroupedMixinOptions = () => {
@@ -170,6 +171,12 @@ const createEntity = (mixinId) => {
       entityToMove.object3D.parent.worldToLocal(entityToMove.object3D.position);
     }
   } else {
+    const position = pickPointOnGroundPlane({
+      normalizedX: 0,
+      normalizedY: -0.1,
+      camera: AFRAME.INSPECTOR.camera
+    });
+    newEntity.setAttribute('position', position);
     const streetContainer = document.querySelector('#street-container');
     // apppend element as a child of street-container
     if (streetContainer) {
@@ -237,7 +244,12 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
         );
       }
     } else {
-      previewEntity.object3D.position.set(0, 0, 0);
+      const position = pickPointOnGroundPlane({
+        normalizedX: 0,
+        normalizedY: -0.1,
+        camera: AFRAME.INSPECTOR.camera
+      });
+      previewEntity.setAttribute('position', position);
     }
   };
 

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -270,7 +270,7 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
         />
       </div>
       <div className={styles.cards}>
-        {selectedCards?.map((card) => (
+        {selectedCards.map((card) => (
           <div
             key={card.id}
             className={styles.card}
@@ -279,7 +279,6 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
             onClick={() => cardClick(card, isProUser)}
             title={card.description}
           >
-            {' '}
             {card.requiresPro && !isProUser ? (
               <div
                 className={styles.img}
@@ -300,7 +299,7 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
               />
             )}
             <div className={styles.body}>
-              {card.icon ? <img src={card.icon} /> : ''}
+              {card.icon ? <img src={card.icon} /> : null}
               <p className={styles.description}>{card.name}</p>
             </div>
           </div>

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -122,6 +122,10 @@ const getSegmentElevationPosY = (ancestorEl) => {
 };
 
 const createEntity = (mixinId) => {
+  const previewEntity = document.getElementById('previewEntity');
+  if (previewEntity) {
+    previewEntity.setAttribute('visible', false);
+  }
   console.log('create entity: ', mixinId);
   const newEntity = document.createElement('a-entity');
   newEntity.setAttribute('mixin', mixinId);
@@ -191,33 +195,37 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
 
   /* create and preview entity events */
 
-  // entity preview element
-  let preEntity = document.createElement('a-entity');
-
-  preEntity.setAttribute('visible', false);
-
-  AFRAME.scenes[0].appendChild(preEntity);
-
   const cardMouseEnter = (mixinId) => {
-    preEntity.setAttribute('mixin', mixinId);
     const selectedElement = AFRAME.INSPECTOR.selectedEntity;
     if (selectedElement) {
       const [ancestorEl, inSegment] = getAncestorEl(selectedElement);
       // avoid adding preview element inside the direct ancestor of a-scene: #environment, #reference, ...
       if (ancestorEl.parentEl.isScene) return;
-      selectedElement.object3D.getWorldPosition(preEntity.object3D.position);
-      preEntity.setAttribute('visible', true);
+      let previewEntity = document.getElementById('previewEntity');
+      if (!previewEntity) {
+        previewEntity = document.createElement('a-entity');
+        previewEntity.setAttribute('id', 'previewEntity');
+        AFRAME.scenes[0].appendChild(previewEntity);
+      }
+      previewEntity.setAttribute('mixin', mixinId);
+      selectedElement.object3D.getWorldPosition(
+        previewEntity.object3D.position
+      );
+      previewEntity.setAttribute('visible', true);
       if (inSegment) {
         // get elevation position Y from attribute of segment element
         const segmentElevationPosY = getSegmentElevationPosY(ancestorEl);
         // set position y by elevation level of segment
-        preEntity.object3D.position.setY(segmentElevationPosY);
+        previewEntity.object3D.position.setY(segmentElevationPosY);
       }
     }
   };
 
   const cardMouseLeave = (mixinId) => {
-    preEntity.setAttribute('visible', false);
+    const previewEntity = document.getElementById('previewEntity');
+    if (previewEntity) {
+      previewEntity.setAttribute('visible', false);
+    }
   };
 
   const cardClick = (card, isProUser) => {

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -224,6 +224,18 @@ const cardMouseEnter = (mixinId) => {
     previewEntity = document.createElement('a-entity');
     previewEntity.setAttribute('id', 'previewEntity');
     AFRAME.scenes[0].appendChild(previewEntity);
+    const dropCursorEntity = document.createElement('a-entity');
+    dropCursorEntity.innerHTML = `
+      <a-ring id="drop-cursor" rotation="-90 0 0" radius-inner="0.2" radius-outer="0.3">
+        <a-ring color="yellow" radius-inner="0.4" radius-outer="0.5"
+          animation="property: scale; from: 1 1 1; to: 2 2 2; loop: true; dir: alternate"></a-ring>
+        <a-ring color="yellow" radius-inner="0.6" radius-outer="0.7"
+          animation="property: scale; from: 1 1 1; to: 3 3 3; loop: true; dir: alternate"></a-ring>
+        <a-entity class="drop-cursor-arrow" rotation="90 0 0">
+          <a-cylinder color="yellow" position="0 5.25 0" radius="0.05" height="2.5"></a-cylinder>
+          <a-cone color="yellow" position="0 4 0" radius-top="0.5" radius-bottom="0" height="1"></a-cone>
+      </a-ring>`;
+    previewEntity.appendChild(dropCursorEntity);
   }
   previewEntity.setAttribute('mixin', mixinId);
   previewEntity.setAttribute('visible', true);

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -131,7 +131,9 @@ const createEntity = (mixinId) => {
   newEntity.setAttribute('mixin', mixinId);
 
   const selectedElement = AFRAME.INSPECTOR.selectedEntity;
-  const [ancestorEl, inSegment] = getAncestorEl(selectedElement);
+  const [ancestorEl, inSegment] = selectedElement
+    ? getAncestorEl(selectedElement)
+    : [undefined, false];
 
   // avoid adding new element inside the direct ancestor of a-scene: #environment, #reference, ...
   if (selectedElement && !ancestorEl.parentEl.isScene) {

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -129,6 +129,14 @@ const createEntity = (mixinId) => {
   console.log('create entity: ', mixinId);
   const newEntity = document.createElement('a-entity');
   newEntity.setAttribute('mixin', mixinId);
+  newEntity.addEventListener(
+    'loaded',
+    () => {
+      Events.emit('entitycreated', newEntity);
+      AFRAME.INSPECTOR.selectEntity(newEntity);
+    },
+    { once: true }
+  );
 
   const selectedElement = AFRAME.INSPECTOR.selectedEntity;
   const [ancestorEl, inSegment] = selectedElement
@@ -170,7 +178,6 @@ const createEntity = (mixinId) => {
       AFRAME.scenes[0].appendChild(newEntity);
     }
   }
-  Events.emit('entitycreated', newEntity);
 };
 
 const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -139,28 +139,28 @@ const createEntity = (mixinId) => {
   if (selectedElement && !ancestorEl.parentEl.isScene) {
     // append element as a child of the entity with .custom-group class.
     let customGroupEl = ancestorEl.querySelector('.custom-group');
+    let entityToMove;
     if (!customGroupEl) {
       customGroupEl = document.createElement('a-entity');
       // .custom-group entity is a child of segment or .street-parent/.buildings-parent elements
       ancestorEl.appendChild(customGroupEl);
       customGroupEl.classList.add('custom-group');
-
-      if (inSegment) {
-        // get elevation position Y from attribute of segment element
-        const segmentElevationPosY = getSegmentElevationPosY(ancestorEl);
-        // set position y by elevation level of segment
-        customGroupEl.setAttribute('position', { y: segmentElevationPosY });
-      } else {
-        // if we are creating element not inside segment-parent
-        selectedElement.object3D.getWorldPosition(
-          customGroupEl.object3D.position
-        );
-        customGroupEl.object3D.parent.worldToLocal(
-          customGroupEl.object3D.position
-        );
-      }
+      entityToMove = customGroupEl;
+    } else {
+      entityToMove = newEntity;
     }
     customGroupEl.appendChild(newEntity);
+
+    if (inSegment) {
+      // get elevation position Y from attribute of segment element
+      const segmentElevationPosY = getSegmentElevationPosY(ancestorEl);
+      // set position y by elevation level of segment
+      entityToMove.setAttribute('position', { y: segmentElevationPosY });
+    } else {
+      // if we are creating element not inside segment-parent
+      selectedElement.object3D.getWorldPosition(entityToMove.object3D.position);
+      entityToMove.object3D.parent.worldToLocal(entityToMove.object3D.position);
+    }
   } else {
     const streetContainer = document.querySelector('#street-container');
     // apppend element as a child of street-container

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -116,7 +116,7 @@ const getAncestorEl = (element) => {
 };
 
 const getSegmentElevationPosY = (ancestorEl) => {
-  if (ancestorEl && ancestorEl.hasAttribute('data-elevation-posY')) {
+  if (ancestorEl.hasAttribute('data-elevation-posY')) {
     return ancestorEl.getAttribute('data-elevation-posY');
   } else return 0; // default value
 };
@@ -146,7 +146,9 @@ const createEntity = (mixinId) => {
         customGroupEl.setAttribute('position', { y: segmentElevationPosY });
       } else {
         // if we are creating element not inside segment-parent
-        // customGroupEl.setAttribute('position', selectedObjPos);
+        selectedElement.object3D.getWorldPosition(
+          customGroupEl.object3D.position
+        );
       }
     }
     customGroupEl.appendChild(newEntity);
@@ -191,7 +193,6 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
 
   // entity preview element
   let preEntity = document.createElement('a-entity');
-  let selectedObjPos = new THREE.Vector3();
 
   preEntity.setAttribute('visible', false);
 
@@ -200,24 +201,17 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
   const cardMouseEnter = (mixinId) => {
     preEntity.setAttribute('mixin', mixinId);
     const selectedElement = AFRAME.INSPECTOR.selectedEntity;
-    const [ancestorEl, inSegment] = getAncestorEl(selectedElement);
-    // avoid adding preview element inside the direct ancestor of a-scene: #environment, #reference, ...
-    if (ancestorEl.parentEl.isScene) return;
-
     if (selectedElement) {
-      selectedElement.object3D.getWorldPosition(selectedObjPos);
-      // get elevation position Y from attribute of segment element
-      const segmentElevationPosY = getSegmentElevationPosY(ancestorEl);
+      const [ancestorEl, inSegment] = getAncestorEl(selectedElement);
+      // avoid adding preview element inside the direct ancestor of a-scene: #environment, #reference, ...
+      if (ancestorEl.parentEl.isScene) return;
+      selectedElement.object3D.getWorldPosition(preEntity.object3D.position);
       preEntity.setAttribute('visible', true);
-      selectedObjPos.setY(segmentElevationPosY);
       if (inSegment) {
-        preEntity.setAttribute('position', selectedObjPos);
-      } else {
-        preEntity.setAttribute('position', {
-          x: selectedObjPos.x,
-          y: 0.2,
-          z: selectedObjPos.z
-        });
+        // get elevation position Y from attribute of segment element
+        const segmentElevationPosY = getSegmentElevationPosY(ancestorEl);
+        // set position y by elevation level of segment
+        preEntity.object3D.position.setY(segmentElevationPosY);
       }
     }
   };

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -155,6 +155,9 @@ const createEntity = (mixinId) => {
         selectedElement.object3D.getWorldPosition(
           customGroupEl.object3D.position
         );
+        customGroupEl.object3D.parent.worldToLocal(
+          customGroupEl.object3D.position
+        );
       }
     }
     customGroupEl.appendChild(newEntity);

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -35,10 +35,10 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
     let categoryName, mixinId;
 
     // convert the mixins array into an object with mixins for faster access by index
-    const mixinCatalogObj = mixinCatalog.reduce((obj, item) => {
-      obj[item.id] = item;
-      return obj;
-    }, {});
+    const mixinCatalogObj = {};
+    for (const item of mixinCatalog) {
+      mixinCatalogObj[item.id] = item;
+    }
 
     const groupedObject = {};
     let index = 0;
@@ -74,10 +74,10 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
       index += 1;
     }
 
-    for (const categoryName of Object.keys(groupedObject)) {
+    for (const [categoryName, options] of Object.entries(groupedObject)) {
       groupedArray.push({
         label: categoryName,
-        options: groupedObject[categoryName]
+        options: options
       });
     }
     return groupedArray;

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -201,28 +201,36 @@ const AddLayerPanel = ({ onClose, isAddLayerPanelOpen }) => {
   /* create and preview entity events */
 
   const cardMouseEnter = (mixinId) => {
+    let previewEntity = document.getElementById('previewEntity');
+    if (!previewEntity) {
+      previewEntity = document.createElement('a-entity');
+      previewEntity.setAttribute('id', 'previewEntity');
+      AFRAME.scenes[0].appendChild(previewEntity);
+    }
+    previewEntity.setAttribute('mixin', mixinId);
+    previewEntity.setAttribute('visible', true);
+
     const selectedElement = AFRAME.INSPECTOR.selectedEntity;
-    if (selectedElement) {
-      const [ancestorEl, inSegment] = getAncestorEl(selectedElement);
-      // avoid adding preview element inside the direct ancestor of a-scene: #environment, #reference, ...
-      if (ancestorEl.parentEl.isScene) return;
-      let previewEntity = document.getElementById('previewEntity');
-      if (!previewEntity) {
-        previewEntity = document.createElement('a-entity');
-        previewEntity.setAttribute('id', 'previewEntity');
-        AFRAME.scenes[0].appendChild(previewEntity);
-      }
-      previewEntity.setAttribute('mixin', mixinId);
-      selectedElement.object3D.getWorldPosition(
-        previewEntity.object3D.position
-      );
-      previewEntity.setAttribute('visible', true);
+    const [ancestorEl, inSegment] = selectedElement
+      ? getAncestorEl(selectedElement)
+      : [undefined, false];
+
+    // avoid adding new element inside the direct ancestor of a-scene: #environment, #reference, ...
+    if (selectedElement && !ancestorEl.parentEl.isScene) {
       if (inSegment) {
         // get elevation position Y from attribute of segment element
         const segmentElevationPosY = getSegmentElevationPosY(ancestorEl);
         // set position y by elevation level of segment
-        previewEntity.object3D.position.setY(segmentElevationPosY);
+        ancestorEl.object3D.getWorldPosition(previewEntity.object3D.position);
+        previewEntity.object3D.position.y += segmentElevationPosY;
+      } else {
+        // if we are creating element not inside segment-parent
+        selectedElement.object3D.getWorldPosition(
+          previewEntity.object3D.position
+        );
       }
+    } else {
+      previewEntity.object3D.position.set(0, 0, 0);
     }
   };
 

--- a/src/editor/components/components/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/components/AddLayerPanel/createLayerFunctions.js
@@ -19,9 +19,15 @@ function createSvgExtrudedEntity() {
     newEl.setAttribute('svg-extruder', `svgString: ${svgString}`);
     newEl.setAttribute('data-layer-name', 'SVG Path • My Custom Path');
     const parentEl = document.querySelector('#street-container');
+    newEl.addEventListener(
+      'loaded',
+      () => {
+        Events.emit('entitycreated', newEl);
+        AFRAME.INSPECTOR.selectEntity(newEl);
+      },
+      { once: true }
+    );
     parentEl.appendChild(newEl);
-    // update sceneGraph
-    Events.emit('entitycreated', newEl);
   }
 }
 
@@ -128,9 +134,15 @@ function createCustomModel() {
     newEl.setAttribute('gltf-model', `url(${modelUrl})`);
     newEl.setAttribute('data-layer-name', 'glTF Model • My Custom Object');
     const parentEl = document.querySelector('#street-container');
+    newEl.addEventListener(
+      'loaded',
+      () => {
+        Events.emit('entitycreated', newEl);
+        AFRAME.INSPECTOR.selectEntity(newEl);
+      },
+      { once: true }
+    );
     parentEl.appendChild(newEl);
-    // update sceneGraph
-    Events.emit('entitycreated', newEl);
   }
 }
 
@@ -144,9 +156,15 @@ function createPrimitiveGeometry() {
   );
   newEl.setAttribute('material', 'src: #asphalt-texture; repeat: 5 5;');
   const parentEl = document.querySelector('#street-container');
+  newEl.addEventListener(
+    'loaded',
+    () => {
+      Events.emit('entitycreated', newEl);
+      AFRAME.INSPECTOR.selectEntity(newEl);
+    },
+    { once: true }
+  );
   parentEl.appendChild(newEl);
-  // update sceneGraph
-  Events.emit('entitycreated', newEl);
 }
 
 function createIntersection() {
@@ -155,9 +173,15 @@ function createIntersection() {
   newEl.setAttribute('data-layer-name', 'Street • Intersection 90º');
   newEl.setAttribute('rotation', '-90 -90 0');
   const parentEl = document.querySelector('#street-container');
+  newEl.addEventListener(
+    'loaded',
+    () => {
+      Events.emit('entitycreated', newEl);
+      AFRAME.INSPECTOR.selectEntity(newEl);
+    },
+    { once: true }
+  );
   parentEl.appendChild(newEl);
-  // update sceneGraph
-  Events.emit('entitycreated', newEl);
 }
 
 function createSplatObject() {
@@ -176,9 +200,15 @@ function createSplatObject() {
     newEl.setAttribute('data-layer-name', 'Splat Model • My Custom Object');
     newEl.play();
     const parentEl = document.querySelector('#street-container');
+    newEl.addEventListener(
+      'loaded',
+      () => {
+        Events.emit('entitycreated', newEl);
+        AFRAME.INSPECTOR.selectEntity(newEl);
+      },
+      { once: true }
+    );
     parentEl.appendChild(newEl);
-    // update sceneGraph
-    Events.emit('entitycreated', newEl);
   }
 }
 

--- a/src/editor/components/components/PropertyRow.js
+++ b/src/editor/components/components/PropertyRow.js
@@ -25,7 +25,6 @@ export default class PropertyRow extends React.Component {
       PropTypes.string.isRequired
     ]),
     entity: PropTypes.object.isRequired,
-    id: PropTypes.string,
     isSingle: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
     schema: PropTypes.object.isRequired

--- a/src/editor/lib/pick-point-on-ground-plane.js
+++ b/src/editor/lib/pick-point-on-ground-plane.js
@@ -1,0 +1,45 @@
+const pickingPlane = new THREE.Mesh(
+  new THREE.PlaneGeometry(1000000, 1000000),
+  new THREE.MeshBasicMaterial()
+);
+pickingPlane.rotation.x = -Math.PI / 2;
+pickingPlane.updateMatrixWorld();
+const pickingVector = new THREE.Vector3();
+const pickingRaycaster = new THREE.Raycaster();
+
+export default function pickPointOnGroundPlane(args) {
+  // API
+  const x = args.x;
+  const y = args.y;
+  let nX = args.normalizedX;
+  let nY = args.normalizedY;
+  const canvas = args.canvas;
+  const camera = args.camera;
+
+  // get normalized 2D coordinates
+  if (nX === undefined || nY === undefined) {
+    const viewport = canvas.getBoundingClientRect();
+    nX = (2 * (x - viewport.left)) / viewport.width - 1;
+    nY = -((2 * (y - viewport.top)) / viewport.height - 1);
+  }
+
+  // setup raycaster
+  pickingRaycaster.set(
+    camera.position,
+    pickingVector
+      .set(nX, nY, 1)
+      .unproject(camera)
+      .sub(camera.position)
+      .normalize()
+  );
+
+  // shoot ray
+  const intersects = pickingRaycaster.intersectObject(pickingPlane);
+  // in case of no result
+  if (intersects.length === 0) {
+    console.warn('Picking raycaster got 0 results.');
+    return new THREE.Vector3();
+  }
+
+  return intersects[0].point;
+}

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -275,8 +275,11 @@ export function Viewport(inspector) {
       } else if (object.el.hasAttribute('gltf-model')) {
         const listener = (event) => {
           if (event.target !== object.el) return; // we got an event for a child, ignore
-          selectionBox.setFromObject(object);
-          selectionBox.visible = true;
+          // Some models have a wrong bounding box if we don't wait a bit
+          setTimeout(() => {
+            selectionBox.setFromObject(object);
+            selectionBox.visible = true;
+          }, 20);
           object.el.removeEventListener('model-loaded', listener);
         };
         object.el.addEventListener('model-loaded', listener);

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -273,14 +273,13 @@ export function Viewport(inspector) {
         selectionBox.setFromObject(object);
         selectionBox.visible = true;
       } else if (object.el.hasAttribute('gltf-model')) {
-        object.el.addEventListener(
-          'model-loaded',
-          () => {
-            selectionBox.setFromObject(object);
-            selectionBox.visible = true;
-          },
-          { once: true }
-        );
+        const listener = (event) => {
+          if (event.target !== object.el) return; // we got an event for a child, ignore
+          selectionBox.setFromObject(object);
+          selectionBox.visible = true;
+          object.el.removeEventListener('model-loaded', listener);
+        };
+        object.el.addEventListener('model-loaded', listener);
       }
 
       transformControls.attach(object);


### PR DESCRIPTION
This is mainly code cleanup and creating pure functions (not using variables from outside the function) to better understand this code.
I fixed some issues and implemented drag and drop.
This closes #576

- Don't recreate AddLayerPanel each time we want to add an element, and make sure getSelectedMixinCards is not recalculated unnecessarily.
- Don't create preview entity each time the panel open.
- Don't set y to 0.2 for preview on non segment (for example bicycle on waterfront :p) and properly use worldToLocal when creating the entity so the preview and created entity are at the same position.
- Placing a second element moved the existing custom-group entity instead of moving the second entity inside the existing custom-group entity.
- The preview entity wrongly used a previous position instead of scene origin when no entity was selected.
- Instead of scene origin, place element at the intersection of ground and current camera position.
- Select created entity.
- Allow to drag and drop card to create an element at the drop position