### PR TITLE
streetmix-parsers: drop dead object3D write in randomPosition, fix typo

### DIFF
--- a/src/aframe-streetmix-parsers.js
+++ b/src/aframe-streetmix-parsers.js
@@ -558,7 +558,7 @@ function createDriveLaneElement(
 
     const reusableObjectEl = document.createElement('a-entity');
 
-    if (!positionZ) {
+    if (positionZ === undefined) {
       positionZ = randomPosition(
         reusableObjectEl,
         'z',

--- a/src/aframe-streetmix-parsers.js
+++ b/src/aframe-streetmix-parsers.js
@@ -385,13 +385,9 @@ function randomPosition(entity, axis, length, objSizeAttr = undefined) {
   // place randomly an element on a line length='length' on the axis 'axis'
   // Need to call from 'model-loaded' event if objSizeAttr is undefined
   // existEnts - array with existing entities (for prevent intersection)
-  const newObject = entity.object3D;
-  const objSize = objSizeAttr || getDimensions(newObject)[axis];
+  const objSize = objSizeAttr || getDimensions(entity.object3D)[axis];
   const { start, end } = getStartEndPosition(length, objSize);
-  const setFunc = `set${axis.toUpperCase()}`;
-  const newPosition = getRandomArbitrary(start, end);
-  newObject.position[setFunc](newPosition);
-  return newPosition;
+  return getRandomArbitrary(start, end);
 }
 
 function createChooChooElement(
@@ -644,7 +640,7 @@ function createFoodTruckElement(variantList, length) {
     length,
     foodTruckLength
   );
-  reusableObjectEl.setAttribute('positon', '0 0 ' + positionZ);
+  reusableObjectEl.setAttribute('position', '0 0 ' + positionZ);
   foodTruckParentEl.append(reusableObjectEl);
 
   return foodTruckParentEl;

--- a/src/aframe-streetmix-parsers.js
+++ b/src/aframe-streetmix-parsers.js
@@ -1,5 +1,3 @@
-/* global THREE */
-
 // Orientation - default model orientation is "outbound" (away from camera)
 var streetmixParsersTested = require('./tested/aframe-streetmix-parsers-tested');
 var { segmentVariants } = require('./segments-variants.js');
@@ -364,15 +362,6 @@ function getBusLaneMixin(variant) {
   return 'bus-lane';
 }
 
-function getDimensions(object3d) {
-  var box = new THREE.Box3().setFromObject(object3d);
-  var x = box.max.x - box.min.x;
-  var y = box.max.y - box.min.y;
-  var z = box.max.z - box.min.z;
-
-  return { x, y, z };
-}
-
 function getStartEndPosition(streetLength, objectLength) {
   // get the start and end position for placing an object on a line
   // computed by length of the street and object's length
@@ -381,11 +370,8 @@ function getStartEndPosition(streetLength, objectLength) {
   return { start, end };
 }
 
-function randomPosition(entity, axis, length, objSizeAttr = undefined) {
-  // place randomly an element on a line length='length' on the axis 'axis'
-  // Need to call from 'model-loaded' event if objSizeAttr is undefined
-  // existEnts - array with existing entities (for prevent intersection)
-  const objSize = objSizeAttr || getDimensions(entity.object3D)[axis];
+function randomPosition(length, objSize) {
+  // place randomly an element on a line of length 'length'
   const { start, end } = getStartEndPosition(length, objSize);
   return getRandomArbitrary(start, end);
 }
@@ -405,7 +391,7 @@ function createChooChooElement(
   placedObjectEl.setAttribute('rotation', '0 ' + rotationY + ' 0');
   placedObjectEl.setAttribute('mixin', objectMixinId);
   placedObjectEl.setAttribute('class', objectMixinId);
-  const positionZ = randomPosition(placedObjectEl, 'z', length, tramLength);
+  const positionZ = randomPosition(length, tramLength);
   placedObjectEl.setAttribute('position', '0 0 ' + positionZ);
   return placedObjectEl;
 }
@@ -420,7 +406,7 @@ function createBusElement(variantList, length, showVehicles) {
   const busObjectEl = document.createElement('a-entity');
   busObjectEl.setAttribute('rotation', '0 ' + rotationY + ' 0');
   busObjectEl.setAttribute('mixin', 'bus');
-  const positionZ = randomPosition(busObjectEl, 'z', length, busLength);
+  const positionZ = randomPosition(length, busLength);
   busObjectEl.setAttribute('position', '0 0 ' + positionZ);
   busParentEl.append(busObjectEl);
 
@@ -559,12 +545,7 @@ function createDriveLaneElement(
     const reusableObjectEl = document.createElement('a-entity');
 
     if (positionZ === undefined) {
-      positionZ = randomPosition(
-        reusableObjectEl,
-        'z',
-        streetLength,
-        params['length']
-      );
+      positionZ = randomPosition(streetLength, params['length']);
     }
     reusableObjectEl.setAttribute('position', `0 0 ${positionZ}`);
     reusableObjectEl.setAttribute('mixin', params['mixin']);
@@ -634,12 +615,7 @@ function createFoodTruckElement(variantList, length) {
   reusableObjectEl.setAttribute('rotation', '0 ' + rotationY + ' 0');
   reusableObjectEl.setAttribute('mixin', 'food-trailer-rig');
 
-  const positionZ = randomPosition(
-    reusableObjectEl,
-    'z',
-    length,
-    foodTruckLength
-  );
+  const positionZ = randomPosition(length, foodTruckLength);
   reusableObjectEl.setAttribute('position', '0 0 ' + positionZ);
   foodTruckParentEl.append(reusableObjectEl);
 
@@ -685,7 +661,6 @@ function createOutdoorDining(length, posY) {
     const reusableObjectEl = document.createElement('a-entity');
     reusableObjectEl.setAttribute('mixin', 'outdoor_dining');
 
-    // const positionZ = randomPosition(reusableObjectEl, 'z', length, outdorDiningLength);
     reusableObjectEl.setAttribute('position', { x: 0, y: posY, z: randPosZ });
     outdoorDiningParentEl.append(reusableObjectEl);
   });


### PR DESCRIPTION
randomPosition wrote to entity.object3D.position[setFunc](newPosition) on a freshly-created entity. For createChooChoo/Bus/Car this was already dead — setAttribute('position', '0 0 ' + positionZ) ran right after and queued the same value. For createFoodTruckElement the setAttribute is typo'd as 'positon', so removing the dead write would have regressed the food truck to z=0; fix the typo so the position component takes over the placement.