### PR TITLE
Make the whole 'Upload 3DStreet JSON File' button clickable

### DIFF
--- a/src/editor/components/components/Button/Button.component.jsx
+++ b/src/editor/components/components/Button/Button.component.jsx
@@ -1,4 +1,4 @@
-import { bool, element, func, node, number, string } from 'prop-types';
+import { bool, element, func, node, number, object, string } from 'prop-types';
 
 import classNames from 'classnames';
 import styles from './Button.module.scss';
@@ -19,6 +19,7 @@ const variants = {
  * @category Components
  * @param {{
  *  className?: string;
+ *  style?: object;
  *  onClick?: () => void;
  *  onPointerDown?: () => void;
  *  onPointerUp?: () => void;
@@ -34,6 +35,7 @@ const variants = {
  */
 const Button = ({
   className,
+  style,
   onClick,
   onPointerDown,
   onPointerUp,
@@ -48,6 +50,7 @@ const Button = ({
 }) => (
   <button
     className={classNames(styles.buttonWrapper, variants[variant], className)}
+    style={style}
     onClick={onClick}
     onPointerDown={onPointerDown}
     onPointerUp={onPointerUp}
@@ -65,6 +68,7 @@ const Button = ({
 
 Button.propTypes = {
   className: string,
+  style: object,
   onClick: func,
   onPointerDown: func,
   onPointerUp: func,

--- a/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -223,25 +223,24 @@ const ScenesModal = ({ isOpen, onClose, initialTab = 'owner', delay }) => {
               <Button
                 leadingIcon={<Upload24Icon />}
                 className={styles.uploadBtn}
+                style={{ position: 'relative' }}
               >
-                <label
+                Upload 3DStreet JSON File
+                <input
+                  type="file"
+                  onChange={(e) => {
+                    fileJSON(e);
+                    onClose(); // Close the modal
+                  }}
                   style={{
-                    display: 'block',
-                    width: '100%',
+                    position: 'absolute',
+                    inset: 0,
+                    opacity: 0,
+                    fontSize: 0,
                     cursor: 'pointer'
                   }}
-                >
-                  <input
-                    type="file"
-                    onChange={(e) => {
-                      fileJSON(e);
-                      onClose(); // Close the modal
-                    }}
-                    style={{ display: 'none' }}
-                    accept=".js, .json, .txt"
-                  />
-                  Upload 3DStreet JSON File
-                </label>
+                  accept=".js, .json, .txt"
+                />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Just for you to see with 
```
opacity: 1,
border: '1px solid black',
```
the clickable area is now this:
![image](https://github.com/user-attachments/assets/0d30b4b8-ad74-4234-a451-f97d05d20c5d)

Before the clickable area was this:
![image](https://github.com/user-attachments/assets/88f6b161-2360-48e2-8130-fe734b542887)
