### PR TITLE
Fix selection box not updating when moving group entities via panel or undo

### DIFF
--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -380,10 +380,7 @@ export function Viewport(inspector) {
 
   Events.on('entityupdate', (detail) => {
     const object = detail.entity.object3D;
-    if (
-      inspector.selected === object &&
-      inspector.selectedEntity.object3DMap.mesh
-    ) {
+    if (inspector.selected === object) {
       selectionBox.setFromObject(inspector.selected);
       hoverBox.visible = false;
     }
@@ -513,20 +510,6 @@ export function Viewport(inspector) {
 
   Events.on('entityupdate', (detail) => {
     const object = detail.entity.object3D;
-    if (inspector.selected === object) {
-      // Hack because object3D always has geometry :(
-      if (
-        object.geometry &&
-        ((object.geometry.vertices && object.geometry.vertices.length > 0) ||
-          (object.geometry.attributes &&
-            object.geometry.attributes.position &&
-            object.geometry.attributes.position.array.length))
-      ) {
-        selectionBox.setFromObject(object);
-        hoverBox.visible = false;
-      }
-    }
-
     transformControls.update();
     if (object instanceof THREE.PerspectiveCamera) {
       object.updateProjectionMatrix();


### PR DESCRIPTION
The entityupdate handler required object3DMap.mesh to update the selection box, so group entities (parents without a mesh) were skipped. Removed that check and the redundant second handler's geometry-based selection box update.

Steps to reproduce
- move managed street entity
- undo
- the selection box should be updated