### PR TITLE
Call pause on the created entity

### DIFF
--- a/src/editor/lib/commands/EntityCreateCommand.js
+++ b/src/editor/lib/commands/EntityCreateCommand.js
@@ -36,6 +36,7 @@ export class EntityCreateCommand extends Command {
   execute(nextCommandCallback) {
     let definition = this.definition;
     const callback = (entity) => {
+      entity.pause();
       this.editor.selectEntity(entity);
       this.callback?.(entity);
       nextCommandCallback?.(entity);

--- a/src/editor/lib/commands/EntityRemoveCommand.js
+++ b/src/editor/lib/commands/EntityRemoveCommand.js
@@ -43,6 +43,7 @@ export class EntityRemoveCommand extends Command {
     this.entity.addEventListener(
       'loaded',
       () => {
+        this.entity.pause();
         Events.emit('entitycreated', this.entity);
         this.editor.selectEntity(this.entity);
         nextCommandCallback?.(this.entity);


### PR DESCRIPTION
Call `pause()` on the created entity, important when parent is the scene because `play()` has been called because of `scene.isPlaying = true` hack.
We already did it for the entityclone command but not for entitycreate and the undo entityremove.

Backport of https://github.com/c-frame/aframe-editor/pull/40
but it's not an issue on 3dstreet actually because all created entities are in the street-container entity, so not the scene where we have the issue of the created entity playing.