### PR TITLE
Fix warning about using SelectWidget with a number as value

### DIFF
--- a/src/editor/components/widgets/SelectWidget.js
+++ b/src/editor/components/widgets/SelectWidget.js
@@ -8,7 +8,11 @@ export default class SelectWidget extends React.Component {
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     options: PropTypes.array.isRequired,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+      PropTypes.array
+    ]).isRequired
   };
 
   static defaultProps = {


### PR DESCRIPTION
Fix warning about using SelectWidget with a number as value, that works fine.