### PR TITLE
Entity Color Options

### DIFF
--- a/src/components/custom-colors.js
+++ b/src/components/custom-colors.js
@@ -1,0 +1,7 @@
+/* global AFRAME */
+
+AFRAME.registerComponent('custom-colors', {
+  schema: {
+    type: 'string'
+  }
+});

--- a/src/components/custom-colors.js
+++ b/src/components/custom-colors.js
@@ -1,7 +1,47 @@
 /* global AFRAME */
 
+import { getMaterials } from '../editor/components/components/CustomizeColorWidget';
+
 AFRAME.registerComponent('custom-colors', {
   schema: {
     type: 'string'
+  },
+  update() {
+    const materials = getMaterials(this.el.object3D);
+    const customColorMapping = {};
+    this.data
+      .replaceAll(' ', '')
+      .split(';')
+      .forEach((entry) => {
+        // Skip unnamed
+        if (entry === '') return;
+        const [mat, color] = entry.split(':');
+        customColorMapping[mat] = color;
+      });
+
+    materials.forEach((material) => {
+      if (customColorMapping[material.name] !== undefined) {
+        material.color.set(customColorMapping[material.name]);
+      } else {
+        // Reset to default, no tint
+        material.color.set(material.userData.origColor);
+      }
+    });
+  },
+  init() {
+    if (this.el.getObject3D('mesh')) {
+      this.update();
+    } else {
+      this.el.addEventListener('model-loaded', () => {
+        this.update();
+      });
+    }
+  },
+  remove() {
+    const materials = getMaterials(this.el.object3D);
+    materials.forEach((material) => {
+      // Reset to default, no tint
+      material.color.set(material.userData.origColor);
+    });
   }
 });

--- a/src/editor/components/components/CommonComponents.js
+++ b/src/editor/components/components/CommonComponents.js
@@ -69,9 +69,7 @@ export default class CommonComponents extends React.Component {
         />
       );
     });
-
     rows.push(<CustomizeColorWidget entity={entity} key={entity.id} />);
-
     return rows;
   }
 

--- a/src/editor/components/components/CommonComponents.js
+++ b/src/editor/components/components/CommonComponents.js
@@ -6,6 +6,7 @@ import { getEntityClipboardRepresentation } from '../../lib/entity';
 import Events from '../../lib/Events';
 import Clipboard from 'clipboard';
 import { saveBlob } from '../../lib/utils';
+import CustomizeColorWidget from './CustomizeColorWidget';
 
 export default class CommonComponents extends React.Component {
   static propTypes = {
@@ -46,7 +47,7 @@ export default class CommonComponents extends React.Component {
   renderCommonAttributes() {
     const entity = this.props.entity;
     // return ['position', 'rotation', 'scale', 'visible']
-    return ['position', 'rotation', 'scale'].map((componentName) => {
+    const rows = ['position', 'rotation', 'scale'].map((componentName) => {
       const schema = AFRAME.components[componentName].schema;
       var data = entity.object3D[componentName];
       if (componentName === 'rotation') {
@@ -68,6 +69,12 @@ export default class CommonComponents extends React.Component {
         />
       );
     });
+
+    console.log(this.props.entity);
+
+    rows.push(<CustomizeColorWidget entity={entity} key={'customizeColor'} />);
+
+    return rows;
   }
 
   exportToGLTF() {

--- a/src/editor/components/components/CommonComponents.js
+++ b/src/editor/components/components/CommonComponents.js
@@ -69,7 +69,11 @@ export default class CommonComponents extends React.Component {
         />
       );
     });
-    rows.push(<CustomizeColorWidget entity={entity} key={entity.id} />);
+
+    // Custom colors are only applicable to entities, not things like intersections or groups.
+    if (entity.hasAttribute('mixin')) {
+      rows.push(<CustomizeColorWidget entity={entity} key={entity.id} />);
+    }
     return rows;
   }
 

--- a/src/editor/components/components/CommonComponents.js
+++ b/src/editor/components/components/CommonComponents.js
@@ -70,9 +70,7 @@ export default class CommonComponents extends React.Component {
       );
     });
 
-    console.log(this.props.entity);
-
-    rows.push(<CustomizeColorWidget entity={entity} key={'customizeColor'} />);
+    rows.push(<CustomizeColorWidget entity={entity} key={entity.id} />);
 
     return rows;
   }

--- a/src/editor/components/components/CustomizeColorWidget/index.js
+++ b/src/editor/components/components/CustomizeColorWidget/index.js
@@ -1,0 +1,137 @@
+import { useMemo, useState } from 'react';
+import { Button } from '../Button';
+import BooleanWidget from '../../widgets/BooleanWidget';
+import ColorWidget from '../../widgets/ColorWidget';
+import SelectWidget from '../../widgets/SelectWidget';
+
+export const getMaterials = (object3D) => {
+  const materials = new Set();
+  object3D.traverse((c) => c.material && materials.add(c.material));
+  return Array.from(materials);
+};
+
+const CustomizeColorContent = ({ entity }) => {
+  const customColorData = entity.getAttribute('custom-colors') ?? '';
+  // Convert the string data of `materialName:color;...` to a mapping of color overrides: { [materialName]: color }
+  const baseColorMapping = useMemo(() => {
+    if (!customColorData) return {};
+    const mapping = {};
+    customColorData
+      .replaceAll(' ', '')
+      .split(';')
+      .forEach((entry) => {
+        // Skip unnamed
+        if (entry === '') return;
+        const [mat, color] = entry.split(':');
+        mapping[mat] = color;
+      });
+    return mapping;
+  }, [customColorData]);
+  const [colorMapping, setColorMapping] = useState(baseColorMapping);
+
+  // Retrieve materials from the entity
+  const materials = useMemo(() => getMaterials(entity.object3D), [entity]);
+  const [selectedMaterial, setSelectedMaterial] = useState();
+
+  const setMaterialColor = (material, color) => {
+    const newColorMapping = { ...colorMapping, [material]: color };
+    setColorMapping(newColorMapping);
+
+    const newColorsString = Object.entries(newColorMapping)
+      .map(([mat, color]) => `${mat}:${color}`)
+      .join(';');
+
+    AFRAME.INSPECTOR.execute('entityupdate', {
+      entity: entity,
+      component: 'custom-colors',
+      value: newColorsString
+    });
+  };
+
+  const handleToggleOverride = (_, v) => {
+    if (v) {
+      setMaterialColor(selectedMaterial, '#FF0000');
+    } else {
+      setMaterialColor(selectedMaterial, undefined);
+    }
+  };
+
+  const handleColorChange = (_, v) => {
+    setMaterialColor(selectedMaterial, v);
+  };
+
+  return (
+    <div className="details">
+      <div className="propertyRow">
+        <label className="text">Material</label>
+        <SelectWidget
+          name="material"
+          value={selectedMaterial}
+          onChange={(_, v) => {
+            setSelectedMaterial(v);
+          }}
+          options={materials.map((m) => m.name)}
+        />
+      </div>
+      {selectedMaterial && (
+        <>
+          <div className="propertyRow">
+            <label className="text">Override default</label>
+            <BooleanWidget
+              componentname="override"
+              name="override"
+              onChange={handleToggleOverride}
+              value={colorMapping[selectedMaterial] !== undefined}
+            />
+          </div>
+          <div className="propertyRow">
+            <label className="text">Color</label>
+            <ColorWidget
+              componentname="color"
+              name="color"
+              value={colorMapping[selectedMaterial]}
+              onChange={handleColorChange}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const CustomizeColorWrapper = ({ entity }) => {
+  const [hasCustomColorComponent, setHasCustomColorComponent] = useState(
+    Boolean(entity.getAttribute('custom-colors'))
+  );
+
+  const toggleCustomColors = () => {
+    if (!hasCustomColorComponent) {
+      AFRAME.INSPECTOR.execute('componentadd', {
+        entity,
+        component: 'custom-colors',
+        value: ''
+      });
+      setHasCustomColorComponent(true);
+      return;
+    }
+    AFRAME.INSPECTOR.execute('componentremove', {
+      entity,
+      component: 'custom-colors'
+    });
+    setHasCustomColorComponent(false);
+  };
+
+  return (
+    <div className="details">
+      <div className="propertyRow">
+        <label className="text">Custom Colors</label>
+        <Button variant="toolbtn" onClick={toggleCustomColors}>
+          {hasCustomColorComponent ? 'Remove' : 'Add'} Custom Colors
+        </Button>
+      </div>
+      {hasCustomColorComponent && <CustomizeColorContent entity={entity} />}
+    </div>
+  );
+};
+
+export default CustomizeColorWrapper;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ require('./components/svg-extruder.js');
 require('./lib/animation-mixer.js');
 require('./lib/aframe-gaussian-splatting-component.min.js');
 require('./assets.js');
+require('./components/custom-colors.js');
 require('./components/notify.js');
 require('./components/create-from-json');
 require('./components/screentock.js');


### PR DESCRIPTION
[Revisal of #992]

Following the discussion, I implemented a widget to customize the colors of materials in each entity. 
<img width="786" alt="Screenshot 2025-01-01 at 7 11 17 PM" src="https://github.com/user-attachments/assets/140e190e-e35e-4d67-9443-3d1cbe06733d" />
> This PR depends on https://github.com/3DStreet/3dstreet-assets-dist/pull/37 for the new vertex colors in the specific entities in this screenshot. Otherwise, entities will have the material named `atlas_colors` as the only material, which is the UV map.

There is a button to add custom colors for an entity. 
<img width="390" alt="Screenshot 2025-01-01 at 9 47 19 PM" src="https://github.com/user-attachments/assets/d4055e9d-c78b-46e0-8814-26792471eb6b" />

Once added, the user can pick which materials to modify. Multiple materials can be modified at the same time.
<img width="1208" alt="Screenshot 2025-01-01 at 6 08 43 PM" src="https://github.com/user-attachments/assets/e18170fb-bd9d-4c53-a4ff-c186d55f6503" />
<img width="363" alt="Screenshot 2025-01-01 at 9 47 59 PM" src="https://github.com/user-attachments/assets/4aed556d-df19-40da-8041-c4821e1682c3" />

The data is serialized in the format: `<material_name>:<overriden_color>;<material_name>:<overriden_color>;...`. The component is not added by default - only when the customize button is clicked will it be created.