### PR TITLE
Fix crash in selectionBox when gltf-model loads after entity is detached

### DIFF
--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -472,12 +472,13 @@ export function Viewport(inspector) {
       } else if (object.el.hasAttribute('gltf-model')) {
         const listener = (event) => {
           if (event.target !== object.el) return; // we got an event for a child, ignore
+          object.el.removeEventListener('model-loaded', listener);
           // Some models have a wrong bounding box if we don't wait a bit
           setTimeout(() => {
+            if (object.parent === null) return; // entity was detached before timeout fired
             selectionBox.setFromObject(object);
             selectionBox.visible = true;
           }, 20);
-          object.el.removeEventListener('model-loaded', listener);
         };
         object.el.addEventListener('model-loaded', listener);
       } else if (!object.el.isScene && object.el.id !== 'street-container') {


### PR DESCRIPTION
Very rare case but could happen when you undo/redo a reparent action very quickly.

The model-loaded listener attached when selecting a gltf-model entity could fire (and its 20ms setTimeout could resolve) after the entity had been removed/reparented, calling setFromObject on a detached object3D and crashing in any helper update that dereferences this.object.parent.matrixWorld. Remove the listener up-front and bail when object.parent is null inside the timeout.