### PR TITLE
Remove ctrl+x action

### DIFF
--- a/src/editor/components/modals/ModalHelp/components/Shortcuts/Shortcuts.component.jsx
+++ b/src/editor/components/modals/ModalHelp/components/Shortcuts/Shortcuts.component.jsx
@@ -12,7 +12,7 @@ const shortcuts = [
     { key: ['g'], description: 'Toggle grid visibility' },
     { key: ['n'], description: 'Add new entity' },
     { key: ['o'], description: 'Toggle local between global transform' },
-    { key: ['del | backspace'], description: 'Delete selected entity' }
+    { key: ['delete | backspace'], description: 'Delete selected entity' }
   ],
   [
     { key: ['0'], description: 'Toggle panels' },
@@ -24,11 +24,10 @@ const shortcuts = [
     { key: ['6'], description: 'Back view' },
     { key: ['7'], description: 'Front view' },
 
-    { key: ['ctrl | cmd', 'x'], description: 'Cut selected entity' },
-    { key: ['ctrl | cmd', 'c'], description: 'Copy selected entity' },
-    { key: ['ctrl | cmd', 'v'], description: 'Paste entity' },
+    { key: ['ctrl | cmd', 'c'], description: 'Copy selected entity' },
+    { key: ['ctrl | cmd', 'v'], description: 'Paste entity' },
     { key: ['h'], description: 'Show this help' },
-    { key: ['Esc'], description: 'Unselect entity' },
+    { key: ['esc'], description: 'Unselect entity' },
     { key: ['ctrl', 'alt', 'i'], description: 'Switch Edit and VR Modes' }
   ]
 ];

--- a/src/editor/components/modals/ModalHelp/components/Shortcuts/Shortcuts.component.jsx
+++ b/src/editor/components/modals/ModalHelp/components/Shortcuts/Shortcuts.component.jsx
@@ -12,7 +12,9 @@ const shortcuts = [
     { key: ['g'], description: 'Toggle grid visibility' },
     { key: ['n'], description: 'Add new entity' },
     { key: ['o'], description: 'Toggle local between global transform' },
-    { key: ['delete | backspace'], description: 'Delete selected entity' }
+    { key: ['delete | backspace'], description: 'Delete selected entity' },
+    { key: ['ctrl | cmd', 'z'], description: 'Undo action' },
+    { key: ['ctrl | cmd', 'shift', 'z'], description: 'Redo action' }
   ],
   [
     { key: ['0'], description: 'Toggle panels' },

--- a/src/editor/lib/shortcuts.js
+++ b/src/editor/lib/shortcuts.js
@@ -33,7 +33,7 @@ export const Shortcuts = {
       Events.emit('openhelpmodal');
     }
 
-    // esc: close inspector
+    // esc: unselect entity
     if (keyCode === 27) {
       if (this.inspector.selectedEntity) {
         this.inspector.selectEntity(null);
@@ -65,7 +65,7 @@ export const Shortcuts = {
       Events.emit('togglegrid');
     }
 
-    // backspace & supr: remove selected entity
+    // backspace & delete: remove selected entity
     if (keyCode === 8 || keyCode === 46) {
       removeSelectedEntity();
     }
@@ -136,12 +136,6 @@ export const Shortcuts = {
         AFRAME.INSPECTOR.selectedEntity &&
         document.activeElement.tagName !== 'INPUT'
       ) {
-        // x: cut selected entity
-        if (event.keyCode === 88) {
-          AFRAME.INSPECTOR.entityToCopy = AFRAME.INSPECTOR.selectedEntity;
-          removeSelectedEntity(true);
-        }
-
         // c: copy selected entity
         if (event.keyCode === 67) {
           AFRAME.INSPECTOR.entityToCopy = AFRAME.INSPECTOR.selectedEntity;
@@ -154,7 +148,7 @@ export const Shortcuts = {
       }
     }
 
-    // º: toggle sidebars visibility
+    // 0: toggle sidebars visibility
     if (event.keyCode === 48) {
       Events.emit('togglesidebar', { which: 'all' });
       event.preventDefault();


### PR DESCRIPTION
See https://github.com/aframevr/aframe-inspector/pull/759 for more context.

Also here ctrl+x then ctrl+v didn't do anything anymore with our EntityCloneCommand, the cut entity is not in the DOM so getElementById return null.
https://github.com/3DStreet/3dstreet/blob/3cf8194117ef02004d9763dfe0401dbc2c072cfe/src/editor/lib/commands/EntityCloneCommand.js#L20

I know we don't use the help modal anymore here, but I still updated it.