### PR TITLE
add hy-world-replicate cog deployment for tencent HY-World 2.0

### DIFF
--- a/hy-world-replicate/.dockerignore
+++ b/hy-world-replicate/.dockerignore
@@ -1,0 +1,11 @@
+README.md
+.gitignore
+.dockerignore
+__pycache__
+*.pyc
+.pytest_cache
+.venv
+samples
+*.zip
+*.mp4
+*.ply

--- a/hy-world-replicate/.gitignore
+++ b/hy-world-replicate/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.cog/
+.venv/
+samples/
+*.ply
+*.zip
+*.mp4
+inference_output/

--- a/hy-world-replicate/LICENSE
+++ b/hy-world-replicate/LICENSE
@@ -1,0 +1,29 @@
+MIT License
+
+Copyright (c) 2026 3DStreet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This license covers ONLY the wrapper code in this repository (cog.yaml,
+predict.py, helper scripts). The underlying HY-World 2.0 model weights and
+code are governed by Tencent's separate license terms — see
+https://github.com/Tencent-Hunyuan/HY-World-2.0 and
+https://huggingface.co/tencent/HY-World-2.0 before commercial use.

--- a/hy-world-replicate/README.md
+++ b/hy-world-replicate/README.md
@@ -1,0 +1,107 @@
+# HY-World 2.0 Replicate (cog)
+
+Cog deployment of [Tencent HY-World 2.0](https://github.com/Tencent-Hunyuan/HY-World-2.0) — specifically the **WorldMirror 2.0** reconstruction component, a unified feed-forward model that takes multi-view images or a video and predicts depth, surface normals, camera parameters, point clouds, and 3D Gaussian splats in a single pass.
+
+Modeled after [`kfarr/sharp-ml-replicate`](https://github.com/kfarr/sharp-ml-replicate).
+
+Model: https://huggingface.co/tencent/HY-World-2.0
+Paper / repo: https://github.com/Tencent-Hunyuan/HY-World-2.0
+
+## Files
+
+- `cog.yaml` — Build config (CUDA 12.4, Python 3.10, torch 2.4.0, prebuilt FlashAttention-2 + gsplat wheels, model weights baked in).
+- `predict.py` — Cog predictor (`Predictor`). Accepts a video or a zip of images, returns a zip of reconstructed assets.
+- `scripts/make_sample_zip.py` — Helper to package a directory of images into a `samples/scene.zip` for local `cog predict` runs.
+- `LICENSE` — MIT, covers the wrapper code only. The underlying model has its own Tencent Hunyuan license.
+
+## Inputs
+
+- `input_file` — A video (`.mp4`/`.mov`/...) **or** a `.zip` of multi-view images. A single image is also accepted.
+- `target_size` — Longest-edge resolution; resized to a multiple of 14. Default `952`.
+- `fps`, `video_max_frames` — Frame extraction controls for video input.
+- `save_gaussians`, `save_points`, `save_depth`, `save_normal`, `save_camera` — Toggle output assets.
+- `apply_sky_mask`, `apply_edge_mask` — Filter unreliable regions before reconstruction.
+- `compress_gs_max_points`, `compress_pts_max_points` — Caps on output density.
+
+## Output
+
+A single `.zip` containing the run directory, e.g.:
+
+```
+hy_world_output.zip
+├── gaussians.ply        # 3D Gaussian splatting (drop into 3DStreet / a splat viewer)
+├── points.ply           # Dense point cloud
+├── camera_params.json   # Predicted intrinsics + extrinsics per view
+├── depth/               # depth_0000.png + depth_0000.npy per view
+└── normal/              # normal_0000.png per view
+```
+
+`gaussians.ply` is the headline asset for 3DStreet workflows.
+
+## Build & push
+
+Get a CLI token from https://replicate.com/auth/token (different from the API token):
+
+```bash
+cog login --token-stdin
+# paste token, Enter, Ctrl+D
+
+cog push r8.im/<your-username>/hy-world
+```
+
+## Local test
+
+Package up a folder of images, then run a prediction:
+
+```bash
+python scripts/make_sample_zip.py /path/to/multi-view-images samples/scene.zip
+cog predict -i input_file=@samples/scene.zip -i target_size=952
+```
+
+Or with a video:
+
+```bash
+cog predict -i input_file=@samples/clip.mp4 -i fps=2 -i video_max_frames=24
+```
+
+## Calling from the Replicate API
+
+Once pushed, the model is invokable like any other Replicate model:
+
+```python
+import replicate
+
+output = replicate.run(
+    "<your-username>/hy-world:<version>",
+    input={
+        "input_file": open("scene.zip", "rb"),
+        "target_size": 952,
+        "fps": 2,
+    },
+)
+# `output` is a URL to the result zip — download and unzip it.
+```
+
+## Build notes
+
+- **FlashAttention** is installed from a prebuilt wheel (`flash-attn 2.7.0.post2`, cu12, torch 2.4, py310). Building from source on Replicate routinely exceeds the build timeout. If the wheel link 404s, generate a matching one from https://github.com/Dao-AILab/flash-attention/releases or fall back to building in `cog.yaml`'s `run:` step.
+- **gsplat** uses the upstream-blessed wheel (`v1.5.3+pt24cu124-cp310`).
+- Model weights (~6 GB) are pre-downloaded during build via `huggingface_hub.snapshot_download` so the first prediction doesn't pay the download cost.
+- `bf16` is enabled in `setup()` to keep activation memory in check on smaller GPUs (A40/L40 work; 24 GB cards may need to drop `target_size`).
+- `uniception` and `pycolmap==3.10.0` are upstream-required and unusual — keep them pinned.
+
+## Known limitations
+
+- Only the **WorldMirror 2.0** (reconstruction) component is wired up. The full text/image → world generation pipeline (HY-Pano 2.0, WorldNav, WorldStereo 2.0) is not yet released by Tencent as of this writing — wire those up here when they ship.
+- `--use_fsdp` multi-GPU mode is not exposed; Replicate predictions run on a single GPU.
+- Multi-view input must contain at least 2 views for a useful reconstruction.
+
+## Hardware
+
+Recommend an **A100 40GB** or **L40S** for default settings. A40 / L40 work but may need `target_size <= 800` and a smaller `video_max_frames`. Set the GPU tier on Replicate via `cog push` after configuring your model's hardware in the Replicate dashboard.
+
+## Attribution
+
+- Model and pipeline code: [Tencent HY-World 2.0](https://github.com/Tencent-Hunyuan/HY-World-2.0) — Tencent Hunyuan license.
+- Cog wrapper structure: inspired by [`kfarr/sharp-ml-replicate`](https://github.com/kfarr/sharp-ml-replicate).
+- Wrapper code in this repo: MIT (see `LICENSE`).

--- a/hy-world-replicate/cog.yaml
+++ b/hy-world-replicate/cog.yaml
@@ -1,0 +1,60 @@
+# Cog config for Tencent HY-World 2.0 (WorldMirror 2.0 reconstruction).
+# Mirrors the upstream environment: Python 3.10, CUDA 12.4, torch 2.4.0.
+# https://github.com/Tencent-Hunyuan/HY-World-2.0
+
+build:
+  gpu: true
+  cuda: "12.4"
+  python_version: "3.10"
+  system_packages:
+    - "git"
+    - "wget"
+    - "ninja-build"
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+    - "libsm6"
+    - "libxext6"
+    - "libxrender-dev"
+    - "ffmpeg"
+    - "libgomp1"
+  python_packages:
+    # Pinned to the upstream-tested versions.
+    - "torch==2.4.0"
+    - "torchvision==0.19.0"
+    - "numpy<2.0.0"
+    - "jaxtyping"
+    - "typeguard"
+    - "tqdm"
+    - "omegaconf"
+    - "plyfile"
+    - "colorspacious"
+    - "pydantic"
+    - "opencv-python"
+    - "scipy"
+    - "requests"
+    - "trimesh"
+    - "matplotlib"
+    - "pillow_heif"
+    - "onnxruntime"
+    - "einops"
+    - "torchmetrics"
+    - "uniception"
+    - "safetensors"
+    - "open3d==0.18.0"
+    - "pycolmap==3.10.0"
+    - "moviepy==1.0.3"
+    - "huggingface_hub"
+    - "imageio[ffmpeg]"
+    # Prebuilt gsplat wheel matching torch 2.4 / cu124 / cp310.
+    - "https://github.com/nerfstudio-project/gsplat/releases/download/v1.5.3/gsplat-1.5.3+pt24cu124-cp310-cp310-linux_x86_64.whl"
+  run:
+    # Clone the upstream pipeline code.
+    - "git clone --depth 1 https://github.com/Tencent-Hunyuan/HY-World-2.0 /opt/hy-world"
+    # FlashAttention 2 prebuilt wheel (cu12, torch 2.4, cxx11abiFALSE, py310).
+    # Building from source takes 30+ min and breaks Replicate build timeouts.
+    - "pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.0.post2/flash_attn-2.7.0.post2+cu12torch2.4cxx11abiFALSE-cp310-cp310-linux_x86_64.whl"
+    # Pre-download model weights (~6GB) so cold-start prediction is fast.
+    - "python -c 'from huggingface_hub import snapshot_download; snapshot_download(repo_id=\"tencent/HY-World-2.0\", allow_patterns=[\"HY-WorldMirror-2.0/*\"])'"
+    # Smoke test the import path so build fails early on missing deps.
+    - "cd /opt/hy-world && python -c 'from hyworld2.worldrecon.pipeline import WorldMirrorPipeline; print(\"WorldMirrorPipeline imports OK\")'"
+predict: "predict.py:Predictor"

--- a/hy-world-replicate/predict.py
+++ b/hy-world-replicate/predict.py
@@ -1,0 +1,208 @@
+"""
+Cog predictor for Tencent HY-World 2.0 (WorldMirror 2.0 reconstruction).
+
+Takes a video file or a zip of multi-view images and returns a zip of
+reconstructed 3D assets: gaussian splats (.ply), point cloud (.ply),
+depth maps, normal maps, and camera parameters.
+
+Upstream: https://github.com/Tencent-Hunyuan/HY-World-2.0
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+# Make the cloned upstream repo importable.
+sys.path.insert(0, "/opt/hy-world")
+
+import torch
+from cog import BasePredictor, Input, Path as CogPath
+
+
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp", ".heic"}
+
+
+def _is_video(path: Path) -> bool:
+    return path.suffix.lower() in VIDEO_EXTENSIONS
+
+
+def _extract_zip_of_images(zip_path: Path, dest_dir: Path) -> Path:
+    """Unzip into dest_dir and return the directory containing the images.
+
+    If the zip contains a single top-level folder, returns that folder.
+    Filters out hidden/system files (e.g. __MACOSX, .DS_Store).
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        for member in zf.infolist():
+            name = member.filename
+            if name.startswith("__MACOSX/") or name.endswith("/.DS_Store"):
+                continue
+            zf.extract(member, dest_dir)
+
+    entries = [p for p in dest_dir.iterdir() if not p.name.startswith(".")]
+    if len(entries) == 1 and entries[0].is_dir():
+        return entries[0]
+    return dest_dir
+
+
+def _zip_directory(src_dir: Path, zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, _, files in os.walk(src_dir):
+            for fname in files:
+                fpath = Path(root) / fname
+                zf.write(fpath, fpath.relative_to(src_dir))
+
+
+class Predictor(BasePredictor):
+    """Cog predictor wrapping WorldMirrorPipeline for image/video → 3D."""
+
+    def setup(self) -> None:
+        from hyworld2.worldrecon.pipeline import WorldMirrorPipeline
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA GPU required for HY-World 2.0 inference.")
+
+        print(f"CUDA device: {torch.cuda.get_device_name(0)}")
+        start = time.time()
+
+        # bf16 substantially reduces memory; weights are pre-cached in the
+        # image so this just loads from local HF cache.
+        self.pipeline = WorldMirrorPipeline.from_pretrained(
+            "tencent/HY-World-2.0",
+            subfolder="HY-WorldMirror-2.0",
+            enable_bf16=True,
+        )
+        print(f"Pipeline ready in {time.time() - start:.1f}s")
+
+    def predict(
+        self,
+        input_file: CogPath = Input(
+            description=(
+                "A video file (mp4/mov/etc.) or a .zip archive of multi-view "
+                "images. With a video, frames are extracted at the given fps."
+            ),
+        ),
+        target_size: int = Input(
+            description=(
+                "Maximum resolution (longest edge). Images are resized and "
+                "center-cropped to the nearest multiple of 14."
+            ),
+            default=952,
+            ge=224,
+            le=1568,
+        ),
+        fps: int = Input(
+            description="Frames-per-second to extract from a video input.",
+            default=1,
+            ge=1,
+            le=30,
+        ),
+        video_max_frames: int = Input(
+            description="Maximum number of frames to use from a video input.",
+            default=32,
+            ge=2,
+            le=128,
+        ),
+        save_gaussians: bool = Input(
+            description="Save 3D Gaussian splats (gaussians.ply).",
+            default=True,
+        ),
+        save_points: bool = Input(
+            description="Save dense point cloud (points.ply).",
+            default=True,
+        ),
+        save_depth: bool = Input(
+            description="Save per-view depth maps (PNG previews + .npy).",
+            default=True,
+        ),
+        save_normal: bool = Input(
+            description="Save per-view surface-normal maps.",
+            default=True,
+        ),
+        save_camera: bool = Input(
+            description="Save predicted camera parameters (camera_params.json).",
+            default=True,
+        ),
+        apply_sky_mask: bool = Input(
+            description="Mask out the sky region before reconstruction.",
+            default=True,
+        ),
+        apply_edge_mask: bool = Input(
+            description="Mask out unreliable depth/normal discontinuities.",
+            default=True,
+        ),
+        compress_gs_max_points: int = Input(
+            description="Max number of gaussians to retain in the output PLY.",
+            default=5_000_000,
+            ge=100_000,
+            le=20_000_000,
+        ),
+        compress_pts_max_points: int = Input(
+            description="Max number of points to retain in points.ply.",
+            default=2_000_000,
+            ge=100_000,
+            le=10_000_000,
+        ),
+    ) -> CogPath:
+        """Run reconstruction and return a zip of all generated assets."""
+        in_path = Path(str(input_file))
+
+        # Stage the input. The upstream pipeline takes either a directory of
+        # images or a video file path, so we hand it whichever applies.
+        work_dir = Path(tempfile.mkdtemp(prefix="hyw_in_"))
+        try:
+            if in_path.suffix.lower() == ".zip":
+                pipeline_input = str(_extract_zip_of_images(in_path, work_dir))
+            elif _is_video(in_path):
+                # Cog hands us a temp file with no extension preserved on disk,
+                # but `in_path` keeps the original suffix — pass it directly.
+                pipeline_input = str(in_path)
+            elif in_path.suffix.lower() in IMAGE_EXTENSIONS:
+                # Single-image edge case: place it in a directory.
+                staged = work_dir / in_path.name
+                shutil.copy2(in_path, staged)
+                pipeline_input = str(work_dir)
+            else:
+                raise ValueError(
+                    f"Unsupported input '{in_path.name}'. Provide a video, "
+                    "a single image, or a .zip of images."
+                )
+
+            out_root = Path(tempfile.mkdtemp(prefix="hyw_out_"))
+            run_dir = out_root / "run"
+            run_dir.mkdir(parents=True, exist_ok=True)
+
+            t0 = time.time()
+            self.pipeline(
+                input_path=pipeline_input,
+                output_path=str(out_root),
+                strict_output_path=str(run_dir),
+                target_size=target_size,
+                fps=fps,
+                video_max_frames=video_max_frames,
+                save_depth=save_depth,
+                save_normal=save_normal,
+                save_gs=save_gaussians,
+                save_camera=save_camera,
+                save_points=save_points,
+                apply_sky_mask=apply_sky_mask,
+                apply_edge_mask=apply_edge_mask,
+                compress_gs_max_points=compress_gs_max_points,
+                compress_pts_max_points=compress_pts_max_points,
+            )
+            print(f"Reconstruction took {time.time() - t0:.1f}s")
+
+            # If the pipeline ignored strict_output_path and wrote into a
+            # timestamped subdir under out_root, fall back to zipping that.
+            zip_src = run_dir if any(run_dir.iterdir()) else out_root
+            zip_path = Path(tempfile.mkdtemp(prefix="hyw_zip_")) / "hy_world_output.zip"
+            _zip_directory(zip_src, zip_path)
+            return CogPath(zip_path)
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/hy-world-replicate/scripts/make_sample_zip.py
+++ b/hy-world-replicate/scripts/make_sample_zip.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Pack a directory of images into a zip for `cog predict -i input_file=@...`.
+
+Usage:
+    python scripts/make_sample_zip.py /path/to/images samples/scene.zip
+"""
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp", ".heic"}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("src", type=Path, help="Directory of images")
+    p.add_argument("dest", type=Path, help="Output .zip path")
+    args = p.parse_args()
+
+    if not args.src.is_dir():
+        print(f"error: {args.src} is not a directory", file=sys.stderr)
+        return 1
+
+    images = sorted(
+        f for f in args.src.iterdir()
+        if f.is_file() and f.suffix.lower() in IMAGE_EXTS
+    )
+    if not images:
+        print(f"error: no images found in {args.src}", file=sys.stderr)
+        return 1
+
+    args.dest.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(args.dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for img in images:
+            zf.write(img, img.name)
+
+    print(f"wrote {len(images)} images to {args.dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Wraps the WorldMirror 2.0 reconstruction component (multi-view images
or video -> gaussians.ply, points.ply, depth, normals, cameras) for
deployment on Replicate, mirroring the structure of sharp-ml-replicate.

Bakes the ~6GB HuggingFace weights into the image at build time and
uses prebuilt FlashAttention-2 + gsplat wheels to keep build times
within Replicate's timeout.