### PR TITLE
wip remove length from `street-generated-*` components

### DIFF
--- a/src/components/street-generated-pedestrians.js
+++ b/src/components/street-generated-pedestrians.js
@@ -4,17 +4,10 @@ import { createRNG } from '../lib/rng';
 AFRAME.registerComponent('street-generated-pedestrians', {
   multiple: true,
   schema: {
-    segmentWidth: {
-      type: 'number',
-      default: 3
-    },
     density: {
       type: 'string',
       default: 'normal',
       oneOf: ['empty', 'sparse', 'normal', 'dense']
-    },
-    length: {
-      type: 'number'
     },
     direction: {
       type: 'string',
@@ -39,6 +32,8 @@ AFRAME.registerComponent('street-generated-pedestrians', {
       normal: 0.125,
       dense: 0.25
     };
+    this.length = this.getSegmentLength();
+    this.segmentWidth = this.getSegmentWidth();
   },
 
   remove: function () {
@@ -77,13 +72,24 @@ AFRAME.registerComponent('street-generated-pedestrians', {
     }
     AFRAME.INSPECTOR.execute('multi', commands);
   },
-
+  getSegmentLength() {
+    if (this.el.hasAttribute('street-segment')) {
+      return this.el.getAttribute('street-segment')?.length;
+    }
+  },
+  getSegmentWidth() {
+    if (this.el.hasAttribute('street-segment')) {
+      return this.el.getAttribute('street-segment')?.width;
+    }
+  },
   update: function (oldData) {
     const data = this.data;
 
-    // if length is not set, then derive length from the segment
-    if (!data.length) {
-      data.length = this.el.getAttribute('street-segment').length;
+    if (this.length !== this.getSegmentLength()) {
+      this.length = this.getSegmentLength() || 0;
+    }
+    if (this.segmentWidth !== this.getSegmentWidth()) {
+      this.segmentWidth = this.getSegmentWidth() || 0;
     }
 
     // Handle seed initialization
@@ -101,19 +107,20 @@ AFRAME.registerComponent('street-generated-pedestrians', {
 
     // Calculate x position range based on segment width
     const xRange = {
-      min: -(0.37 * data.segmentWidth),
-      max: 0.37 * data.segmentWidth
+      min: -(0.37 * this.segmentWidth),
+      max: 0.37 * this.segmentWidth
     };
 
     // Calculate total number of pedestrians based on density and street length
     const totalPedestrians = Math.floor(
-      this.densityFactors[data.density] * data.length
+      this.densityFactors[data.density] * this.length
     );
 
     // Get Z positions using seeded randomization
+    if (!this.length) return;
     const zPositions = this.getZPositions(
-      -data.length / 2,
-      data.length / 2,
+      -this.length / 2,
+      this.length / 2,
       1.5
     );
 

--- a/src/components/street-generated-rail.js
+++ b/src/components/street-generated-rail.js
@@ -3,10 +3,6 @@
 AFRAME.registerComponent('street-generated-rail', {
   multiple: true,
   schema: {
-    length: {
-      // length in meters of linear path to fill with rail
-      type: 'number'
-    },
     gauge: {
       // spacing in millimeters between rails
       type: 'int',
@@ -16,15 +12,20 @@ AFRAME.registerComponent('street-generated-rail', {
   },
   init: function () {
     this.createdEntities = [];
+    this.length = this.getSegmentLength();
   },
   remove: function () {
     this.createdEntities.forEach((entity) => entity.remove());
     this.createdEntities.length = 0; // Clear the array
   },
+  getSegmentLength() {
+    if (this.el.hasAttribute('street-segment')) {
+      return this.el.getAttribute('street-segment').length;
+    }
+  },
   update: function (oldData) {
-    // if length is not set, then derive length from the segment
-    if (!this.data.length) {
-      this.data.length = this.el.getAttribute('street-segment').length;
+    if (this.length !== this.getSegmentLength()) {
+      this.length = this.getSegmentLength();
     }
 
     // Clean up old entities

--- a/src/components/street-generated-striping.js
+++ b/src/components/street-generated-striping.js
@@ -20,19 +20,12 @@ AFRAME.registerComponent('street-generated-striping', {
         'solid-dashed-yellow-mirror'
       ]
     },
-    segmentWidth: {
-      type: 'number'
-    },
     side: {
       default: 'left',
       oneOf: ['left', 'right']
     },
     facing: {
       default: 0, // this is a Y Rotation value in degrees -- UI could offer a dropdown with options for 0, 90, 180, 270
-      type: 'number'
-    },
-    length: {
-      // length in meters of linear path to fill with clones
       type: 'number'
     },
     positionY: {
@@ -43,12 +36,32 @@ AFRAME.registerComponent('street-generated-striping', {
   },
   init: function () {
     this.createdEntities = [];
+    this.length = this.getSegmentLength();
+    this.segmentWidth = this.getSegmentWidth();
   },
   remove: function () {
     this.createdEntities.forEach((entity) => entity.remove());
     this.createdEntities.length = 0; // Clear the array
   },
+  getSegmentLength() {
+    if (this.el.hasAttribute('street-segment')) {
+      return this.el.getAttribute('street-segment').length;
+    }
+  },
+  getSegmentWidth() {
+    if (this.el.hasAttribute('street-segment')) {
+      return this.el.getAttribute('street-segment').width;
+    }
+  },
   update: function (oldData) {
+    // update this.length if segment length is modified
+    if (this.length !== this.getSegmentLength()) {
+      this.length = this.getSegmentLength();
+    }
+    if (this.segmentWidth !== this.getSegmentWidth()) {
+      this.segmentWidth = this.getSegmentWidth();
+    }
+
     const data = this.data;
 
     // Clean up old entities
@@ -59,8 +72,8 @@ AFRAME.registerComponent('street-generated-striping', {
     }
     const clone = document.createElement('a-entity');
     const { stripingTextureId, repeatY, color, stripingWidth } =
-      this.calculateStripingMaterial(data.striping, data.length);
-    const positionX = ((data.side === 'left' ? -1 : 1) * data.segmentWidth) / 2;
+      this.calculateStripingMaterial(data.striping, this.length);
+    const positionX = ((data.side === 'left' ? -1 : 1) * this.segmentWidth) / 2;
     clone.setAttribute('position', {
       x: positionX,
       y: data.positionY,
@@ -77,7 +90,7 @@ AFRAME.registerComponent('street-generated-striping', {
     );
     clone.setAttribute(
       'geometry',
-      `primitive: plane; width: ${stripingWidth}; height: ${data.length}; skipCache: true;`
+      `primitive: plane; width: ${stripingWidth}; height: ${this.length}; skipCache: true;`
     );
     clone.classList.add('autocreated');
     // clone.setAttribute('data-ignore-raycaster', ''); // i still like clicking to zoom to individual clones, but instead this should show the generated-fixed clone settings

--- a/src/components/street-segment.js
+++ b/src/components/street-segment.js
@@ -216,7 +216,6 @@ AFRAME.registerComponent('street-segment', {
         this.el.setAttribute(`street-generated-clones__${index + 1}`, {
           mode: clone.mode,
           modelsArray: clone.modelsArray,
-          length: this.data.length,
           spacing: clone.spacing,
           direction: this.data.direction,
           count: clone.count
@@ -228,7 +227,6 @@ AFRAME.registerComponent('street-segment', {
       componentsToGenerate.stencil.forEach((clone, index) => {
         this.el.setAttribute(`street-generated-stencil__${index + 1}`, {
           modelsArray: clone.modelsArray,
-          length: this.data.length,
           spacing: clone.spacing,
           direction: clone.direction ?? this.data.direction,
           padding: clone.padding,
@@ -242,7 +240,6 @@ AFRAME.registerComponent('street-segment', {
         this.el.setAttribute(`street-generated-pedestrians__${index + 1}`, {
           segmentWidth: this.data.width,
           density: pedestrian.density,
-          length: this.data.length,
           direction: this.data.direction
         });
       });
@@ -253,7 +250,6 @@ AFRAME.registerComponent('street-segment', {
         this.el.setAttribute(`street-generated-striping__${index + 1}`, {
           striping: stripe.striping,
           segmentWidth: this.data.width,
-          length: this.data.length,
           positionY: stripe.positionY ?? 0.05, // Default to 0.05 if not specified
           side: stripe.side ?? 'left', // Default to left if not specified
           facing: stripe.facing ?? 0 // Default to 0 if not specified
@@ -264,8 +260,7 @@ AFRAME.registerComponent('street-segment', {
     if (componentsToGenerate?.rail?.length > 0) {
       componentsToGenerate.rail.forEach((rail, index) => {
         this.el.setAttribute(`street-generated-rail__${index + 1}`, {
-          gauge: rail.gauge,
-          length: this.data.length
+          gauge: rail.gauge
         });
       });
     }
@@ -314,6 +309,12 @@ AFRAME.registerComponent('street-segment', {
       for (const componentName of this.generatedComponents) {
         this.el.setAttribute(componentName, 'length', this.data.length);
       }
+      // Emit length change event
+      console.log('segment length changed');
+      this.el.emit('segment-length-changed', {
+        oldLength: oldData.length,
+        newLength: this.data.length
+      });
     }
     this.clearMesh();
     this.height = this.calculateHeight(data.level);


### PR DESCRIPTION
why:
- length shouldn't be stored separately in components; it should always come from street-segment
- component should update if street-segment length/width updated

issues to resolve:
- when loading from a scene, the length isn't available until a bit after the component is initialized -- how to handle (answer: handle 0 / undefined length value without error, update to proper value when loaded)
- calcs depending on length and width should update in a uniform manner when street-segment length or width is updated. If street-segment value is changed, then to inform the children of a new length and width value through an event
- the children should listen for the event and update as needed