### PR TITLE
remove the h key to close modals that is not the help modal

### DIFF
--- a/src/editor/components/modals/PaymentModal/PaymentModal.component.jsx
+++ b/src/editor/components/modals/PaymentModal/PaymentModal.component.jsx
@@ -60,12 +60,7 @@ const PaymentModal = ({ isOpen, onClose }) => {
   };
 
   return (
-    <Modal
-      className={styles.modalWrapper}
-      isOpen={isOpen}
-      onClose={onClose}
-      extraCloseKeyCode={72}
-    >
+    <Modal className={styles.modalWrapper} isOpen={isOpen} onClose={onClose}>
       <div className={styles.paymentDetails}>
         <h3>Unlock Geospatial Features with a free 30 day trial</h3>
         <h2>

--- a/src/editor/components/modals/ProfileModal/ProfileModal.component.jsx
+++ b/src/editor/components/modals/ProfileModal/ProfileModal.component.jsx
@@ -40,12 +40,7 @@ const ProfileModal = ({ isOpen, onClose }) => {
   };
 
   return (
-    <Modal
-      className={styles.modalWrapper}
-      isOpen={isOpen}
-      onClose={onClose}
-      extraCloseKeyCode={72}
-    >
+    <Modal className={styles.modalWrapper} isOpen={isOpen} onClose={onClose}>
       <div className={styles.contentWrapper}>
         <h2 className={styles.title}>3DStreet Cloud Account</h2>
         <div className={styles.content}>

--- a/src/editor/components/modals/ScreenshotModal/ScreenshotModal.component.jsx
+++ b/src/editor/components/modals/ScreenshotModal/ScreenshotModal.component.jsx
@@ -186,7 +186,6 @@ function ScreenshotModal({ isOpen, onClose }) {
       className={styles.screenshotModalWrapper}
       isOpen={isOpen}
       onClose={onClose}
-      extraCloseKeyCode={72}
       title={'Share scene'}
       titleElement={
         <>

--- a/src/editor/components/modals/SignInModal/SignInModal.component.jsx
+++ b/src/editor/components/modals/SignInModal/SignInModal.component.jsx
@@ -4,12 +4,7 @@ import styles from './SignInModal.module.scss';
 import { signIn, signInMicrosoft } from '../../../api';
 
 const SignInModal = ({ isOpen, onClose }) => (
-  <Modal
-    className={styles.modalWrapper}
-    isOpen={isOpen}
-    onClose={onClose}
-    extraCloseKeyCode={72}
-  >
+  <Modal className={styles.modalWrapper} isOpen={isOpen} onClose={onClose}>
     <div className={styles.contentWrapper}>
       <h2 className={styles.title}>Sign in to 3DStreet Cloud</h2>
       <div className={styles.content}>


### PR DESCRIPTION
You fixed https://github.com/3DStreet/3dstreet/pull/814/commits/1f4df9ae15ec83cd4c6f16e75292a64b691ee84a @kfarr but there are lots of the other modals where we have that. It doesn't make sense in any of the modals except the help modal (we currently disabled) to have that h key to close the modal.

See #795 