### PR TITLE
remove weird background image when right panel title is clicked

### DIFF
--- a/src/editor/style/index.scss
+++ b/src/editor/style/index.scss
@@ -671,14 +671,6 @@ span {
   background-color: variables.$purple-200;
 }
 
-.outliner.hide #layers-title:active span {
-  display: block;
-  font-size: 18px;
-  color: variables.$lightgray-200;
-  background-position: left;
-  background-image: url(variables.$iconLayersActive) !important;
-}
-
 .outliner.hide #toggle-rightbar {
   background: rgba(50, 50, 50, 0.5) !important;
   backdrop-filter: blur(24px);


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0691baa2-d96b-4640-b3a0-88daa8b61826)

After:
![image](https://github.com/user-attachments/assets/1c36c9cd-782f-45b8-b088-0d69ffafc3b1)

