### PR TITLE
Better double click on item in scene graph

### DIFF
--- a/src/editor/components/scenegraph/Entity.js
+++ b/src/editor/components/scenegraph/Entity.js
@@ -103,7 +103,12 @@ export default class Entity extends React.Component {
     });
 
     return (
-      <div className={className} onClick={this.onClick} id={this.props.id}>
+      <div
+        className={className}
+        onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
+        id={this.props.id}
+      >
         <span>
           <span
             style={{
@@ -111,7 +116,7 @@ export default class Entity extends React.Component {
             }}
           />
           {visibilityButton}
-          {printEntity(entity, this.onDoubleClick)}
+          {printEntity(entity)}
           {collapse}
         </span>
         <span className="entityActions">

--- a/src/editor/components/scenegraph/SceneGraph.js
+++ b/src/editor/components/scenegraph/SceneGraph.js
@@ -91,6 +91,7 @@ export default class SceneGraph extends React.Component {
       if (entityOption.entity === entity) {
         this.setState({ selectedIndex: i });
         setTimeout(() => {
+          // wait 500ms to allow user to double click on entity
           document
             .getElementById('sgnode' + i)
             ?.scrollIntoView({ behavior: 'smooth' });

--- a/src/editor/components/scenegraph/SceneGraph.js
+++ b/src/editor/components/scenegraph/SceneGraph.js
@@ -89,11 +89,12 @@ export default class SceneGraph extends React.Component {
     for (let i = 0; i < this.state.entities.length; i++) {
       const entityOption = this.state.entities[i];
       if (entityOption.entity === entity) {
-        this.setState({ selectedIndex: i }, () => {
+        this.setState({ selectedIndex: i });
+        setTimeout(() => {
           document
             .getElementById('sgnode' + i)
             ?.scrollIntoView({ behavior: 'smooth' });
-        });
+        }, 500);
         // Make sure selected value is visible in scenegraph
         this.expandToRoot(entity);
         posthog.capture('entity_selected', {

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -572,7 +572,7 @@ const ICONS = {
   light: 'fa-lightbulb-o',
   text: 'fa-font'
 };
-export function printEntity(entity, onDoubleClick) {
+export function printEntity(entity) {
   if (!entity) {
     return '';
   }
@@ -589,7 +589,7 @@ export function printEntity(entity, onDoubleClick) {
   // Custom display name for a layer if available, otherwise use entity name or tag
   let displayName = getEntityDisplayName(entity);
   return (
-    <span className="entityPrint" onDoubleClick={onDoubleClick}>
+    <span className="entityPrint">
       {displayName && <span className="entityName">&nbsp;{displayName}</span>}
       {!!icons && (
         <span


### PR DESCRIPTION
wait 500ms before scrolling item into view so the user has time for a double click
allow double click on the whole purple area, like the click