### PR TITLE
Fix PR review issues #3 and #9: Storage paths and magic strings

### DIFF
--- a/src/shared/gallery/constants.js
+++ b/src/shared/gallery/constants.js
@@ -1,0 +1,114 @@
+/**
+ * Gallery Constants
+ * Centralized constants for asset types, categories, and storage paths
+ */
+
+/**
+ * Valid asset types for gallery items
+ * @readonly
+ * @enum {string}
+ */
+export const ASSET_TYPES = {
+  IMAGE: 'image',
+  VIDEO: 'video',
+  SPLAT: 'splat',
+  MESH: 'mesh'
+};
+
+/**
+ * Valid asset categories for gallery items
+ * @readonly
+ * @enum {string}
+ */
+export const ASSET_CATEGORIES = {
+  AI_RENDER: 'ai-render',
+  SCREENSHOT: 'screenshot',
+  UPLOAD: 'upload',
+  SPLAT_SOURCE: 'splat-source',
+  SPLAT_OUTPUT: 'splat-output'
+};
+
+/**
+ * Pluralization map for asset type folders in storage
+ * Maps singular type to plural folder name
+ * @readonly
+ */
+export const ASSET_TYPE_FOLDERS = {
+  [ASSET_TYPES.IMAGE]: 'images',
+  [ASSET_TYPES.VIDEO]: 'videos',
+  [ASSET_TYPES.SPLAT]: 'splats',
+  [ASSET_TYPES.MESH]: 'meshes'
+};
+
+/**
+ * Storage path configuration
+ * Matches the structure in public/storage.rules: users/{userId}/assets/{allPaths=**}
+ */
+export const STORAGE_PATHS = {
+  /**
+   * Base path pattern for user assets
+   * @param {string} userId - The user ID
+   * @returns {string} Base path for user's assets
+   */
+  userAssetsBase: (userId) => `users/${userId}/assets`,
+
+  /**
+   * Full path for an asset file
+   * @param {string} userId - The user ID
+   * @param {string} typeFolder - The pluralized type folder (e.g., 'images', 'videos')
+   * @param {string} filename - The filename
+   * @returns {string} Full storage path
+   */
+  assetFile: (userId, typeFolder, filename) =>
+    `users/${userId}/assets/${typeFolder}/${filename}`
+};
+
+/**
+ * Get the plural folder name for an asset type
+ * @param {string} type - The asset type (e.g., 'image', 'video')
+ * @returns {string} The plural folder name (e.g., 'images', 'videos')
+ * @throws {Error} If the type is not recognized
+ */
+export function getTypeFolderName(type) {
+  const folder = ASSET_TYPE_FOLDERS[type];
+  if (!folder) {
+    throw new Error(
+      `Unknown asset type: ${type}. Valid types are: ${Object.values(ASSET_TYPES).join(', ')}`
+    );
+  }
+  return folder;
+}
+
+/**
+ * Validate a user ID for use in storage paths
+ * Ensures the userId doesn't contain characters that could cause path traversal or other issues
+ * @param {string} userId - The user ID to validate
+ * @returns {boolean} True if valid
+ * @throws {Error} If the userId is invalid
+ */
+export function validateUserIdForPath(userId) {
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('User ID is required and must be a string');
+  }
+
+  // Check for empty or whitespace-only
+  if (userId.trim().length === 0) {
+    throw new Error('User ID cannot be empty');
+  }
+
+  // Check for path traversal attempts
+  if (userId.includes('..') || userId.includes('/') || userId.includes('\\')) {
+    throw new Error('User ID contains invalid characters');
+  }
+
+  // Firebase UIDs are typically alphanumeric with some special chars
+  // This regex matches Firebase Auth UIDs
+  const validUserIdPattern = /^[a-zA-Z0-9_-]+$/;
+  if (!validUserIdPattern.test(userId)) {
+    throw new Error(
+      'User ID contains invalid characters. Only alphanumeric, underscore, and hyphen are allowed.'
+    );
+  }
+
+  return true;
+}

--- a/src/shared/gallery/hooks/useGallery.js
+++ b/src/shared/gallery/hooks/useGallery.js
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback, useContext, useRef } from 'react';
 import galleryServiceV2 from '../services/galleryServiceV2.js';
 import galleryMigration from '../services/galleryMigration.js';
+import { ASSET_TYPES, ASSET_CATEGORIES } from '../constants.js';
 import { AuthContext } from '@shared/contexts';
 import { auth } from '@shared/services/firebase.js';
 
@@ -291,11 +292,11 @@ const useGallery = () => {
    * Add a new item to the gallery (V2)
    * @param {string} imageDataUri - Data URI of the image
    * @param {object} metadata - Image metadata
-   * @param {string} type - Image type ('screenshot' | 'ai-render' | 'video')
+   * @param {string} type - Image type (use ASSET_CATEGORIES constants)
    * @returns {Promise<string>} - Returns the new asset ID
    */
   const addItem = useCallback(
-    async (imageDataUri, metadata, type = 'ai-render') => {
+    async (imageDataUri, metadata, type = ASSET_CATEGORIES.AI_RENDER) => {
       // Get userId directly from Firebase auth (handles generator timing issues)
       const currentUserId =
         auth.currentUser?.uid || window.authState?.currentUser?.uid;
@@ -305,8 +306,8 @@ const useGallery = () => {
 
       try {
         // Map type to V2 structure
-        const assetType = type === 'video' ? 'video' : 'image';
-        const category = type === 'video' ? 'ai-render' : type;
+        const assetType = type === ASSET_TYPES.VIDEO ? ASSET_TYPES.VIDEO : ASSET_TYPES.IMAGE;
+        const category = type === ASSET_TYPES.VIDEO ? ASSET_CATEGORIES.AI_RENDER : type;
 
         const assetId = await galleryServiceV2.addAsset(
           imageDataUri,
@@ -424,10 +425,10 @@ const useGallery = () => {
     link.href = item.fullImageURL || item.storageUrl || item.objectURL;
 
     // Create filename
-    const isVideo = item.type === 'video';
+    const isVideo = item.type === ASSET_TYPES.VIDEO;
     const model =
       item.metadata?.model ||
-      (item.type === 'screenshot' ? '3dstreet' : 'flux');
+      (item.type === ASSET_CATEGORIES.SCREENSHOT ? '3dstreet' : 'flux');
     const timestamp = item.metadata?.timestamp
       ? new Date(item.metadata.timestamp)
           .toISOString()

--- a/src/shared/gallery/index.js
+++ b/src/shared/gallery/index.js
@@ -3,6 +3,16 @@
  * V2 (Firestore + Firebase Storage) is the primary service
  */
 
+// Constants
+export {
+  ASSET_TYPES,
+  ASSET_CATEGORIES,
+  ASSET_TYPE_FOLDERS,
+  STORAGE_PATHS,
+  getTypeFolderName,
+  validateUserIdForPath
+} from './constants';
+
 // Services
 export { default as galleryService } from './services/galleryService'; // V1 - kept for migration only
 export { default as galleryServiceV2 } from './services/galleryServiceV2'; // V2 - primary service


### PR DESCRIPTION
Issue #3 - Hard-coded Storage Paths:
- Add proper pluralization map (ASSET_TYPE_FOLDERS) instead of naive ${type}s
- Add validateUserIdForPath() to prevent path traversal attacks
- Extract storage path pattern to shared STORAGE_PATHS constant
- Update getStoragePath() to use validation and proper type mapping

Issue #9 - Magic Strings Everywhere:
- Create new src/shared/gallery/constants.js with centralized constants
- Add ASSET_TYPES enum (image, video, splat, mesh)
- Add ASSET_CATEGORIES enum (ai-render, screenshot, upload, etc.)
- Update galleryServiceV2.js to use constants for type checks
- Update useGallery.js to use constants for type mapping
- Export all constants from gallery index.js for easy importing