### PR TITLE
mvp barely working snapshot feature

### DIFF
--- a/src/editor/api/snapshot.js
+++ b/src/editor/api/snapshot.js
@@ -1,0 +1,246 @@
+import { doc, getDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { v4 as uuidv4 } from 'uuid';
+import { db, storage } from '../services/firebase';
+import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
+import { getCurrentCameraState } from '../lib/cameraUtils';
+import posthog from 'posthog-js';
+
+/**
+ * Create and upload a snapshot with camera state
+ * @param {string} sceneId - The scene ID
+ * @param {boolean} setAsDefault - Whether to set this as the default snapshot
+ * @param {string} label - Optional label for the snapshot
+ * @returns {Object} The created snapshot object
+ */
+export async function createSceneSnapshot(
+  sceneId,
+  setAsDefault = false,
+  label = null
+) {
+  try {
+    const snapshotId = uuidv4();
+    const cameraState = getCurrentCameraState();
+
+    if (!cameraState) {
+      throw new Error('Failed to capture camera state');
+    }
+
+    // Get the screenshot element
+    const screentockImgElement = document.getElementById(
+      'screentock-destination'
+    );
+    if (!screentockImgElement || !screentockImgElement.src) {
+      throw new Error(
+        'No screenshot available. Please generate a preview first.'
+      );
+    }
+
+    // Upload low-res thumbnail (320x240)
+    const lowResUrl = await uploadSnapshotImage(
+      sceneId,
+      snapshotId,
+      screentockImgElement,
+      320,
+      240,
+      'low'
+    );
+
+    // Upload high-res version (1280x960)
+    const highResUrl = await uploadSnapshotImage(
+      sceneId,
+      snapshotId,
+      screentockImgElement,
+      1280,
+      960,
+      'high'
+    );
+
+    // Create snapshot object
+    const snapshot = {
+      id: snapshotId,
+      imagePath: lowResUrl,
+      imagePathHD: highResUrl,
+      cameraState: cameraState,
+      isDefault: setAsDefault,
+      timestamp: new Date().toISOString(),
+      label: label || `Snapshot ${new Date().toLocaleString()}`
+    };
+
+    // Update the scene document
+    await updateSceneSnapshots(sceneId, snapshot, setAsDefault);
+
+    posthog.capture('snapshot_created', {
+      scene_id: sceneId,
+      snapshot_id: snapshotId,
+      is_default: setAsDefault
+    });
+
+    return snapshot;
+  } catch (error) {
+    console.error('Error creating scene snapshot:', error);
+    throw error;
+  }
+}
+
+/**
+ * Upload a snapshot image at specific resolution
+ * @param {string} sceneId - Scene ID
+ * @param {string} snapshotId - Snapshot ID
+ * @param {HTMLImageElement} imgElement - Source image element
+ * @param {number} targetWidth - Target width
+ * @param {number} targetHeight - Target height
+ * @param {string} quality - Quality level ('low' or 'high')
+ * @returns {string} Download URL
+ */
+async function uploadSnapshotImage(
+  sceneId,
+  snapshotId,
+  imgElement,
+  targetWidth,
+  targetHeight,
+  quality
+) {
+  // Get the original image dimensions
+  const originalWidth = imgElement.naturalWidth;
+  const originalHeight = imgElement.naturalHeight;
+
+  // Calculate the scale factors
+  const scaleX = targetWidth / originalWidth;
+  const scaleY = targetHeight / originalHeight;
+
+  // Use the larger scale factor to fill the entire space
+  const scale = Math.max(scaleX, scaleY);
+
+  // Calculate the new dimensions
+  const newWidth = originalWidth * scale;
+  const newHeight = originalHeight * scale;
+
+  const resizedCanvas = document.createElement('canvas');
+  resizedCanvas.width = targetWidth;
+  resizedCanvas.height = targetHeight;
+  const context = resizedCanvas.getContext('2d');
+
+  // Calculate the position to center the image
+  const posX = (targetWidth - newWidth) / 2;
+  const posY = (targetHeight - newHeight) / 2;
+
+  // Draw the image on the canvas
+  context.drawImage(imgElement, posX, posY, newWidth, newHeight);
+
+  // Convert to blob with appropriate quality
+  const jpegQuality = quality === 'high' ? 0.9 : 0.5;
+  const dataUrl = resizedCanvas.toDataURL('image/jpeg', jpegQuality);
+  const res = await fetch(dataUrl);
+  const blobFile = await res.blob();
+
+  // Upload to Firebase Storage - using files/ path for compatibility with existing security rules
+  const filename =
+    quality === 'high'
+      ? `snapshot-${snapshotId}-hd.jpg`
+      : `snapshot-${snapshotId}.jpg`;
+  const storageRef = ref(storage, `scenes/${sceneId}/files/${filename}`);
+
+  const uploadedImg = await uploadBytes(storageRef, blobFile);
+  return await getDownloadURL(uploadedImg.ref);
+}
+
+/**
+ * Update scene document with new snapshot
+ * @param {string} sceneId - Scene ID
+ * @param {Object} newSnapshot - New snapshot object
+ * @param {boolean} setAsDefault - Whether to set as default
+ */
+async function updateSceneSnapshots(sceneId, newSnapshot, setAsDefault) {
+  const sceneDocRef = doc(db, 'scenes', sceneId);
+  const sceneSnapshot = await getDoc(sceneDocRef);
+
+  if (!sceneSnapshot.exists()) {
+    throw new Error('Scene not found');
+  }
+
+  const sceneData = sceneSnapshot.data();
+  let snapshots = sceneData.snapshots || [];
+
+  // If setting as default, update all other snapshots
+  if (setAsDefault) {
+    snapshots = snapshots.map((s) => ({ ...s, isDefault: false }));
+  }
+
+  // Add the new snapshot
+  snapshots.push(newSnapshot);
+
+  // Update the scene document
+  const updateData = {
+    snapshots: snapshots,
+    updateTimestamp: serverTimestamp()
+  };
+
+  // If this is the default snapshot, also update the main imagePath
+  if (setAsDefault) {
+    updateData.imagePath = newSnapshot.imagePath;
+    updateData.thumbnailLocked = true; // Indicates manual thumbnail set
+  }
+
+  await updateDoc(sceneDocRef, updateData);
+}
+
+/**
+ * Get the default snapshot for a scene
+ * @param {string} sceneId - Scene ID
+ * @returns {Object|null} Default snapshot or null
+ */
+export async function getDefaultSnapshot(sceneId) {
+  try {
+    const sceneDocRef = doc(db, 'scenes', sceneId);
+    const sceneSnapshot = await getDoc(sceneDocRef);
+
+    if (!sceneSnapshot.exists()) {
+      return null;
+    }
+
+    const sceneData = sceneSnapshot.data();
+    if (!sceneData.snapshots || sceneData.snapshots.length === 0) {
+      return null;
+    }
+
+    return sceneData.snapshots.find((s) => s.isDefault) || null;
+  } catch (error) {
+    console.error('Error getting default snapshot:', error);
+    return null;
+  }
+}
+
+/**
+ * Remove a snapshot from a scene
+ * @param {string} sceneId - Scene ID
+ * @param {string} snapshotId - Snapshot ID to remove
+ */
+export async function removeSnapshot(sceneId, snapshotId) {
+  try {
+    const sceneDocRef = doc(db, 'scenes', sceneId);
+    const sceneSnapshot = await getDoc(sceneDocRef);
+
+    if (!sceneSnapshot.exists()) {
+      throw new Error('Scene not found');
+    }
+
+    const sceneData = sceneSnapshot.data();
+    const snapshots = sceneData.snapshots || [];
+
+    // Filter out the snapshot to remove
+    const updatedSnapshots = snapshots.filter((s) => s.id !== snapshotId);
+
+    await updateDoc(sceneDocRef, {
+      snapshots: updatedSnapshots,
+      updateTimestamp: serverTimestamp()
+    });
+
+    posthog.capture('snapshot_removed', {
+      scene_id: sceneId,
+      snapshot_id: snapshotId
+    });
+  } catch (error) {
+    console.error('Error removing snapshot:', error);
+    throw error;
+  }
+}

--- a/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -54,11 +54,10 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
     }
 
     if (event.ctrlKey || event.metaKey) {
-      // Store both data, memory, and snapshots for new tab
+      // Store both data and memory (which contains snapshots) for new tab
       const fullData = {
         data: sceneData.data,
         memory: sceneData.memory,
-        snapshots: sceneData.snapshots,
         title: sceneData.title,
         author: sceneData.author
       };
@@ -74,12 +73,8 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
         console.log('No memory data found in scene data');
       }
 
-      // Pass data, memory, and snapshots to createElementsForScenesFromJSON
-      createElementsForScenesFromJSON(
-        sceneData.data,
-        sceneData.memory,
-        sceneData.snapshots
-      );
+      // Pass data and memory (which now contains snapshots) to createElementsForScenesFromJSON
+      createElementsForScenesFromJSON(sceneData.data, sceneData.memory);
       window.location.hash = `#/scenes/${scene.id}`;
 
       const sceneId = scene.id;
@@ -102,11 +97,7 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
         if (storedData.memory) {
           console.log('Memory data found in localStorage:', storedData.memory);
         }
-        createElementsForScenesFromJSON(
-          storedData.data,
-          storedData.memory,
-          storedData.snapshots
-        );
+        createElementsForScenesFromJSON(storedData.data, storedData.memory);
       } else {
         // Old format with just data
         console.log('Loading scene from localStorage with old format');

--- a/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -54,10 +54,13 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
     }
 
     if (event.ctrlKey || event.metaKey) {
-      // Store both data and memory for new tab
+      // Store both data, memory, and snapshots for new tab
       const fullData = {
         data: sceneData.data,
-        memory: sceneData.memory
+        memory: sceneData.memory,
+        snapshots: sceneData.snapshots,
+        title: sceneData.title,
+        author: sceneData.author
       };
       localStorage.setItem('sceneData', JSON.stringify(fullData));
       const newTabUrl = `#/scenes/${scene.id}`;
@@ -80,6 +83,22 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
       AFRAME.scenes[0].setAttribute('metadata', 'sceneId', sceneId);
       useStore.getState().setSceneTitle(sceneTitle);
       AFRAME.scenes[0].setAttribute('metadata', 'authorId', sceneData.author);
+
+      // Check for snapshots and apply default camera position
+      if (sceneData.snapshots && sceneData.snapshots.length > 0) {
+        const defaultSnapshot = sceneData.snapshots.find((s) => s.isDefault);
+        if (defaultSnapshot && defaultSnapshot.cameraState) {
+          console.log(
+            '[ScenesModal] Applying default snapshot camera state:',
+            defaultSnapshot.cameraState
+          );
+          // Apply camera state after a short delay to ensure scene is fully loaded
+          setTimeout(() => {
+            STREET.utils.applyCameraState(defaultSnapshot.cameraState);
+          }, 500);
+        }
+      }
+
       STREET.notify.successMessage('Scene loaded from 3DStreet Cloud.');
       onClose();
     }
@@ -88,6 +107,8 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
   useEffect(() => {
     const storedData = JSON.parse(localStorage.getItem('sceneData'));
     if (storedData) {
+      let sceneData = null;
+
       if (storedData.data) {
         // New format with separate data and memory
         console.log('Loading scene from localStorage with new format');
@@ -95,11 +116,29 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
           console.log('Memory data found in localStorage:', storedData.memory);
         }
         createElementsForScenesFromJSON(storedData.data, storedData.memory);
+        sceneData = storedData; // Full data including snapshots
       } else {
         // Old format with just data
         console.log('Loading scene from localStorage with old format');
         createElementsForScenesFromJSON(storedData);
+        sceneData = { data: storedData }; // Wrap in expected format
       }
+
+      // Check for snapshots and apply default camera position
+      if (sceneData.snapshots && sceneData.snapshots.length > 0) {
+        const defaultSnapshot = sceneData.snapshots.find((s) => s.isDefault);
+        if (defaultSnapshot && defaultSnapshot.cameraState) {
+          console.log(
+            '[ScenesModal localStorage] Applying default snapshot camera state:',
+            defaultSnapshot.cameraState
+          );
+          // Apply camera state after a short delay to ensure scene is fully loaded
+          setTimeout(() => {
+            STREET.utils.applyCameraState(defaultSnapshot.cameraState);
+          }, 500);
+        }
+      }
+
       localStorage.removeItem('sceneData');
     }
   }, []);

--- a/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -74,8 +74,12 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
         console.log('No memory data found in scene data');
       }
 
-      // Pass both data and memory to createElementsForScenesFromJSON
-      createElementsForScenesFromJSON(sceneData.data, sceneData.memory);
+      // Pass data, memory, and snapshots to createElementsForScenesFromJSON
+      createElementsForScenesFromJSON(
+        sceneData.data,
+        sceneData.memory,
+        sceneData.snapshots
+      );
       window.location.hash = `#/scenes/${scene.id}`;
 
       const sceneId = scene.id;
@@ -83,21 +87,6 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
       AFRAME.scenes[0].setAttribute('metadata', 'sceneId', sceneId);
       useStore.getState().setSceneTitle(sceneTitle);
       AFRAME.scenes[0].setAttribute('metadata', 'authorId', sceneData.author);
-
-      // Check for snapshots and apply default camera position
-      if (sceneData.snapshots && sceneData.snapshots.length > 0) {
-        const defaultSnapshot = sceneData.snapshots.find((s) => s.isDefault);
-        if (defaultSnapshot && defaultSnapshot.cameraState) {
-          console.log(
-            '[ScenesModal] Applying default snapshot camera state:',
-            defaultSnapshot.cameraState
-          );
-          // Apply camera state after a short delay to ensure scene is fully loaded
-          setTimeout(() => {
-            STREET.utils.applyCameraState(defaultSnapshot.cameraState);
-          }, 500);
-        }
-      }
 
       STREET.notify.successMessage('Scene loaded from 3DStreet Cloud.');
       onClose();
@@ -107,36 +96,21 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
   useEffect(() => {
     const storedData = JSON.parse(localStorage.getItem('sceneData'));
     if (storedData) {
-      let sceneData = null;
-
       if (storedData.data) {
         // New format with separate data and memory
         console.log('Loading scene from localStorage with new format');
         if (storedData.memory) {
           console.log('Memory data found in localStorage:', storedData.memory);
         }
-        createElementsForScenesFromJSON(storedData.data, storedData.memory);
-        sceneData = storedData; // Full data including snapshots
+        createElementsForScenesFromJSON(
+          storedData.data,
+          storedData.memory,
+          storedData.snapshots
+        );
       } else {
         // Old format with just data
         console.log('Loading scene from localStorage with old format');
         createElementsForScenesFromJSON(storedData);
-        sceneData = { data: storedData }; // Wrap in expected format
-      }
-
-      // Check for snapshots and apply default camera position
-      if (sceneData.snapshots && sceneData.snapshots.length > 0) {
-        const defaultSnapshot = sceneData.snapshots.find((s) => s.isDefault);
-        if (defaultSnapshot && defaultSnapshot.cameraState) {
-          console.log(
-            '[ScenesModal localStorage] Applying default snapshot camera state:',
-            defaultSnapshot.cameraState
-          );
-          // Apply camera state after a short delay to ensure scene is fully loaded
-          setTimeout(() => {
-            STREET.utils.applyCameraState(defaultSnapshot.cameraState);
-          }, 500);
-        }
       }
 
       localStorage.removeItem('sceneData');

--- a/src/editor/components/modals/ScreenshotModal/ScreenshotModal.component.jsx
+++ b/src/editor/components/modals/ScreenshotModal/ScreenshotModal.component.jsx
@@ -106,12 +106,18 @@ function ScreenshotModal() {
               currentUser.uid === STREET.utils.getAuthorId() && (
                 <Button
                   onClick={handleSetAsSceneThumbnail}
-                  variant="filled"
-                  className={styles.downloadButton}
+                  variant="outlined"
+                  className={styles.thumbnailButton}
                   disabled={isSavingSnapshot}
-                  style={{ marginTop: '8px' }}
                 >
-                  {isSavingSnapshot ? 'Saving...' : '📸 Set as Scene Thumbnail'}
+                  {isSavingSnapshot ? (
+                    'Saving...'
+                  ) : (
+                    <span>
+                      <span>📸</span>
+                      <span>Set as Scene Thumbnail</span>
+                    </span>
+                  )}
                 </Button>
               )}
           </div>

--- a/src/editor/components/modals/ScreenshotModal/ScreenshotModal.module.scss
+++ b/src/editor/components/modals/ScreenshotModal/ScreenshotModal.module.scss
@@ -201,11 +201,28 @@
   .downloadSection {
     padding: 16px;
     border-bottom: 1px solid var(--panel-border);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 
     .downloadButton {
       width: 100%;
       max-width: 250px;
       justify-content: center;
+    }
+
+    .thumbnailButton {
+      width: 100%;
+      max-width: 250px;
+      justify-content: center;
+      height: 40px; // Match the height of the primary button
+
+      // Add space between emoji and text
+      span {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
     }
   }
 

--- a/src/editor/lib/SceneUtils.js
+++ b/src/editor/lib/SceneUtils.js
@@ -262,6 +262,29 @@ export async function saveScene(currentUser, doSaveAs, doPromptTitle) {
   // Ensure memory data (including project info) is preserved
   filteredData.memory = data.memory;
 
+  // If we have an existing scene ID, fetch and preserve snapshots from Firebase
+  if (sceneId && !doSaveAs) {
+    try {
+      const sceneDocRef = doc(db, 'scenes', sceneId);
+      const sceneSnapshot = await getDoc(sceneDocRef);
+
+      if (sceneSnapshot.exists()) {
+        const existingSceneData = sceneSnapshot.data();
+
+        // Merge existing snapshots with the local memory data
+        if (existingSceneData.memory?.snapshots) {
+          filteredData.memory = {
+            ...filteredData.memory,
+            snapshots: existingSceneData.memory.snapshots
+          };
+        }
+      }
+    } catch (error) {
+      console.warn('Could not fetch existing snapshots during save:', error);
+      // Continue with save even if we couldn't fetch snapshots
+    }
+  }
+
   // we want to save, so if we *still* have no sceneID at this point, then create a new one
   if (!sceneId || !!doSaveAs) {
     let title = sceneTitle;

--- a/src/editor/lib/SceneUtils.js
+++ b/src/editor/lib/SceneUtils.js
@@ -125,6 +125,10 @@ export function fileJSON(event) {
     const data = JSON.parse(reader.result);
     // Pass the data and memory (which now contains snapshots)
     createElementsForScenesFromJSON(data.data, data.memory);
+
+    // Reset the file input value so it can be selected again
+    // This fixes the issue where selecting a file a second time doesn't work
+    event.target.value = '';
   };
 
   reader.readAsText(event.target.files[0]);

--- a/src/editor/lib/SceneUtils.js
+++ b/src/editor/lib/SceneUtils.js
@@ -47,11 +47,7 @@ export function inputStreetmix() {
   );
 }
 
-export function createElementsForScenesFromJSON(
-  streetData,
-  memoryData,
-  snapshotData
-) {
+export function createElementsForScenesFromJSON(streetData, memoryData) {
   // clear scene data, create new blank scene.
   // clearMetadata = true, clearUrlHash = false, addDefaultStreet = false
   STREET.utils.newScene(true, false, false);
@@ -74,8 +70,8 @@ export function createElementsForScenesFromJSON(
 
   // Store snapshot camera state if available
   let defaultSnapshotCameraState = null;
-  if (snapshotData && snapshotData.length > 0) {
-    const defaultSnapshot = snapshotData.find((s) => s.isDefault);
+  if (memoryData?.snapshots && memoryData.snapshots.length > 0) {
+    const defaultSnapshot = memoryData.snapshots.find((s) => s.isDefault);
     if (defaultSnapshot && defaultSnapshot.cameraState) {
       defaultSnapshotCameraState = defaultSnapshot.cameraState;
     }
@@ -127,8 +123,8 @@ export function fileJSON(event) {
 
   reader.onload = function () {
     const data = JSON.parse(reader.result);
-    // Pass the entire data object to handle scene data, memory, and snapshots
-    createElementsForScenesFromJSON(data.data, data.memory, data.snapshots);
+    // Pass the data and memory (which now contains snapshots)
+    createElementsForScenesFromJSON(data.data, data.memory);
   };
 
   reader.readAsText(event.target.files[0]);

--- a/src/editor/lib/cameraUtils.js
+++ b/src/editor/lib/cameraUtils.js
@@ -1,0 +1,70 @@
+// Camera utility functions for snapshot feature
+
+/**
+ * Get the current camera state including position, rotation, and zoom
+ * @returns {Object} Camera state object with position, rotation, and zoom
+ */
+export function getCurrentCameraState() {
+  const camera = AFRAME.scenes[0].camera;
+  if (!camera) {
+    console.error('No camera found in scene');
+    return null;
+  }
+
+  return {
+    position: {
+      x: camera.position.x,
+      y: camera.position.y,
+      z: camera.position.z
+    },
+    rotation: {
+      x: camera.rotation.x,
+      y: camera.rotation.y,
+      z: camera.rotation.z
+    },
+    // For perspective camera, we'll store FOV as "zoom"
+    zoom: camera.fov || 60,
+    type: camera.type
+  };
+}
+
+/**
+ * Set camera to a specific state
+ * @param {Object} cameraState - Camera state object with position, rotation, and zoom
+ */
+export function setCameraState(cameraState) {
+  if (!cameraState) return;
+
+  const camera = AFRAME.scenes[0].camera;
+  if (!camera) {
+    console.error('No camera found in scene');
+    return;
+  }
+
+  // Set position
+  if (cameraState.position) {
+    camera.position.set(
+      cameraState.position.x,
+      cameraState.position.y,
+      cameraState.position.z
+    );
+  }
+
+  // Set rotation
+  if (cameraState.rotation) {
+    camera.rotation.set(
+      cameraState.rotation.x,
+      cameraState.rotation.y,
+      cameraState.rotation.z
+    );
+  }
+
+  // Set zoom/FOV if applicable
+  if (cameraState.zoom && camera.fov !== undefined) {
+    camera.fov = cameraState.zoom;
+    camera.updateProjectionMatrix();
+  }
+
+  // Update camera
+  camera.updateMatrixWorld();
+}

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -379,8 +379,10 @@ export function Viewport(inspector) {
     Events.emit('camerachanged');
   });
 
-  sceneEl.addEventListener('newScene', () => {
-    controls.resetZoom();
+  sceneEl.addEventListener('newScene', (event) => {
+    // Check if there's a snapshot camera state passed with the event
+    const snapshotCameraState = event.detail?.snapshotCameraState;
+    controls.newSceneCameraZoom(snapshotCameraState);
   });
 
   Events.on('cameratoggle', (data) => {

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -749,8 +749,13 @@ AFRAME.registerComponent('set-loader-from-hash', {
 
         // Check for snapshots and store default camera state BEFORE createElementsFromJSON
         let defaultSnapshotCameraState = null;
-        if (jsonData.snapshots && jsonData.snapshots.length > 0) {
-          const defaultSnapshot = jsonData.snapshots.find((s) => s.isDefault);
+        if (
+          jsonData.memory?.snapshots &&
+          jsonData.memory.snapshots.length > 0
+        ) {
+          const defaultSnapshot = jsonData.memory.snapshots.find(
+            (s) => s.isDefault
+          );
           if (defaultSnapshot && defaultSnapshot.cameraState) {
             console.log(
               '[set-loader-from-hash] Found default snapshot camera state:',

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -761,10 +761,7 @@ AFRAME.registerComponent('set-loader-from-hash', {
                 '[set-loader-from-hash] Applying default snapshot camera state:',
                 defaultSnapshot.cameraState
               );
-              // Apply camera state after a short delay to ensure scene is fully loaded
-              setTimeout(() => {
-                STREET.utils.applyCameraState(defaultSnapshot.cameraState);
-              }, 500);
+              STREET.utils.applyCameraState(defaultSnapshot.cameraState);
             }
           }
         }


### PR DESCRIPTION
things to test before pushing:

also test load from scratch vs. dynamic (open modal, template)

with snapshot:
- [x] - open scene from hash
- [x] - open scene from modal
- [x] - save/load from desktop - no , is memory saved / loaded? fixed
- [x] - viewer mode - camera path
- [x] - viewer mode - ar
- [x] - viewer mode - locomotion

without snapshot:
- [x] - app url (new scene without uuid) - no animation
- [x] - template create blank scene
- [x] - open scene from hash
- [x] - open scene from modal
- [x] - import from streetmix - no animation
- [x] - import from streetplan - no animation (not tested)
- [x] - import from bollard buddy - no animation (not tested)
- [x] - save/load from desktop - no animation
- [x] - viewer mode - camera path
- [x] - viewer mode - ar
- [x] - viewer mode - locomotion

nice things to fix:
- [x] - download jpg should be primary action (purplish as is)
- [x] - pin as scene thumbnail is a secondary action (gray)
- [x] - the height of both buttons should match
- [x] - there should be a space between the emoji and the text of set as scene thumbnail
- [x] - animation for streetmix/streetplan import