### PR TITLE
guard atlas-uvs.update() in cloneMixinAsChildren when not yet mounted

### DIFF
--- a/src/aframe-streetmix-parsers.js
+++ b/src/aframe-streetmix-parsers.js
@@ -22,7 +22,10 @@ function cloneMixinAsChildren({
 
     if (length) {
       placedObjectEl.setAttribute('geometry', 'height', length);
-      placedObjectEl.components['atlas-uvs'].update();
+      // If parentEl is not yet mounted, atlas-uvs hasn't init'd; its init
+      // will read the new geometry.height once mounted. Only call update()
+      // if it's already initialized.
+      placedObjectEl.components['atlas-uvs']?.update();
     }
 
     if (randomY) {


### PR DESCRIPTION
That was missed with the manual testing in #1574 I just created a new scene importing the default example from streetmix and got the error atlas-uvs wasn't defined.

cloneMixinAsChildren is called with parentEls created via createStencilsParentElement that are not yet mounted (only appended to the segment later). The atlas-uvs component on placedObjectEl isn't initialized in that case, so calling update() on it threw TypeError on parking-lane sideways/angled variants.

Guard with optional chaining; when not yet initialized, atlas-uvs's init will read the current geometry.height once the subtree is mounted.