### PR TITLE
Remove unneeded child-attached listener that refreshes raycaster objects

### DIFF
--- a/src/editor/lib/raycaster.js
+++ b/src/editor/lib/raycaster.js
@@ -1,17 +1,16 @@
 import Events from './Events';
-import debounce from 'lodash-es/debounce';
 
 export function initRaycaster(inspector) {
   // Use cursor="rayOrigin: mouse".
   const mouseCursor = document.createElement('a-entity');
   mouseCursor.setAttribute('id', 'aframeInspectorMouseCursor');
-  mouseCursor.setAttribute('cursor', 'rayOrigin', 'mouse');
-  mouseCursor.setAttribute('data-aframe-inspector', 'true');
   mouseCursor.setAttribute('raycaster', {
     interval: 100,
     objects:
       'a-scene :not([data-aframe-inspector]):not([data-ignore-raycaster])'
   });
+  mouseCursor.setAttribute('cursor', 'rayOrigin', 'mouse');
+  mouseCursor.setAttribute('data-aframe-inspector', 'true');
 
   // Only visible objects.
   const raycaster = mouseCursor.components.raycaster;
@@ -33,13 +32,6 @@ export function initRaycaster(inspector) {
 
   inspector.sceneEl.appendChild(mouseCursor);
   inspector.cursor = mouseCursor;
-
-  inspector.sceneEl.addEventListener(
-    'child-attached',
-    debounce(function () {
-      mouseCursor.components.raycaster.refreshObjects();
-    }, 250)
-  );
 
   mouseCursor.addEventListener('click', handleClick);
   mouseCursor.addEventListener('mouseenter', onMouseEnter);


### PR DESCRIPTION
Same as https://github.com/aframevr/aframe-inspector/pull/721
The closes #646