### PR TITLE
first cut of data-no-transform

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,15 +96,15 @@
 
     </a-assets>
 
-    <a-entity id="street-container" data-layer-name="User Layers" data-layer-show-children>
+    <a-entity id="street-container" data-layer-name="User Layers" data-no-transform>
       <a-entity id="default-street" street streetmix-loader set-loader-from-hash></a-entity>
     </a-entity>
 
-    <a-entity id="reference-layers" data-layer-name="Geospatial Layers" data-layer-show-children></a-entity>
+    <a-entity id="reference-layers" data-layer-name="Geospatial Layers" data-no-transform></a-entity>
 
-    <a-entity id="environment" data-layer-name="Environment" street-environment="preset: day;"></a-entity>
+    <a-entity id="environment" data-layer-name="Environment" street-environment="preset: day;" data-no-transform></a-entity>
 
-    <a-entity id="cameraRig" class="ph-no-capture" data-layer-name="Viewer"
+    <a-entity id="cameraRig" class="ph-no-capture" data-layer-name="Viewer" data-no-transform
       cursor-teleport="cameraRig: #cameraRig; cameraHead: #camera;"
       movement-controls="camera: #camera; fly: true">
       <a-entity id="camera" position="0 1.6 0" camera look-controls="reverseMouseDrag: true"></a-entity>

--- a/src/aframe-streetmix-parsers.js
+++ b/src/aframe-streetmix-parsers.js
@@ -1009,6 +1009,7 @@ function processSegments(
   var streetParentEl = createCenteredStreetElement(segments);
   streetParentEl.classList.add('street-parent');
   streetParentEl.setAttribute('data-layer-name', 'Street Segments Container');
+  streetParentEl.setAttribute('data-no-transform', '');
 
   var cumulativeWidthInMeters = 0;
   for (var i = 0; i < segments.length; i++) {

--- a/src/editor/components/Main.js
+++ b/src/editor/components/Main.js
@@ -310,6 +310,7 @@ export default class Main extends Component {
             <ActionBar
               handleAddClick={this.toggleAddLayerPanel}
               isAddLayerPanelOpen={this.state.isAddLayerPanelOpen}
+              selectedEntity={this.state.entity}
             />
           </div>
         )}

--- a/src/editor/components/components/ActionBar/ActionBar.component.jsx
+++ b/src/editor/components/components/ActionBar/ActionBar.component.jsx
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react';
 import posthog from 'posthog-js';
 import { Rotate24Icon, Translate24Icon } from '../../../icons';
 
-const ActionBar = ({ handleAddClick, isAddLayerPanelOpen }) => {
+const ActionBar = ({ handleAddClick, isAddLayerPanelOpen, selectedEntity }) => {
   const [cursorEnabled, setCursorEnabled] = useState(
     AFRAME.INSPECTOR.cursor.isPlaying
   );
@@ -40,13 +40,18 @@ const ActionBar = ({ handleAddClick, isAddLayerPanelOpen }) => {
     setCursorEnabled(true);
   };
 
+  console.log('entity', selectedEntity);
   return (
     <div>
       {!isAddLayerPanelOpen && (
         <div className={styles.wrapper}>
           <Button
             variant="toolbtn"
-            className={classNames({ [styles.active]: !cursorEnabled })}
+            className={classNames({
+              [styles.active]:
+                !cursorEnabled ||
+                selectedEntity?.hasAttribute('data-no-transform')
+            })}
             onClick={handleHandClick}
           >
             <AwesomeIcon icon={faHand} />
@@ -54,18 +59,24 @@ const ActionBar = ({ handleAddClick, isAddLayerPanelOpen }) => {
           <Button
             variant="toolbtn"
             className={classNames({
-              [styles.active]: transformMode === 'translate'
+              [styles.active]:
+                transformMode === 'translate' &&
+                !selectedEntity?.hasAttribute('data-no-transform')
             })}
             onClick={() => changeTransformMode('translate')}
+            disabled={selectedEntity?.hasAttribute('data-no-transform')}
           >
             <Translate24Icon />
           </Button>
           <Button
             variant="toolbtn"
             className={classNames({
-              [styles.active]: transformMode === 'rotate'
+              [styles.active]:
+                transformMode === 'rotate' &&
+                !selectedEntity?.hasAttribute('data-no-transform')
             })}
             onClick={() => changeTransformMode('rotate')}
+            disabled={selectedEntity?.hasAttribute('data-no-transform')}
           >
             <Rotate24Icon />
           </Button>

--- a/src/editor/components/components/ActionBar/ActionBar.component.jsx
+++ b/src/editor/components/components/ActionBar/ActionBar.component.jsx
@@ -40,7 +40,6 @@ const ActionBar = ({ handleAddClick, isAddLayerPanelOpen, selectedEntity }) => {
     setCursorEnabled(true);
   };
 
-  console.log('entity', selectedEntity);
   return (
     <div>
       {!isAddLayerPanelOpen && (

--- a/src/editor/components/components/ComponentsContainer.js
+++ b/src/editor/components/components/ComponentsContainer.js
@@ -34,10 +34,12 @@ export default class ComponentsContainer extends React.Component {
         {entity.hasAttribute('data-no-transform') ? (
           <div>
             <br />
-            ⚠️ Transformations disabled for this layer.
+            <p>⚠️ Transformations disabled for this layer.</p>
           </div>
         ) : (
-          <CommonComponents entity={entity} />
+          <div>
+            <CommonComponents entity={entity} />
+          </div>
         )}
         <div className="advancedComponentsContainer">
           <AdvancedComponents entity={entity} />

--- a/src/editor/components/components/ComponentsContainer.js
+++ b/src/editor/components/components/ComponentsContainer.js
@@ -31,7 +31,14 @@ export default class ComponentsContainer extends React.Component {
 
     return (
       <div className="components">
-        <CommonComponents entity={entity} />
+        {entity.hasAttribute('data-no-transform') ? (
+          <div>
+            <br />
+            ⚠️ Transformations disabled for this layer.
+          </div>
+        ) : (
+          <CommonComponents entity={entity} />
+        )}
         <div className="advancedComponentsContainer">
           <AdvancedComponents entity={entity} />
         </div>

--- a/src/editor/components/components/Sidebar.js
+++ b/src/editor/components/components/Sidebar.js
@@ -96,20 +96,24 @@ export default class Sidebar extends React.Component {
                 {entity.id !== 'reference-layers' ? (
                   <>
                     {!!entity.mixinEls.length && <Mixins entity={entity} />}
-                    <div id="sidebar-buttons">
-                      <Button
-                        variant={'toolbtn'}
-                        onClick={() => cloneEntity(entity)}
-                      >
-                        Duplicate
-                      </Button>
-                      <Button
-                        variant={'toolbtn'}
-                        onClick={() => removeSelectedEntity()}
-                      >
-                        Delete
-                      </Button>
-                    </div>
+                    {entity.hasAttribute('data-no-transform') ? (
+                      <></>
+                    ) : (
+                      <div id="sidebar-buttons">
+                        <Button
+                          variant={'toolbtn'}
+                          onClick={() => cloneEntity(entity)}
+                        >
+                          Duplicate
+                        </Button>
+                        <Button
+                          variant={'toolbtn'}
+                          onClick={() => removeSelectedEntity()}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    )}
                     <ComponentsContainer entity={entity} />
                   </>
                 ) : (

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -287,8 +287,9 @@ export function Viewport(inspector) {
       }
 
       if (inspector.cursor.isPlaying) {
-        // Only show transform controls when we are in pointer mode
-        transformControls.attach(object);
+        if (!object.el.hasAttribute('data-no-transform')) {
+          transformControls.attach(object);
+        }
       }
     }
   });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e0073599-a372-4e86-9202-5baad9be2100)

kinda ugly at the moment, suggestions to clean it up:
- also remove duplicate / delete buttons for `data-no-transform` layers
- consider more user friendly message such as editing disabled on this layer, choose another.