### PR TITLE
Add multi command to be able to undo a sequence of actions in one step

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -206,13 +206,13 @@ Inspector.prototype = {
     });
   },
 
-  execute: function (cmdName, payload, optionalName) {
+  execute: function (cmdName, payload, optionalName, callback = undefined) {
     const Cmd = commandsByType.get(cmdName);
     if (!Cmd) {
       console.error(`Command ${cmdName} not found`);
       return;
     }
-    return this.history.execute(new Cmd(this, payload), optionalName);
+    return this.history.execute(new Cmd(this, payload, callback), optionalName);
   },
 
   undo: function () {

--- a/src/editor/lib/commands/ComponentAddCommand.js
+++ b/src/editor/lib/commands/ComponentAddCommand.js
@@ -19,7 +19,7 @@ export class ComponentAddCommand extends Command {
     this.value = payload.value;
   }
 
-  execute() {
+  execute(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       entity.setAttribute(this.component, this.value);
@@ -28,10 +28,11 @@ export class ComponentAddCommand extends Command {
         component: this.component,
         value: this.value
       });
+      nextCommandCallback?.(entity);
     }
   }
 
-  undo() {
+  undo(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       entity.removeAttribute(this.component);
@@ -39,6 +40,7 @@ export class ComponentAddCommand extends Command {
         entity,
         component: this.component
       });
+      nextCommandCallback?.(entity);
     }
   }
 }

--- a/src/editor/lib/commands/ComponentRemoveCommand.js
+++ b/src/editor/lib/commands/ComponentRemoveCommand.js
@@ -25,7 +25,7 @@ export class ComponentRemoveCommand extends Command {
       : structuredClone(entity.getDOMAttribute(payload.component));
   }
 
-  execute() {
+  execute(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       entity.removeAttribute(this.component);
@@ -33,10 +33,11 @@ export class ComponentRemoveCommand extends Command {
         entity,
         component: this.component
       });
+      nextCommandCallback?.(entity);
     }
   }
 
-  undo() {
+  undo(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       entity.setAttribute(this.component, this.value);
@@ -45,6 +46,7 @@ export class ComponentRemoveCommand extends Command {
         component: this.component,
         value: this.value
       });
+      nextCommandCallback?.(entity);
     }
   }
 }

--- a/src/editor/lib/commands/EntityCloneCommand.js
+++ b/src/editor/lib/commands/EntityCloneCommand.js
@@ -16,21 +16,23 @@ export class EntityCloneCommand extends Command {
     this.entityId = null;
   }
 
-  execute() {
+  execute(nextCommandCallback) {
     const entityToClone = document.getElementById(this.entityIdToClone);
     if (entityToClone) {
       const clone = cloneEntityImpl(entityToClone, this.entityId);
       this.entityId = clone.id;
+      nextCommandCallback?.(clone);
       return clone;
     }
   }
 
-  undo() {
+  undo(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       entity.parentNode.removeChild(entity);
       Events.emit('entityremoved', entity);
       this.editor.selectEntity(document.getElementById(this.entityIdToClone));
+      nextCommandCallback?.(entity);
     }
   }
 }

--- a/src/editor/lib/commands/EntityCreateCommand.js
+++ b/src/editor/lib/commands/EntityCreateCommand.js
@@ -27,9 +27,17 @@ export class EntityCreateCommand extends Command {
       this.callback?.(entity);
       nextCommandCallback?.(entity);
     };
-    const parentEl =
-      this.definition.parentEl ??
-      document.querySelector(this.editor.config.defaultParent);
+    let parentEl;
+    if (this.definition.parentEl) {
+      if (typeof this.definition.parentEl === 'string') {
+        parentEl = document.getElementById(this.definition.parentEl);
+      } else {
+        parentEl = this.definition.parentEl;
+      }
+    }
+    if (!parentEl) {
+      parentEl = document.querySelector(this.editor.config.defaultParent);
+    }
     // If we undo and redo, use the previous id so next redo actions (for example entityupdate to move the position) works correctly
     if (this.entityId) {
       definition = { ...this.definition, id: this.entityId };

--- a/src/editor/lib/commands/EntityCreateCommand.js
+++ b/src/editor/lib/commands/EntityCreateCommand.js
@@ -2,20 +2,30 @@ import Events from '../Events';
 import { Command } from '../command.js';
 import { createEntity } from '../entity.js';
 
+/**
+ * @param editor Editor
+ * @param definition Entity definition
+ * @param callback Optional callback to call after the entity is created,
+ *                 get as argument the created entity.
+ * @constructor
+ */
 export class EntityCreateCommand extends Command {
-  constructor(editor, definition) {
+  constructor(editor, definition, callback = undefined) {
     super(editor);
 
     this.type = 'entitycreate';
     this.name = 'Create Entity';
     this.definition = definition;
+    this.callback = callback;
     this.entityId = null;
   }
 
-  execute() {
+  execute(nextCommandCallback) {
     let definition = this.definition;
     const callback = (entity) => {
       this.editor.selectEntity(entity);
+      this.callback?.(entity);
+      nextCommandCallback?.(entity);
     };
     const parentEl =
       this.definition.parentEl ??
@@ -30,12 +40,13 @@ export class EntityCreateCommand extends Command {
     return entity;
   }
 
-  undo() {
+  undo(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       entity.parentNode.removeChild(entity);
       Events.emit('entityremoved', entity);
       this.editor.selectEntity(null);
+      nextCommandCallback?.(entity);
     }
   }
 }

--- a/src/editor/lib/commands/EntityRemoveCommand.js
+++ b/src/editor/lib/commands/EntityRemoveCommand.js
@@ -16,7 +16,7 @@ export class EntityRemoveCommand extends Command {
     this.index = Array.from(this.parentEl.children).indexOf(entity);
   }
 
-  execute() {
+  execute(nextCommandCallback) {
     const closest = findClosestEntity(this.entity);
 
     // Keep a clone not attached to DOM for undo
@@ -31,9 +31,10 @@ export class EntityRemoveCommand extends Command {
     this.entity = clone;
 
     this.editor.selectEntity(closest);
+    nextCommandCallback?.(null);
   }
 
-  undo() {
+  undo(nextCommandCallback) {
     // Reinsert the entity at its original position using the stored index
     const referenceNode = this.parentEl.children[this.index] ?? null;
     this.parentEl.insertBefore(this.entity, referenceNode);
@@ -44,6 +45,7 @@ export class EntityRemoveCommand extends Command {
       () => {
         Events.emit('entitycreated', this.entity);
         this.editor.selectEntity(this.entity);
+        nextCommandCallback?.(this.entity);
       },
       { once: true }
     );

--- a/src/editor/lib/commands/EntityUpdateCommand.js
+++ b/src/editor/lib/commands/EntityUpdateCommand.js
@@ -87,7 +87,7 @@ export class EntityUpdateCommand extends Command {
     }
   }
 
-  execute() {
+  execute(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       if (this.editor.selectedEntity && this.editor.selectedEntity !== entity) {
@@ -119,10 +119,11 @@ export class EntityUpdateCommand extends Command {
       if (this.component === 'id') {
         this.entityId = this.newValue;
       }
+      nextCommandCallback?.(entity);
     }
   }
 
-  undo() {
+  undo(nextCommandCallback) {
     const entity = document.getElementById(this.entityId);
     if (entity) {
       if (this.editor.selectedEntity && this.editor.selectedEntity !== entity) {
@@ -149,6 +150,7 @@ export class EntityUpdateCommand extends Command {
       if (this.component === 'id') {
         this.entityId = this.oldValue;
       }
+      nextCommandCallback?.(entity);
     }
   }
 

--- a/src/editor/lib/commands/MultiCommand.js
+++ b/src/editor/lib/commands/MultiCommand.js
@@ -1,0 +1,50 @@
+import { Command } from '../command.js';
+import { commandsByType } from './index.js';
+
+/**
+ * @param editor Editor
+ * @param commands
+ * @param callback Optional callback to call after all commands are executed,
+ *                 get as argument the created entity or null if last command is entityremove.
+ * @constructor
+ */
+export class MultiCommand extends Command {
+  constructor(editor, commands, callback = undefined) {
+    super(editor);
+
+    this.type = 'multi';
+    this.name = 'Multiple changes';
+    this.updatable = false;
+    this.callback = callback;
+    this.commands = commands
+      .map((cmdTuple) => {
+        const Cmd = commandsByType.get(cmdTuple[0]);
+        if (!Cmd) {
+          console.error(`Command ${cmdTuple[0]} not found`);
+          return null;
+        }
+        return new Cmd(editor, cmdTuple[1], cmdTuple[2]);
+      })
+      .filter(Boolean);
+  }
+
+  execute() {
+    const run = this.commands
+      .toReversed()
+      .reduce((nextCommandCallback, command) => {
+        return (entityIgnored) => {
+          return command.execute(nextCommandCallback);
+        };
+      }, this.callback); // latest callback uses the entity as parameter
+    return run();
+  }
+
+  undo() {
+    const run = this.commands.reduce((nextCommandCallback, command) => {
+      return (entityIgnored) => {
+        return command.undo(nextCommandCallback);
+      };
+    }, this.callback); // latest callback uses the entity as parameter
+    return run();
+  }
+}

--- a/src/editor/lib/commands/index.js
+++ b/src/editor/lib/commands/index.js
@@ -4,6 +4,7 @@ import { EntityCloneCommand } from './EntityCloneCommand.js';
 import { EntityCreateCommand } from './EntityCreateCommand.js';
 import { EntityRemoveCommand } from './EntityRemoveCommand.js';
 import { EntityUpdateCommand } from './EntityUpdateCommand.js';
+import { MultiCommand } from './MultiCommand.js';
 
 export const commandsByType = new Map();
 commandsByType.set('componentadd', ComponentAddCommand);
@@ -12,3 +13,4 @@ commandsByType.set('entityclone', EntityCloneCommand);
 commandsByType.set('entitycreate', EntityCreateCommand);
 commandsByType.set('entityremove', EntityRemoveCommand);
 commandsByType.set('entityupdate', EntityUpdateCommand);
+commandsByType.set('multi', MultiCommand);


### PR DESCRIPTION
Usage:
```js
const commands: Commands = [
  ["entitycreate", {position: "0 0 0", components: {"gltf-model": "model.glb"}],
  ["entitycreate", {position: "1 0 0", components: {"gltf-model": "model.glb"}],
];
AFRAME.INSPECTOR.execute("multi", commands)
```

To create a parent with children in one go, passing parentEl the id of the parent:

```js
const parentEntityId = createUniqueId();
const definition = {
  id: parentEntityId,
  components: {
    position: "0 0 0",
    "gltf-model": "parent.glb",
  },
};
const commands: Commands = [];
commands.push(["entitycreate", definition]);
commands.push(["entitycreate", {parentEl: parentEntityId, components: {position: "0 1 0", "gltf-model": "child.glb"}]]);
const afterCreate = (entity: Entity | null) => {
  if (!entity) return; // actually not possible, but typescript doesn't know that
  textureSelectorForceUpdate();
};
AFRAME.INSPECTOR.execute("multi", commands, undefined, afterCreate);
```

Types:
```js
type ComponentAddCommand = [
  "componentadd",
  {
    entity: Entity;
    component: string;
    value: string;
  },
];

type ComponentRemoveCommand = [
  "componentremove",
  {
    entity: Entity;
    component: string;
  },
];

type EntityCreateCommand = ["entitycreate", EntityObject] | ["entitycreate", EntityObject, (el: Entity) => void];

type EntityRemoveCommand = ["entityremove", Entity];

type EntityUpdateCommand = [
  "entityupdate",
  {
    entity: Entity;
    component: string;
    property?: string | undefined;
    value: string;
  },
];

type Commands = (
  | ComponentAddCommand
  | ComponentRemoveCommand
  | EntityCreateCommand
  | EntityRemoveCommand
  | EntityUpdateCommand
)[];
```