### PR TITLE
In SceneGraph, only scroll node into view if it's not currently visible

### DIFF
--- a/src/editor/components/scenegraph/SceneGraph.js
+++ b/src/editor/components/scenegraph/SceneGraph.js
@@ -92,7 +92,7 @@ export default class SceneGraph extends React.Component {
       if (entityOption.entity === entity) {
         this.setState({ selectedIndex: i });
         setTimeout(() => {
-          // wait 500ms to allow user to double click on entity
+          // wait 100ms to allow React to update the UI and create the node we're interested in
           const node = document.getElementById('sgnode' + i);
           const scrollableContainer = document.querySelector(
             '#scenegraph .layers'
@@ -106,7 +106,7 @@ export default class SceneGraph extends React.Component {
           if (!isVisible) {
             node.scrollIntoView({ behavior: 'smooth' });
           }
-        }, 500);
+        }, 100);
         // Make sure selected value is visible in scenegraph
         this.expandToRoot(entity);
         posthog.capture('entity_selected', {

--- a/src/editor/components/scenegraph/SceneGraph.js
+++ b/src/editor/components/scenegraph/SceneGraph.js
@@ -93,9 +93,19 @@ export default class SceneGraph extends React.Component {
         this.setState({ selectedIndex: i });
         setTimeout(() => {
           // wait 500ms to allow user to double click on entity
-          document
-            .getElementById('sgnode' + i)
-            ?.scrollIntoView({ behavior: 'smooth' });
+          const node = document.getElementById('sgnode' + i);
+          const scrollableContainer = document.querySelector(
+            '#scenegraph .layers'
+          );
+          if (!node || !scrollableContainer) return;
+          const containerRect = scrollableContainer.getBoundingClientRect();
+          const nodeRect = node.getBoundingClientRect();
+          const isVisible =
+            nodeRect.top >= containerRect.top &&
+            nodeRect.bottom <= containerRect.bottom;
+          if (!isVisible) {
+            node.scrollIntoView({ behavior: 'smooth' });
+          }
         }, 500);
         // Make sure selected value is visible in scenegraph
         this.expandToRoot(entity);


### PR DESCRIPTION
Before:
[3dstreet-sg-scroll-before.webm](https://github.com/user-attachments/assets/4eea0e61-f320-4df8-8999-89eb2e979930)

After:
[3dstreet-sg-scroll.webm](https://github.com/user-attachments/assets/5f4f5e86-d90a-4793-a7f6-fba4d728934d)
