### PR TITLE
Fix editor focus for scaled targets

### DIFF
--- a/src/editor/lib/EditorControls.js
+++ b/src/editor/lib/EditorControls.js
@@ -38,6 +38,9 @@ THREE.EditorControls = function (_object, domElement) {
   var pointerOld = new THREE.Vector2();
   var spherical = new THREE.Spherical();
   var sphere = new THREE.Sphere();
+  var focusWorldPos = new THREE.Vector3();
+  var focusWorldQuat = new THREE.Quaternion();
+  var focusWorldScale = new THREE.Vector3();
 
   this.isOrthographic = false;
   this.rotationEnabled = true;
@@ -83,6 +86,14 @@ THREE.EditorControls = function (_object, domElement) {
       localCenterY = target.position.y;
     }
 
+    // Apply only target's world position + rotation, not its scale, to offsets expressed
+    // in world units (localCenterY / distance come from the world-space bbox).
+    target.matrixWorld.decompose(
+      focusWorldPos,
+      focusWorldQuat,
+      focusWorldScale
+    );
+
     const targetEl = target.el;
     let cameraPosition;
     // if focus-camera-pose set on target then use that vec3 as target
@@ -90,14 +101,13 @@ THREE.EditorControls = function (_object, domElement) {
       const poseRelativePosition =
         targetEl.getAttribute('focus-camera-pose')['relativePosition'];
       if (poseRelativePosition) {
-        // Create a vector from the relative position and transform it to world space
-        cameraPosition = target.localToWorld(
-          new THREE.Vector3(
-            poseRelativePosition.x,
-            poseRelativePosition.y,
-            poseRelativePosition.z
-          )
-        );
+        cameraPosition = new THREE.Vector3(
+          poseRelativePosition.x,
+          poseRelativePosition.y,
+          poseRelativePosition.z
+        )
+          .applyQuaternion(focusWorldQuat)
+          .add(focusWorldPos);
       }
     }
     // Fallback to default positioning if no pose relative position
@@ -129,7 +139,9 @@ THREE.EditorControls = function (_object, domElement) {
         defaultOffset.x * Math.sin(baseRotationRad) +
         defaultOffset.z * Math.cos(baseRotationRad);
 
-      cameraPosition = target.localToWorld(rotatedOffset);
+      cameraPosition = rotatedOffset
+        .applyQuaternion(focusWorldQuat)
+        .add(focusWorldPos);
     }
     // Set camera position
     object.position.copy(cameraPosition);


### PR DESCRIPTION
EditorControls.focus used target.localToWorld to place the camera, which multiplied the world-space bbox-derived offset by the target's world scale. Focusing a model scaled by N ended up N times too far. Decompose matrixWorld instead and rotate the offset by the target's world rotation only. Preserves the focus-camera-pose override and the catalog baseRotation behaviour.

This is a backport of https://github.com/aframevr/aframe-inspector/pull/854 but you don't seem to use scale on any entity currently, so you probably never saw that issue, but you may in the future if the user drag and drop a glb and scale the entity.