### PR TITLE
quick prevention of accidentally hitting new when a scene is saving

### DIFF
--- a/src/editor/components/scenegraph/Toolbar.js
+++ b/src/editor/components/scenegraph/Toolbar.js
@@ -416,7 +416,11 @@ export default class Toolbar extends Component {
       <div id="toolbar">
         <div className="toolbarActions">
           <div>
-            <Button leadingIcon={<Edit24Icon />} onClick={this.newHandler}>
+            <Button
+              leadingIcon={<Edit24Icon />}
+              onClick={this.newHandler}
+              disabled={this.state.isSavingScene}
+            >
               <div className="hideInLowResolution">New</div>
             </Button>
           </div>


### PR DESCRIPTION
Saw this bug occur when demoing 3dstreet. if you hit new while the scene is auto-saving, it wipes the scene.