### PR TITLE
Fix intersection sidewalk being in wrong position for intersections with non-default sizes

### DIFF
--- a/src/components/intersection.js
+++ b/src/components/intersection.js
@@ -131,7 +131,7 @@ AFRAME.registerComponent('intersection', {
       west: {
         positionVec: {
           x: -intersectWidth / 2,
-          y: -intersectWidth / 2,
+          y: -intersectDepth / 2,
           z: 0.1
         },
         width: intersectDepth,
@@ -141,7 +141,7 @@ AFRAME.registerComponent('intersection', {
       east: {
         positionVec: {
           x: intersectWidth / 2,
-          y: -intersectWidth / 2,
+          y: -intersectDepth / 2,
           z: 0.1
         },
         scaleVec: { x: -1, y: 1, z: 1 },
@@ -152,22 +152,22 @@ AFRAME.registerComponent('intersection', {
       north: {
         positionVec: {
           x: -intersectWidth / 2,
-          y: intersectWidth / 2,
+          y: intersectDepth / 2,
           z: 0.1
         },
         scaleVec: { x: 1, y: -1, z: 1 },
         width: sidewalkArray[2],
-        length: intersectDepth,
+        length: intersectWidth,
         displayName: 'North'
       },
       south: {
         positionVec: {
           x: -intersectWidth / 2,
-          y: -intersectWidth / 2,
+          y: -intersectDepth / 2,
           z: 0.1
         },
         width: sidewalkArray[3],
-        length: intersectDepth,
+        length: intersectWidth,
         displayName: 'South'
       }
     };


### PR DESCRIPTION
fixes incorrect width and depth order.

Before:
<img width="745" alt="Screenshot 2024-12-27 at 4 30 09 PM" src="https://github.com/user-attachments/assets/397f62dc-163f-4439-a622-57acefeaca85" />

After:
<img width="559" alt="Screenshot 2024-12-27 at 4 38 00 PM" src="https://github.com/user-attachments/assets/3c07e5ea-22f5-41e5-83b8-ce08e43f90dc" />
