### PR TITLE
Properly unregister listeners when React component unmount

### DIFF
--- a/src/editor/components/components/CommonComponents.js
+++ b/src/editor/components/components/CommonComponents.js
@@ -28,18 +28,20 @@ export default class CommonComponents extends React.Component {
     entity: PropTypes.object
   };
 
+  onEntityUpdate = (detail) => {
+    if (detail.entity !== this.props.entity) {
+      return;
+    }
+    if (
+      DEFAULT_COMPONENTS.indexOf(detail.component) !== -1 ||
+      detail.component === 'mixin'
+    ) {
+      this.forceUpdate();
+    }
+  };
+
   componentDidMount() {
-    Events.on('entityupdate', (detail) => {
-      if (detail.entity !== this.props.entity) {
-        return;
-      }
-      if (
-        DEFAULT_COMPONENTS.indexOf(detail.component) !== -1 ||
-        detail.component === 'mixin'
-      ) {
-        this.forceUpdate();
-      }
-    });
+    Events.on('entityupdate', this.onEntityUpdate);
 
     var clipboard = new Clipboard('[data-action="copy-entity-to-clipboard"]', {
       text: (trigger) => {
@@ -49,6 +51,10 @@ export default class CommonComponents extends React.Component {
     clipboard.on('error', (e) => {
       // @todo Show the error on the UI
     });
+  }
+
+  componentWillUnmount() {
+    Events.off('entityupdate', this.onEntityUpdate);
   }
 
   renderCommonAttributes() {

--- a/src/editor/components/components/Component.js
+++ b/src/editor/components/components/Component.js
@@ -28,6 +28,15 @@ export default class Component extends React.Component {
     };
   }
 
+  onEntityUpdate = (detail) => {
+    if (detail.entity !== this.props.entity) {
+      return;
+    }
+    if (detail.component === this.props.name) {
+      this.forceUpdate();
+    }
+  };
+
   componentDidMount() {
     var clipboard = new Clipboard(
       '[data-action="copy-component-to-clipboard"]',
@@ -49,14 +58,11 @@ export default class Component extends React.Component {
       console.error(e);
     });
 
-    Events.on('entityupdate', (detail) => {
-      if (detail.entity !== this.props.entity) {
-        return;
-      }
-      if (detail.component === this.props.name) {
-        this.forceUpdate();
-      }
-    });
+    Events.on('entityupdate', this.onEntityUpdate);
+  }
+
+  componentWillUnmount() {
+    Events.off('entityupdate', this.onEntityUpdate);
   }
 
   static getDerivedStateFromProps(props, state) {

--- a/src/editor/components/components/ComponentsContainer.js
+++ b/src/editor/components/components/ComponentsContainer.js
@@ -5,20 +5,27 @@ import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Events from '../../lib/Events';
+
 export default class ComponentsContainer extends React.Component {
   static propTypes = {
     entity: PropTypes.object
   };
 
+  onEntityUpdate = (detail) => {
+    if (detail.entity !== this.props.entity) {
+      return;
+    }
+    if (detail.component === 'mixin') {
+      this.forceUpdate();
+    }
+  };
+
   componentDidMount() {
-    Events.on('entityupdate', (detail) => {
-      if (detail.entity !== this.props.entity) {
-        return;
-      }
-      if (detail.component === 'mixin') {
-        this.forceUpdate();
-      }
-    });
+    Events.on('entityupdate', this.onEntityUpdate);
+  }
+
+  componentWillUnmount() {
+    Events.off('entityupdate', this.onEntityUpdate);
   }
 
   render() {

--- a/src/editor/components/components/Sidebar.js
+++ b/src/editor/components/components/Sidebar.js
@@ -18,7 +18,6 @@ export default class Sidebar extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      open: false,
       rightBarHide: false
     };
   }
@@ -44,10 +43,6 @@ export default class Sidebar extends React.Component {
 
   toggleRightBar = () => {
     this.setState({ rightBarHide: !this.state.rightBarHide });
-  };
-
-  handleToggle = () => {
-    this.setState({ open: !this.state.open });
     sendMetric('Components', 'toggleSidebar');
   };
 

--- a/src/editor/components/components/Sidebar.js
+++ b/src/editor/components/components/Sidebar.js
@@ -22,25 +22,42 @@ export default class Sidebar extends React.Component {
     };
   }
 
+  onEntityUpdate = (detail) => {
+    if (detail.entity !== this.props.entity) {
+      return;
+    }
+    if (detail.component === 'mixin') {
+      this.forceUpdate();
+    }
+  };
+
+  onComponentRemove = (detail) => {
+    if (detail.entity !== this.props.entity) {
+      return;
+    }
+    this.forceUpdate();
+  };
+
+  onComponentAdd = (detail) => {
+    if (detail.entity !== this.props.entity) {
+      return;
+    }
+    this.forceUpdate();
+  };
+
   componentDidMount() {
-    Events.on('entityupdate', (detail) => {
-      if (detail.entity !== this.props.entity) {
-        return;
-      }
-      if (detail.component === 'mixin') {
-        this.forceUpdate();
-      }
-    });
-
-    Events.on('componentremove', (event) => {
-      this.forceUpdate();
-    });
-    Events.on('componentadd', (event) => {
-      this.forceUpdate();
-    });
+    Events.on('entityupdate', this.onEntityUpdate);
+    Events.on('componentremove', this.onComponentRemove);
+    Events.on('componentadd', this.onComponentAdd);
   }
-  // additional toggle for hide/show panel by clicking the button
 
+  componentWillUnmount() {
+    Events.off('entityupdate', this.onEntityUpdate);
+    Events.off('componentremove', this.onComponentRemove);
+    Events.off('componentadd', this.onComponentAdd);
+  }
+
+  // additional toggle for hide/show panel by clicking the button
   toggleRightBar = () => {
     this.setState({ rightBarHide: !this.state.rightBarHide });
     sendMetric('Components', 'toggleSidebar');

--- a/src/editor/components/modals/ModalTextures.js
+++ b/src/editor/components/modals/ModalTextures.js
@@ -63,12 +63,17 @@ export default class ModalTextures extends React.Component {
     this.registryGallery = React.createRef();
   }
 
-  componentDidMount() {
-    Events.on('assetsimagesload', (images) => {
-      this.generateFromRegistry();
-    });
+  onAssetsImagesLoad = (images) => {
+    this.generateFromRegistry();
+  };
 
+  componentDidMount() {
+    Events.on('assetsimagesload', this.onAssetsImagesLoad);
     this.generateFromAssets();
+  }
+
+  componentWillUnmount() {
+    Events.off('assetsimagesload', this.onAssetsImagesLoad);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/editor/components/scenegraph/SceneGraph.js
+++ b/src/editor/components/scenegraph/SceneGraph.js
@@ -33,17 +33,27 @@ export default class SceneGraph extends React.Component {
     };
   }
 
+  onMixinUpdate = (detail) => {
+    if (detail.component === 'mixin') {
+      this.rebuildEntityOptions();
+    }
+  };
+
   componentDidMount() {
     this.rebuildEntityOptions();
     Events.on('updatescenegraph', this.rebuildEntityOptions);
     Events.on('entityidchange', this.rebuildEntityOptions);
     Events.on('entitycreated', this.rebuildEntityOptions);
     Events.on('entityclone', this.rebuildEntityOptions);
-    Events.on('entityupdate', (detail) => {
-      if (detail.component === 'mixin') {
-        this.rebuildEntityOptions();
-      }
-    });
+    Events.on('entityupdate', this.onMixinUpdate);
+  }
+
+  componentWillUnmount() {
+    Events.off('updatescenegraph', this.rebuildEntityOptions);
+    Events.off('entityidchange', this.rebuildEntityOptions);
+    Events.off('entitycreated', this.rebuildEntityOptions);
+    Events.off('entityclone', this.rebuildEntityOptions);
+    Events.off('entityupdate', this.onMixinUpdate);
   }
 
   /**

--- a/src/editor/components/viewport/CameraToolbar/CameraToolbar.component.js
+++ b/src/editor/components/viewport/CameraToolbar/CameraToolbar.component.js
@@ -40,6 +40,10 @@ class CameraToolbar extends Component {
     areChangesEmitted: false
   };
 
+  onCameraToggle = (data) => {
+    this.setState({ selectedCamera: data.value });
+  };
+
   componentDidMount() {
     setTimeout(() => {
       this.setInitialCamera();
@@ -47,9 +51,7 @@ class CameraToolbar extends Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(() => {
-      this.setInitialCamera();
-    }, 1);
+    Events.off('cameratoggle', this.onCameraToggle);
   }
 
   setInitialCamera = () => {
@@ -61,9 +63,7 @@ class CameraToolbar extends Component {
       this.handleCameraChange(selectedOption);
     }
 
-    Events.on('cameratoggle', (data) =>
-      this.setState({ selectedCamera: data.value })
-    );
+    Events.on('cameratoggle', this.onCameraToggle);
   };
 
   handleCameraChange(option) {

--- a/src/editor/components/viewport/TransformToolbar.js
+++ b/src/editor/components/viewport/TransformToolbar.js
@@ -18,18 +18,26 @@ export default class TransformToolbar extends React.Component {
     };
   }
 
-  componentDidMount() {
-    Events.on('transformmodechange', (mode) => {
-      this.setState({ selectedTransform: mode });
-    });
+  onTransformModeChange = (mode) => {
+    this.setState({ selectedTransform: mode });
+  };
 
-    Events.on('transformspacechange', () => {
-      Events.emit(
-        'transformspacechanged',
-        this.state.localSpace ? 'world' : 'local'
-      );
-      this.setState({ localSpace: !this.state.localSpace });
-    });
+  onTransformSpaceChange = () => {
+    Events.emit(
+      'transformspacechanged',
+      this.state.localSpace ? 'world' : 'local'
+    );
+    this.setState({ localSpace: !this.state.localSpace });
+  };
+
+  componentDidMount() {
+    Events.on('transformmodechange', this.onTransformModeChange);
+    Events.on('transformspacechange', this.onTransformSpaceChange);
+  }
+
+  componentWillUnmount() {
+    Events.off('transformmodechange', this.onTransformModeChange);
+    Events.off('transformspacechange', this.onTransformSpaceChange);
   }
 
   changeTransformMode = (mode) => {

--- a/src/editor/components/viewport/ViewportHUD.js
+++ b/src/editor/components/viewport/ViewportHUD.js
@@ -6,8 +6,7 @@ export default class ViewportHUD extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      hoveredEntity: null,
-      selectedEntity: null
+      hoveredEntity: null
     };
   }
 

--- a/src/editor/components/viewport/ViewportHUD.js
+++ b/src/editor/components/viewport/ViewportHUD.js
@@ -10,14 +10,22 @@ export default class ViewportHUD extends React.Component {
     };
   }
 
-  componentDidMount() {
-    Events.on('raycastermouseenter', (el) => {
-      this.setState({ hoveredEntity: el });
-    });
+  onRaycasterMouseEnter = (el) => {
+    this.setState({ hoveredEntity: el });
+  };
 
-    Events.on('raycastermouseleave', (el) => {
-      this.setState({ hoveredEntity: el });
-    });
+  onRaycasterMouseLeave = (el) => {
+    this.setState({ hoveredEntity: el });
+  };
+
+  componentDidMount() {
+    Events.on('raycastermouseenter', this.onRaycasterMouseEnter);
+    Events.on('raycastermouseleave', this.onRaycasterMouseLeave);
+  }
+
+  componentWillUnmount() {
+    Events.off('raycastermouseenter', this.onRaycasterMouseEnter);
+    Events.off('raycastermouseleave', this.onRaycasterMouseLeave);
   }
 
   render() {


### PR DESCRIPTION
This contains some additional cleanup I did in https://github.com/aframevr/aframe-inspector/pull/745 and backport the unregister listeners on unmount I did in https://github.com/aframevr/aframe-inspector/pull/748

