### PR TITLE
Upgrade @sparkjsdev/spark to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@img-comparison-slider/react": "^8.0.2",
         "@react-google-maps/api": "^2.20.8",
         "@sentry/react": "^10.40.0",
-        "@sparkjsdev/spark": "github:sparkjsdev/spark#v2.0.0-preview",
+        "@sparkjsdev/spark": "github:sparkjsdev/spark#v2.0.0",
         "@stripe/react-stripe-js": "^4.0.2",
         "@stripe/stripe-js": "^3.5.0",
         "3d-tiles-renderer": "^0.4.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@img-comparison-slider/react": "^8.0.2",
         "@react-google-maps/api": "^2.20.8",
         "@sentry/react": "^10.40.0",
-        "@sparkjsdev/spark": "github:sparkjsdev/spark#v2.0.0",
+        "@sparkjsdev/spark": "^2.0.0",
         "@stripe/react-stripe-js": "^4.0.2",
         "@stripe/stripe-js": "^3.5.0",
         "3d-tiles-renderer": "^0.4.21",
@@ -6622,8 +6622,9 @@
       }
     },
     "node_modules/@sparkjsdev/spark": {
-      "version": "0.1.9",
-      "resolved": "git+ssh://git@github.com/sparkjsdev/spark.git#1fea5a102e6e311aaea34d16dce6d360987cd859",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-2.0.0.tgz",
+      "integrity": "sha512-W1p7NM4xXcUAVVcVus2mIFwcAC3VckyE0l4wXJuSmhcOgb6hHpqhQ/Ks9MK9ts7j23K+UwbCBwe+aTc/zgGygw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@img-comparison-slider/react": "^8.0.2",
     "@react-google-maps/api": "^2.20.8",
     "@sentry/react": "^10.40.0",
-    "@sparkjsdev/spark": "github:sparkjsdev/spark#v2.0.0-preview",
+    "@sparkjsdev/spark": "github:sparkjsdev/spark#v2.0.0",
     "@stripe/react-stripe-js": "^4.0.2",
     "@stripe/stripe-js": "^3.5.0",
     "3d-tiles-renderer": "^0.4.21",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@img-comparison-slider/react": "^8.0.2",
     "@react-google-maps/api": "^2.20.8",
     "@sentry/react": "^10.40.0",
-    "@sparkjsdev/spark": "github:sparkjsdev/spark#v2.0.0",
+    "@sparkjsdev/spark": "^2.0.0",
     "@stripe/react-stripe-js": "^4.0.2",
     "@stripe/stripe-js": "^3.5.0",
     "3d-tiles-renderer": "^0.4.21",


### PR DESCRIPTION
## Summary
- Upgrades `@sparkjsdev/spark` from `v2.0.0-preview` to the final `v2.0.0` release
- No code changes needed — our splat component already uses the v2.0 API (SplatMesh, SparkRenderer with LOD)

Closes #1544

## Test plan
- [ ] Verify splat/gaussian splatting loads correctly in the editor
- [ ] Test .splat, .spz, and .rad file formats
- [ ] Confirm no regressions in scene rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)