### PR TITLE
Less moving parts during the saved animation

### DIFF
--- a/src/editor/components/components/Save/Save.component.jsx
+++ b/src/editor/components/components/Save/Save.component.jsx
@@ -89,19 +89,23 @@ export const Save = ({ currentUser }) => {
   return (
     <div>
       {currentUser ? (
-        <div className="saveButtonWrapper relative w-24">
+        <div className="saveButtonWrapper relative">
           {isSavingScene ? (
-            <Button variant="filled">
-              <div>Saved</div>
+            <Button
+              leadingIcon={<Save24Icon />}
+              variant="filled"
+              className="min-w-[110px]"
+            >
+              <div className="grow">Saved</div>
             </Button>
           ) : (
             <Button
               leadingIcon={<Save24Icon />}
               onClick={toggleSaveActionState}
-              disabled={isSavingScene}
               variant="toolbtn"
+              className="min-w-[110px]"
             >
-              <div>Save</div>
+              <div className="grow">Save</div>
             </Button>
           )}
           {isSaveActionActive && (
@@ -128,11 +132,11 @@ export const Save = ({ currentUser }) => {
       ) : (
         <Button
           leadingIcon={<Save24Icon />}
-          onClick={handleUnsignedSave}
-          disabled={isSavingScene}
+          onClick={!isSavingScene ? handleUnsignedSave : undefined}
           variant="toolbtn"
+          className="min-w-[110px]"
         >
-          <div>Save</div>
+          <div className="grow">Save</div>
         </Button>
       )}
     </div>

--- a/src/editor/components/scenegraph/Toolbar.js
+++ b/src/editor/components/scenegraph/Toolbar.js
@@ -31,8 +31,7 @@ function Toolbar({ currentUser }) {
             <div className="col-span-2 flex items-center justify-end gap-2">
               <Button
                 leadingIcon={<Edit24Icon />}
-                onClick={newHandler}
-                disabled={isSavingScene}
+                onClick={!isSavingScene ? newHandler : undefined}
                 variant="toolbtn"
               >
                 <div>New</div>


### PR DESCRIPTION
Before:
[saved-animation-before.webm](https://github.com/user-attachments/assets/b31dabcf-5ffd-4663-a431-e318ffb24a31)

After:
[saved-animation.webm](https://github.com/user-attachments/assets/f5361c83-39a3-47b1-a365-3b8eb481b0cc)
