### PR TITLE
Curb radius option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ The `intersection` component creates an intersection surface with options for ad
 | --------- | --------- | --------- |
 | dimensions | Specifies the width and depth of the intersection. First value represents width, second value represents depth. | '20 20' |
 | sidewalk | Sets the width of the sidewalk at each side of the intersection. Values are set in the order of west, east, north, south. |  '0 0 0 0' |
-| northeastcurb | Sets the curb dimensions for the north east curb. Values are updated as width, then depth. | '4 4' |
-| southwestcurb | Sets the curb dimensions for the south west curb. Values are updated as width, then depth.  | '4 4' |
-| southeastcurb | Sets the curb dimensions for the south east curb. Values are updated as width, then depth. | '4 4' |
-| northwestcurb | Sets the curb dimensions for the north west curb. Values are updated as width, then depth. | '4 4' |
+| northeastcurb | Sets the curb dimensions for the north east curb. Values are updated as width, depth, then radius. | '4 4 0' |
+| southwestcurb | Sets the curb dimensions for the south west curb. Values are updated as width, depth, then radius. | '4 4 0' |
+| southeastcurb | Sets the curb dimensions for the south east curb. Values are updated as width, depth, then radius. | '4 4 0' |
+| northwestcurb | Sets the curb dimensions for the north west curb. Values are updated as width, depth, then radius. | '4 4 0' |
 | stopsign | Sets if each side of the intersection has a stop sign. Values are set in the order of east, west, north, south. 0 is false, 1 is true. | '0 0 0 0' |
 | trafficsignal | Sets if each side of the intersection has a traffic signal. Values are set in the order of east, west, north, south. 0 is false, 1 is true. | '1 1 1 1' |
 | crosswalk | ​​Sets if each side of the intersection has a crosswalk. Values are set in the order of east, west, north, south. 0 is false, 1 is true. | '1 1 1 1' |

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -97,10 +97,12 @@ AFRAME.registerComponent('intersection', {
       console.log(sidewalkTexture);
       sidewalkTexture.wrapS = THREE.RepeatWrapping;
       sidewalkTexture.wrapT = THREE.RepeatWrapping;
-      sidewalkTexture.repeat.set(2, 2);
+      sidewalkTexture.repeat.set(0.5, 0.5);
 
-      const material = new THREE.MeshBasicMaterial({
-        map: sidewalkTexture
+      const material = new THREE.MeshStandardMaterial({
+        map: sidewalkTexture,
+        roughness: 0.8,
+        color: 0xcccccc
       });
       const mesh = new THREE.Mesh(curbGeom, material);
       mesh.scale.setX(scaleVec.x);
@@ -109,13 +111,7 @@ AFRAME.registerComponent('intersection', {
 
       sd.setAttribute('position', positionVec);
       sd.setAttribute('rotation', rotationVec);
-      // sd.setAttribute('mixin', 'sidewalk');
-      // sd.setAttribute('shadow', 'cast: false;');
       sd.classList.add('autocreated');
-      // sd.setAttribute(
-      //   'material',
-      //   `repeat: ${repeatCountInter[0]} ${repeatCountInter[1]}`
-      // );
       sd.setAttribute('data-layer-name', 'Sidewalk • ' + displayName);
       sd.setAttribute('data-no-transform', '');
       sd.setAttribute('data-ignore-raycaster', '');

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -126,43 +126,45 @@ AFRAME.registerComponent('intersection', {
     // describe sidewalk parameters
     const sidewalkParams = {
       west: {
-        positionVec: { x: -intersectWidth / 2 + sidewalkArray[0] / 2, z: 0.1 },
-        rotationVec: { x: 90, y: 0, z: 0 },
-        length: intersectDepth,
-        width: sidewalkArray[0],
+        positionVec: {
+          x: -intersectWidth / 2,
+          y: -intersectWidth / 2,
+          z: 0.1
+        },
+        width: intersectDepth,
+        length: sidewalkArray[0],
         displayName: 'West'
       },
       east: {
-        positionVec: { x: intersectWidth / 2 - sidewalkArray[1] / 2, z: 0.1 },
-        rotationVec: { x: 90, y: 0, z: 0 },
-        length: intersectDepth,
-        width: sidewalkArray[1],
+        positionVec: {
+          x: intersectWidth / 2,
+          y: -intersectWidth / 2,
+          z: 0.1
+        },
+        scaleVec: { x: -1, y: 1, z: 1 },
+        width: intersectDepth,
+        length: sidewalkArray[1],
         displayName: 'East'
       },
       north: {
         positionVec: {
-          // add x offset to avoid sidewalk's element overlap
-          x: sidewalkArray[1] / 2 - sidewalkArray[0] / 2,
-          y: intersectDepth / 2 - sidewalkArray[2] / 2,
+          x: -intersectWidth / 2,
+          y: intersectWidth / 2,
           z: 0.1
         },
-        rotationVec: { x: 0, y: 90, z: -90 },
-        // minus the width of the crossing sidewalk
-        length: intersectWidth - sidewalkArray[1] - sidewalkArray[0],
+        scaleVec: { x: 1, y: -1, z: 1 },
         width: sidewalkArray[2],
+        length: intersectDepth,
         displayName: 'North'
       },
       south: {
         positionVec: {
-          // add x offset to avoid sidewalk's element overlap
-          x: sidewalkArray[1] / 2 - sidewalkArray[0] / 2,
-          y: -intersectDepth / 2 + sidewalkArray[3] / 2,
+          x: -intersectWidth / 2,
+          y: -intersectWidth / 2,
           z: 0.1
         },
-        rotationVec: { x: 0, y: 90, z: -90 },
-        // minus the width of the crossing sidewalk
-        length: intersectWidth - sidewalkArray[1] - sidewalkArray[0],
         width: sidewalkArray[3],
+        length: intersectDepth,
         displayName: 'South'
       }
     };

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -91,7 +91,7 @@ AFRAME.registerComponent('intersection', {
       // Create new shape out of the points:
       const curbShape = new THREE.Shape(points);
       const curbGeom = new THREE.ExtrudeGeometry(curbShape, {
-        depth: 0.4,
+        depth: 0.4, // Match existing sidewalk thickness
         bevelEnabled: false
       });
 
@@ -101,12 +101,12 @@ AFRAME.registerComponent('intersection', {
       console.log(sidewalkTexture);
       sidewalkTexture.wrapS = THREE.RepeatWrapping;
       sidewalkTexture.wrapT = THREE.RepeatWrapping;
-      sidewalkTexture.repeat.set(0.5, 0.5);
+      sidewalkTexture.repeat.set(0.5, 0.5); // Scale the texture to repeat twice every meter
 
       const material = new THREE.MeshStandardMaterial({
         map: sidewalkTexture,
-        roughness: 0.8,
-        color: 0xcccccc
+        roughness: 0.8, // Same roughness as sidewalk mixin in src/assets.js
+        color: 0xcccccc // Darkens the texture to match existing sidewalk
       });
       const mesh = new THREE.Mesh(curbGeom, material);
       mesh.scale.setX(scaleVec.x);

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -6,10 +6,10 @@ AFRAME.registerComponent('intersection', {
     dimensions: { type: 'string', default: '20 20' },
     // cardinal direction order for sidewalk, stopsign, crosswalk, and trafficsignal: west, east, north, south
     sidewalk: { type: 'string', default: '0 0 0 0' },
-    northeastcurb: { type: 'string', default: '4 4 0' },
-    southwestcurb: { type: 'string', default: '4 4 0' },
-    southeastcurb: { type: 'string', default: '4 4 0' },
-    northwestcurb: { type: 'string', default: '4 4 0' },
+    northeastcurb: { type: 'string', default: '4 4 1' },
+    southwestcurb: { type: 'string', default: '4 4 1' },
+    southeastcurb: { type: 'string', default: '4 4 1' },
+    northwestcurb: { type: 'string', default: '4 4 1' },
     stopsign: { type: 'string', default: '0 0 0 0' },
     trafficsignal: { type: 'string', default: '1 1 1 1' },
     crosswalk: { type: 'string', default: '1 1 1 1' }
@@ -185,8 +185,7 @@ AFRAME.registerComponent('intersection', {
           y: intersectDepth / 2,
           z: 0.1
         },
-        rotationVec: { x: 0, y: 0, z: 180 },
-        scaleVec: { x: 1, y: 1, z: 1 },
+        scaleVec: { x: -1, y: -1, z: 1 },
         length: northeastcurbArray[0],
         width: northeastcurbArray[1],
         radius: northeastcurbArray[2],
@@ -198,7 +197,6 @@ AFRAME.registerComponent('intersection', {
           y: -intersectDepth / 2,
           z: 0.1
         },
-        rotationVec: { x: 0, y: 0, z: 0 },
         scaleVec: { x: 1, y: 1, z: 1 },
         length: southwestcurbArray[0],
         width: southwestcurbArray[1],
@@ -211,7 +209,6 @@ AFRAME.registerComponent('intersection', {
           y: -intersectDepth / 2,
           z: 0.1
         },
-        rotationVec: { x: 0, y: 0, z: 0 },
         scaleVec: { x: -1, y: 1, z: 1 },
         length: southeastcurbArray[0],
         width: southeastcurbArray[1],
@@ -224,7 +221,6 @@ AFRAME.registerComponent('intersection', {
           y: intersectDepth / 2,
           z: 0.1
         },
-        rotationVec: { x: 0, y: 0, z: 0 },
         scaleVec: { x: 1, y: -1, z: 1 },
         length: northwestcurbArray[0],
         width: northwestcurbArray[1],

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -4,10 +4,10 @@ AFRAME.registerComponent('intersection', {
     dimensions: { type: 'string', default: '20 20' },
     // cardinal direction order for sidewalk, stopsign, crosswalk, and trafficsignal: west, east, north, south
     sidewalk: { type: 'string', default: '0 0 0 0' },
-    northeastcurb: { type: 'string', default: '4 4' },
-    southwestcurb: { type: 'string', default: '4 4' },
-    southeastcurb: { type: 'string', default: '4 4' },
-    northwestcurb: { type: 'string', default: '4 4' },
+    northeastcurb: { type: 'string', default: '4 4 0' },
+    southwestcurb: { type: 'string', default: '4 4 0' },
+    southeastcurb: { type: 'string', default: '4 4 0' },
+    northwestcurb: { type: 'string', default: '4 4 0' },
     stopsign: { type: 'string', default: '0 0 0 0' },
     trafficsignal: { type: 'string', default: '1 1 1 1' },
     crosswalk: { type: 'string', default: '1 1 1 1' }

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -72,16 +72,20 @@ AFRAME.registerComponent('intersection', {
       const points = [];
       points.push(new THREE.Vector2(0, 0));
       points.push(new THREE.Vector2(length, 0));
-      // The arc
-      const arc = new THREE.EllipseCurve(
-        length - boundedRadius,
-        width - boundedRadius,
-        boundedRadius,
-        boundedRadius,
-        0,
-        Math.PI / 2
-      );
-      points.push(...arc.getSpacedPoints());
+      // Only if a radius is set, create the arc
+      if (radius > 0) {
+        const arc = new THREE.EllipseCurve(
+          length - boundedRadius,
+          width - boundedRadius,
+          boundedRadius,
+          boundedRadius,
+          0,
+          Math.PI / 2
+        );
+        points.push(...arc.getSpacedPoints());
+      } else {
+        points.push(new THREE.Vector2(length, width));
+      }
       points.push(new THREE.Vector2(0, width));
 
       // Create new shape out of the points:

--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -151,6 +151,7 @@ AFRAME.registerComponent('intersection', {
         rotationVec: { x: 0, y: 90, z: -90 },
         length: northeastcurbArray[0],
         width: northeastcurbArray[1],
+        radius: northeastcurbArray[2],
         displayName: 'Northeast'
       },
       southwest: {
@@ -162,6 +163,7 @@ AFRAME.registerComponent('intersection', {
         rotationVec: { x: 0, y: 90, z: -90 },
         length: southwestcurbArray[0],
         width: southwestcurbArray[1],
+        radius: southwestcurbArray[2],
         displayName: 'Southwest'
       },
       southeast: {
@@ -173,6 +175,7 @@ AFRAME.registerComponent('intersection', {
         rotationVec: { x: 0, y: 90, z: -90 },
         length: southeastcurbArray[0],
         width: southeastcurbArray[1],
+        radius: southeastcurbArray[2],
         displayName: 'Southeast'
       },
       northwest: {
@@ -184,6 +187,7 @@ AFRAME.registerComponent('intersection', {
         rotationVec: { x: 0, y: 90, z: -90 },
         length: northwestcurbArray[0],
         width: northwestcurbArray[1],
+        radius: northwestcurbArray[2],
         displayName: 'Northwest'
       }
     };

--- a/src/editor/components/components/IntersectionSidebar.js
+++ b/src/editor/components/components/IntersectionSidebar.js
@@ -59,6 +59,12 @@ const IntersectionSidebar = ({ entity }) => {
     updateCurbArray(newCurbArray);
   };
 
+  const handleCurbRadiusChange = (_, value) => {
+    const newCurbArray = [...curbArrays[curb]];
+    newCurbArray[2] = value;
+    updateCurbArray(newCurbArray);
+  };
+
   const updateCurbArray = (newCurbArray) => {
     switch (curb) {
       case 'northeast':
@@ -245,6 +251,14 @@ const IntersectionSidebar = ({ entity }) => {
               name="curbHeight"
               value={curbArrays[curb][1]}
               onChange={handleCurbHeightChange}
+            />
+          </div>
+          <div className="propertyRow">
+            <label className="text">Radius:</label>
+            <NumberWidget
+              name="curbRadius"
+              value={curbArrays[curb][2]}
+              onChange={handleCurbRadiusChange}
             />
           </div>
         </div>


### PR DESCRIPTION
Adds the curb radius option for intersections: #967 

- Adds a new radius field under `width` and `height` in the intersection properties panel.
- Replaces the curb primitive geometry with a 3js mesh generated from the width, height, and radius parameters.
- Update the README with the changes to the `northeastcurb: ...`, `northwestcurb: ...`, ... API:
  The radius is the third value. Example: `northeastcurb: 4, 4, 1` for a 4m x 4m curb with a 1m radius in the corner of the intersection.
Note: the radius that is generated is bounded to the lower of the width and length of the curb. So a 4m x 6m curb will have a radius no smaller than 4m.

![image](https://github.com/user-attachments/assets/63b54f31-1245-4b77-9b9f-d1ed337de3db)
<img width="754" alt="Screenshot 2024-12-21 at 10 01 30 PM" src="https://github.com/user-attachments/assets/cdff8454-c7fb-4ed1-a8e5-7548bed4ed28" />
