### PR TITLE
emit newScene event when all the entities are created

### DIFF
--- a/src/editor/components/scenegraph/Toolbar.js
+++ b/src/editor/components/scenegraph/Toolbar.js
@@ -163,6 +163,7 @@ export default class Toolbar extends Component {
   newHandler = () => {
     AFRAME.INSPECTOR.selectEntity(null);
     STREET.utils.newScene();
+    AFRAME.scenes[0].emit('newScene');
   };
 
   cloudSaveHandler = async ({ doSaveAs = false }) => {

--- a/src/editor/lib/toolbar.js
+++ b/src/editor/lib/toolbar.js
@@ -1,5 +1,3 @@
-import Events from './Events';
-
 export function inputStreetmix() {
   const streetmixURL = prompt(
     'Please enter a Streetmix URL',
@@ -21,8 +19,7 @@ export function inputStreetmix() {
     streetmixURL
   );
 
-  // update sceneGraph
-  Events.emit('updatescenegraph');
+  AFRAME.scenes[0].emit('newScene');
 }
 
 export function createElementsForScenesFromJSON(streetData) {
@@ -38,6 +35,7 @@ export function createElementsForScenesFromJSON(streetData) {
   }
 
   STREET.utils.createEntities(streetData, streetContainerEl);
+  AFRAME.scenes[0].emit('newScene');
 }
 
 export function fileJSON(event) {
@@ -45,8 +43,6 @@ export function fileJSON(event) {
 
   reader.onload = function () {
     STREET.utils.createElementsFromJSON(reader.result);
-    // update sceneGraph
-    Events.emit('updatescenegraph');
   };
 
   reader.readAsText(event.target.files[0]);

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -640,6 +640,7 @@ function inputStreetmix() {
     'streetmixStreetURL',
     streetmixURL
   );
+  AFRAME.scenes[0].emit('newScene');
 }
 
 STREET.utils.inputStreetmix = inputStreetmix;
@@ -677,6 +678,7 @@ function createElementsFromJSON(streetJSON) {
 
   createEntities(streetObject.data, streetContainerEl);
   STREET.notify.successMessage('Scene loaded from JSON');
+  AFRAME.scenes[0].emit('newScene');
 }
 
 STREET.utils.createElementsFromJSON = createElementsFromJSON;

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -74,8 +74,6 @@ function newScene(
       window.location.hash = '';
     });
   }
-
-  AFRAME.scenes[0].emit('newScene');
 }
 
 STREET.utils.newScene = newScene;


### PR DESCRIPTION
While investigating #819 I found out that we don't use properly the newScene event here, we use it for new scene and also when we load scene but the event is emitted before creating the entities.
We currently use the event to reset the undo history and to update the Geo context.
It doesn't seem we have any issue, but better to have the event emitted at the right time.