### PR TITLE
Check explicitly for canvas element instead of doing typeof string

### DIFF
--- a/src/editor/components/widgets/TextureWidget.js
+++ b/src/editor/components/widgets/TextureWidget.js
@@ -139,21 +139,22 @@ export default class TextureWidget extends React.Component {
     var isAssetHash = value[0] === '#';
     var isAssetImg = value instanceof HTMLImageElement;
     var isAssetVideo = value instanceof HTMLVideoElement;
-    var isAssetImgOrVideo = isAssetImg || isAssetVideo;
+    var isAssetCanvas = value instanceof HTMLCanvasElement;
+    var isAssetElement = isAssetImg || isAssetVideo || isAssetCanvas;
 
-    if (isAssetImgOrVideo) {
+    if (isAssetCanvas) {
+      url = null;
+    } else if (isAssetImg || isAssetVideo) {
       url = value.src;
     } else if (isAssetHash) {
       url = getUrlFromId(value);
     } else {
-      if (typeof value === 'string') {
-        url = AFRAME.utils.srcLoader.parseUrl(value);
-      }
+      url = AFRAME.utils.srcLoader.parseUrl(value);
     }
 
     var texture = getTextureFromSrc(value);
     var valueType = null;
-    valueType = isAssetImgOrVideo || isAssetHash ? 'asset' : 'url';
+    valueType = isAssetElement || isAssetHash ? 'asset' : 'url';
     if (!isAssetVideo && texture) {
       texture.then(paintPreview);
     } else if (!isAssetVideo && url) {
@@ -172,7 +173,7 @@ export default class TextureWidget extends React.Component {
     }
 
     this.setState({
-      value: isAssetImgOrVideo ? '#' + value.id : value,
+      value: isAssetElement ? '#' + value.id : value,
       valueType: valueType,
       url: url
     });
@@ -219,7 +220,10 @@ export default class TextureWidget extends React.Component {
     let hint = '';
     if (this.state.value) {
       if (this.state.valueType === 'asset') {
-        hint = 'Asset ID: ' + this.state.value + '\nURL: ' + this.state.url;
+        hint = 'Asset ID: ' + this.state.value;
+        if (this.state.url !== null) {
+          hint += '\nURL: ' + this.state.url;
+        }
       } else {
         hint = 'URL: ' + this.state.value;
       }


### PR DESCRIPTION
Context: https://github.com/aframevr/aframe-inspector/pull/806
You already had a fix with https://github.com/3DStreet/3dstreet-editor/commit/e5ee022e7a5ab2625f3c68d9be6a97023ac4e159
if your issue was also with a canvas texture, not sure if you remember...
Here the fix is different and is also removing "URL: undefined" from the tooltip.

Do you have a case where you have a canvas texture for material src?