### PR TITLE
Security: Reverse tabnabbing risk via `window.open` without `noopener`

### DIFF
--- a/src/editor/components/modals/ModalHelp/components/DocumentationButton/DocumentationButton.component.jsx
+++ b/src/editor/components/modals/ModalHelp/components/DocumentationButton/DocumentationButton.component.jsx
@@ -15,7 +15,7 @@ class DocumentationButton extends Component {
       <Button variant="toolbtn">
         <div
           className={styles.docsButtonWrapper}
-          onClick={() => window.open('https://3dstreet.org/docs/')}
+          onClick={() => window.open('https://3dstreet.org/docs/', '_blank', 'noopener,noreferrer')}
         >
           Documentation <Open />
         </div>


### PR DESCRIPTION
## Summary

Security: Reverse tabnabbing risk via `window.open` without `noopener`

## Problem

**Severity**: `Low` | **File**: `src/editor/components/modals/ModalHelp/components/DocumentationButton/DocumentationButton.component.jsx:L18`

The documentation link is opened with `window.open('https://3dstreet.org/docs/')` and no `noopener`/`noreferrer` protections. The opened page can access `window.opener` and potentially redirect the original tab (reverse tabnabbing).

## Solution

Use `window.open(url, '_blank', 'noopener,noreferrer')` or render a normal `<a target="_blank" rel="noopener noreferrer">` link.

## Changes

- `src/editor/components/modals/ModalHelp/components/DocumentationButton/DocumentationButton.component.jsx` (modified)