### PR TITLE
fix: remove validation guards from SegmentAddCommand.execute, validate at caller

### DIFF
--- a/src/editor/lib/commands/SegmentAddCommand.js
+++ b/src/editor/lib/commands/SegmentAddCommand.js
@@ -34,24 +34,11 @@ export class SegmentAddCommand extends Command {
       console.error(`[segmentadd] street ${this.streetId} not found`);
       return;
     }
-
     const segment = this.segment;
-    if (!segment || !segment.type) {
-      throw new Error('SegmentAddCommand: segment.type is required');
-    }
 
     const segmentEntities = Array.from(streetEl.children).filter((child) =>
       child.hasAttribute('street-segment')
     );
-
-    if (
-      this.segmentIndex !== undefined &&
-      (this.segmentIndex < 0 || this.segmentIndex > segmentEntities.length)
-    ) {
-      throw new Error(
-        `SegmentAddCommand: invalid segmentIndex ${this.segmentIndex}`
-      );
-    }
 
     const segmentEl = document.createElement('a-entity');
     segmentEl.id = this.entityId;

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -85,6 +85,12 @@ async function managedStreetUpdateHandler(args) {
     if (!segment || !segment.type) {
       throw new Error('Segment must have at least a type property');
     }
+    if (
+      segmentIndex !== undefined &&
+      (segmentIndex < 0 || segmentIndex > segmentEntities.length)
+    ) {
+      throw new Error(`Invalid segmentIndex: ${segmentIndex}`);
+    }
     const label = segment.name || `${segment.type} • default`;
     // segmentadd takes streetId (string), not the resolved element, because
     // its execute() runs on redo too — the parent DOM may have been recreated


### PR DESCRIPTION
Validation belongs at the call site, not inside execute(). Remove all three guards from execute() (streetEl null check, segment.type check, segmentIndex range check). Add segmentIndex range validation for add-segment to managedStreetUpdateHandler where it belongs.