### PR TITLE
Fix initial camera jump

### DIFF
--- a/src/editor/lib/EditorControls.js
+++ b/src/editor/lib/EditorControls.js
@@ -394,8 +394,9 @@ THREE.EditorControls = function (_object, domElement) {
       }
       object.updateProjectionMatrix();
     } else {
-      object.position.set(0, 15, 30);
-      object.lookAt(new THREE.Vector3(0, 1.6, -1));
+      center.set(0, 1.6, 0); // same as in viewport.js
+      object.position.set(0, 15, 30); // same as in camera.js
+      object.lookAt(center);
       object.updateMatrixWorld();
     }
 

--- a/src/editor/lib/cameras.js
+++ b/src/editor/lib/cameras.js
@@ -39,7 +39,8 @@ export function initCameras(inspector) {
   perspectiveCamera.far = 20000; // Changed from 10000 to 20000
   perspectiveCamera.near = 0.01;
   perspectiveCamera.position.set(0, 15, 30);
-  perspectiveCamera.lookAt(new THREE.Vector3(0, 1.6, -1));
+  const center = new THREE.Vector3(0, 1.6, 0); // same as in viewport.js
+  perspectiveCamera.lookAt(center);
   perspectiveCamera.updateMatrixWorld();
   sceneEl.object3D.add(perspectiveCamera);
   sceneEl.camera = perspectiveCamera;


### PR DESCRIPTION
This fixes point 3 of #1060

There were two issues here. 
The initial lookAt in camera.js didn't match the set center in viewport.js
https://github.com/3DStreet/3dstreet/blob/9b330237c295669ad919e9dbdb72c2f9f1ec7c5a/src/editor/lib/viewport.js#L210
And the second issue was that center wasn't reset when loading another scene, you can also reproduce just by clicking on the compass, it also executes the same resetZoom fonction.