### PR TITLE
[WIP] Adding color options to entities

### DIFF
--- a/src/components/accent-color.js
+++ b/src/components/accent-color.js
@@ -11,12 +11,10 @@ AFRAME.registerComponent('accent-color', {
   },
   init: function () {
     this.meshes = [];
-    console.log(this.el);
     // The group children aren't ready when the component is initialized, so wait a bit.
     // TODO: Find a better way to time this.
     setTimeout(() => {
       this.el.object3D.traverse((o) => o.material && this.meshes.push(o));
-      console.log(this.meshes);
       this.update();
     }, 1000);
   },

--- a/src/components/accent-color.js
+++ b/src/components/accent-color.js
@@ -10,24 +10,23 @@ AFRAME.registerComponent('accent-color', {
     }
   },
   init: function () {
-    this.meshes = [];
-    // The group children aren't ready when the component is initialized, so wait a bit.
-    // TODO: Find a better way to time this.
-    setTimeout(() => {
-      this.el.object3D.traverse((o) => o.material && this.meshes.push(o));
-      this.update();
-    }, 1000);
+    // Want the color update to apply when the mixin is loaded,
+    // which may be at a different time than the component
+    this.el.addEventListener('model-loaded', () => this.update());
   },
   update: function (oldData) {
+    // Collect meshes
+    const meshes = [];
+    this.el.object3D.traverse((o) => o.material && meshes.push(o));
     // Remove the tint on the previous mesh
     if (oldData && oldData.index !== this.data.index) {
-      const oldMesh = this.meshes.at(oldData.index);
+      const oldMesh = meshes.at(oldData.index);
       oldMesh && oldMesh.material.color.set(1, 1, 1);
     }
     // Ignore negative index
     if (this.data.index < 0) return;
     // Apply tint to selected mesh
-    const mesh = this.meshes.at(this.data.index);
+    const mesh = meshes.at(this.data.index);
     if (mesh) {
       mesh.material.color.set(this.data.color);
       mesh.material.color.multiplyScalar(255);

--- a/src/components/accent-color.js
+++ b/src/components/accent-color.js
@@ -1,0 +1,38 @@
+/* global AFRAME */
+
+AFRAME.registerComponent('accent-color', {
+  schema: {
+    color: {
+      type: 'color'
+    },
+    index: {
+      type: 'int'
+    }
+  },
+  init: function () {
+    this.meshes = [];
+    console.log(this.el);
+    // The group children aren't ready when the component is initialized, so wait a bit.
+    // TODO: Find a better way to time this.
+    setTimeout(() => {
+      this.el.object3D.traverse((o) => o.material && this.meshes.push(o));
+      console.log(this.meshes);
+      this.update();
+    }, 1000);
+  },
+  update: function (oldData) {
+    // Remove the tint on the previous mesh
+    if (oldData && oldData.index !== this.data.index) {
+      const oldMesh = this.meshes.at(oldData.index);
+      oldMesh && oldMesh.material.color.set(1, 1, 1);
+    }
+    // Ignore negative index
+    if (this.data.index < 0) return;
+    // Apply tint to selected mesh
+    const mesh = this.meshes.at(this.data.index);
+    if (mesh) {
+      mesh.material.color.set(this.data.color);
+      mesh.material.color.multiplyScalar(255);
+    }
+  }
+});

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -204,7 +204,6 @@ const createEntity = (mixinId) => {
     });
     newEntityObject.components.position = position;
   }
-  console.log('heere!!');
   AFRAME.INSPECTOR.execute('entitycreate', newEntityObject);
 };
 

--- a/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/components/AddLayerPanel/AddLayerPanel.component.jsx
@@ -145,7 +145,11 @@ const createEntity = (mixinId) => {
   }
   const newEntityObject = {
     mixin: mixinId,
-    components: {}
+    components: {
+      'accent-color': {
+        index: -1
+      }
+    }
   };
 
   const selectedElement = AFRAME.INSPECTOR.selectedEntity;
@@ -200,6 +204,7 @@ const createEntity = (mixinId) => {
     });
     newEntityObject.components.position = position;
   }
+  console.log('heere!!');
   AFRAME.INSPECTOR.execute('entitycreate', newEntityObject);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ require('./lib/animation-mixer.js');
 require('./lib/aframe-gaussian-splatting-component.min.js');
 require('./assets.js');
 require('./components/notify.js');
+require('./components/accent-color.js');
 require('./components/create-from-json');
 require('./components/screentock.js');
 require('aframe-atlas-uvs-component');


### PR DESCRIPTION
Based on #166, I was playing around with options for adding color. Here's a basic implementation of a simple approach to just modify the contents of meshes `object3D` to have a `color` property on their materials.

- Since each entity has multiple meshes it is hard to determine which one corresponds with which part (i.e. the Sedan has one mesh for the body, one mesh for the windows), I left an `index` field so that the user can specify which mesh to change the color for (though this requires a bit of guessing, and leave it to `-1` for no color applied).
- The data for the coloring is saved in the `accent-color` component which has the `color` and `index` values, and is grouped under the "advanced" section.
- The `color` field doesn't really work as a true color change but more of a tint. So it isn't exactly ideal, but it works for all entities without any changes to the model files.

<img width="1141" alt="Screenshot 2024-12-27 at 12 03 41 AM" src="https://github.com/user-attachments/assets/c5c961ef-37ef-4cd3-8bfb-fe8d5b39666c" />
 
<img width="1146" alt="Screenshot 2024-12-26 at 11 58 55 PM" src="https://github.com/user-attachments/assets/a7abdaef-42e8-4b8c-b421-c1a905c01595" />
