### PR TITLE
Fix thumbnail overlap in SceneCard

### DIFF
--- a/src/editor/components/components/SceneCard/SceneCard.module.scss
+++ b/src/editor/components/components/SceneCard/SceneCard.module.scss
@@ -11,7 +11,7 @@
   .img {
     margin-bottom: 6px;
     object-fit: cover;
-    width: 272px;
+    width: 100%;
     height: 204px;
   }
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/3fc2a656-7afe-4c24-9cb9-7f2c237abd88)

After:
![image](https://github.com/user-attachments/assets/9efa78b7-e09a-4f52-8b1b-a4b37d92c1db)
