### PR TITLE
Use error boundary for better react error handling

### DIFF
--- a/src/editor/components/ErrorBoundary.js
+++ b/src/editor/components/ErrorBoundary.js
@@ -1,0 +1,193 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * ErrorBoundary component for 3DStreet that catches React errors while allowing
+ * the underlying A-Frame/Three.js canvas to continue running.
+ */
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      isDetailsExpanded: false
+    };
+    this.copyErrorDetailsRef = React.createRef();
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Log the error to the console
+    console.error('Error caught by ErrorBoundary:', error, errorInfo);
+
+    // Update state with error details
+    this.setState({ errorInfo });
+
+    // Call the onError callback if provided
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    }
+  }
+
+  toggleDetails = () => {
+    this.setState((prevState) => ({
+      isDetailsExpanded: !prevState.isDetailsExpanded
+    }));
+  };
+
+  copyErrorDetails = () => {
+    const { error, errorInfo } = this.state;
+    const errorDetails = `
+Error: ${error?.toString() || 'Unknown error'}
+
+Component Stack:
+${errorInfo?.componentStack || 'No component stack available'}
+
+URL: ${window.location.href}
+User Agent: ${navigator.userAgent}
+Date/Time: ${new Date().toISOString()}
+    `.trim();
+
+    try {
+      navigator.clipboard.writeText(errorDetails).then(
+        () => {
+          // Show a temporary success message
+          const copyButton = this.copyErrorDetailsRef.current;
+          if (copyButton) {
+            const originalText = copyButton.textContent;
+            copyButton.textContent = 'Copied!';
+            setTimeout(() => {
+              copyButton.textContent = originalText;
+            }, 2000);
+          }
+        },
+        (err) => {
+          console.error('Failed to copy error details:', err);
+        }
+      );
+    } catch (err) {
+      console.error('Copy to clipboard not supported:', err);
+
+      // Fallback for browsers that don't support clipboard API
+      const textarea = document.createElement('textarea');
+      textarea.value = errorDetails;
+      textarea.style.position = 'fixed';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+
+      try {
+        document.execCommand('copy');
+        const copyButton = this.copyErrorDetailsRef.current;
+        if (copyButton) {
+          const originalText = copyButton.textContent;
+          copyButton.textContent = 'Copied!';
+          setTimeout(() => {
+            copyButton.textContent = originalText;
+          }, 2000);
+        }
+      } catch (e) {
+        console.error('Fallback copy failed:', e);
+      }
+
+      document.body.removeChild(textarea);
+    }
+  };
+
+  handleRecovery = () => {
+    // Reset the error state
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      isDetailsExpanded: false
+    });
+
+    // Call the onRecover callback if provided
+    if (this.props.onRecover) {
+      this.props.onRecover();
+    }
+  };
+
+  render() {
+    const { hasError, error, errorInfo, isDetailsExpanded } = this.state;
+    const { children, fallback } = this.props;
+
+    if (!hasError) {
+      return children;
+    }
+
+    // If a custom fallback is provided, use it
+    if (fallback) {
+      return fallback(error, errorInfo, this.handleRecovery);
+    }
+
+    // Default error UI
+    return (
+      <div className="error-boundary-overlay">
+        <div className="error-boundary-container">
+          <div className="error-boundary-header">
+            <h2>Something went wrong</h2>
+            <p>
+              The 3DStreet editor encountered an error, but the 3D view is still
+              running.
+            </p>
+          </div>
+
+          <div className="error-boundary-message">
+            <p>{error?.toString() || 'An unexpected error occurred'}</p>
+          </div>
+
+          <div className="error-boundary-details">
+            <button
+              className="error-boundary-toggle-details"
+              onClick={this.toggleDetails}
+            >
+              {isDetailsExpanded ? 'Hide Details' : 'Show Details'}
+            </button>
+
+            {isDetailsExpanded && (
+              <div className="error-boundary-stack">
+                <pre>
+                  {errorInfo?.componentStack || 'No stack trace available'}
+                </pre>
+              </div>
+            )}
+          </div>
+
+          <div className="error-boundary-actions">
+            <button
+              className="error-boundary-copy-button"
+              onClick={this.copyErrorDetails}
+              ref={this.copyErrorDetailsRef}
+            >
+              Copy Error Details
+            </button>
+
+            <button
+              className="error-boundary-recover-button"
+              onClick={this.handleRecovery}
+            >
+              Try to Recover
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  onError: PropTypes.func,
+  onRecover: PropTypes.func,
+  fallback: PropTypes.func
+};
+
+export default ErrorBoundary;

--- a/src/editor/components/ErrorBoundary.js
+++ b/src/editor/components/ErrorBoundary.js
@@ -135,7 +135,7 @@ Date/Time: ${new Date().toISOString()}
           <div className="error-boundary-header">
             <h2>Something went wrong</h2>
             <p>
-              The 3DStreet editor encountered an error, but the 3D view is still
+              3DStreet Editor encountered an error, but the 3D view is still
               running.
             </p>
           </div>

--- a/src/editor/components/ErrorBoundary.js
+++ b/src/editor/components/ErrorBoundary.js
@@ -73,30 +73,6 @@ Date/Time: ${new Date().toISOString()}
       );
     } catch (err) {
       console.error('Copy to clipboard not supported:', err);
-
-      // Fallback for browsers that don't support clipboard API
-      const textarea = document.createElement('textarea');
-      textarea.value = errorDetails;
-      textarea.style.position = 'fixed';
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
-
-      try {
-        document.execCommand('copy');
-        const copyButton = this.copyErrorDetailsRef.current;
-        if (copyButton) {
-          const originalText = copyButton.textContent;
-          copyButton.textContent = 'Copied!';
-          setTimeout(() => {
-            copyButton.textContent = originalText;
-          }, 2000);
-        }
-      } catch (e) {
-        console.error('Fallback copy failed:', e);
-      }
-
-      document.body.removeChild(textarea);
     }
   };
 

--- a/src/editor/components/MainWrapper.js
+++ b/src/editor/components/MainWrapper.js
@@ -1,7 +1,35 @@
 import Main from './Main';
+import ErrorBoundary from './ErrorBoundary';
+import { useState, useCallback } from 'react';
 
 const MainWrapper = (props) => {
-  return <Main {...props} />;
+  const [key, setKey] = useState(0);
+
+  // This function will be passed to the ErrorBoundary to reset the application state
+  const handleRecover = useCallback(() => {
+    // Reset the key to force a re-render of the Main component
+    setKey((prevKey) => prevKey + 1);
+
+    // You can add additional recovery logic here if needed
+    // For example, clearing specific state in your application
+    console.log('Attempting to recover from error...');
+  }, []);
+
+  // This function will be called when an error is caught
+  const handleError = useCallback((error, errorInfo) => {
+    // Log the error to your preferred error tracking service
+    console.error('Error caught in ErrorBoundary:', error);
+    console.error('Component stack:', errorInfo?.componentStack);
+
+    // You can add additional error handling logic here
+    // For example, sending the error to a monitoring service
+  }, []);
+
+  return (
+    <ErrorBoundary onRecover={handleRecover} onError={handleError}>
+      <Main key={key} {...props} />
+    </ErrorBoundary>
+  );
 };
 
 export default MainWrapper;

--- a/src/editor/style/error-boundary.scss
+++ b/src/editor/style/error-boundary.scss
@@ -1,0 +1,104 @@
+// Error Boundary styles for 3DStreet
+.error-boundary-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: all;
+}
+
+.error-boundary-container {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  width: 90%;
+  max-width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 24px;
+  color: #333;
+}
+
+.error-boundary-header {
+  h2 {
+    margin-top: 0;
+    color: #e53e3e;
+    font-size: 1.5rem;
+  }
+  p {
+    margin-bottom: 16px;
+  }
+}
+
+.error-boundary-message {
+  margin: 16px 0;
+  padding: 12px;
+  background-color: #f8f8f8;
+  border-left: 4px solid #e53e3e;
+  font-family: monospace;
+  word-break: break-word;
+}
+
+.error-boundary-toggle-details {
+  background: none;
+  border: none;
+  color: #4299e1;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.9rem;
+  text-decoration: underline;
+}
+
+.error-boundary-stack {
+  margin-top: 12px;
+  padding: 12px;
+  background-color: #f8f8f8;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.error-boundary-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 24px;
+}
+
+.error-boundary-copy-button,
+.error-boundary-recover-button {
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.error-boundary-copy-button {
+  background-color: #f8f8f8;
+  border: 1px solid #ddd;
+  color: #333;
+
+  &:hover {
+    background-color: #eaeaea;
+  }
+}
+
+.error-boundary-recover-button {
+  background-color: #4299e1;
+  border: none;
+  color: white;
+
+  &:hover {
+    background-color: #3182ce;
+  }
+}

--- a/src/editor/style/index.scss
+++ b/src/editor/style/index.scss
@@ -1,6 +1,7 @@
 @use './variables.scss';
 @import '../normalize.css';
 @import './chat-panel.scss';
+@import './error-boundary.scss';
 
 body.aframe-inspector-opened,
 .toggle-edit {


### PR DESCRIPTION
Power users sometimes manage to get in a state where all of the Editor UI will disappear which is likely a fatal react error that unmounts components. It is difficult to diagnose and users are not familiar with how to open and capture contents of javascript console. Therefore this is an attempt to use error boundaries to display a UI when there is a fatal error so that the user can choose to report the issue with enough info for us to debug in the future.

This PR is mostly from Claude. I'm not sure if it would actually catch anything, I tried to find a "real error" but all I was able to do was  having Claude also make me a react component that triggers the error to confirm the ui is ok. :/