### PR TITLE
mcp: auto-pair via #mcp URL + post-pair workflow nudge

### DIFF
--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -746,6 +746,26 @@ function AIChatPanel() {
     postPairSuccess();
   }, [mcp.status]);
 
+  // Drop the pending-pair intent if retries stop (`mcpVisible` off → the
+  // hook idles) or the connection was kicked by another tab
+  // (`paired-elsewhere` doesn't auto-recover). Without this, a stale
+  // `awaitingPairRef = true` would survive forever and a much later
+  // reconnect — long after the user moved on — would surface a confusing
+  // "MCP relay paired" message. Unmount cleanup is split into its own
+  // mount-only effect so it doesn't fire on every status flip and race
+  // the success effect above.
+  useEffect(() => {
+    if (mcp.status === 'paired-elsewhere' || !mcpVisible) {
+      awaitingPairRef.current = false;
+    }
+  }, [mcp.status, mcpVisible]);
+
+  useEffect(() => {
+    return () => {
+      awaitingPairRef.current = false;
+    };
+  }, []);
+
   // Auto-pair on `#mcp` (or `#mcp=PORT`) URL fragment. Equivalent to the
   // user typing `/mcp` and clicking Reconnect, but skips the manual step
   // entirely — the relay's startup banner prints this URL so the only

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -763,9 +763,11 @@ function AIChatPanel() {
       postPairSuccess();
     } else {
       awaitingPairRef.current = true;
-      if (mcp.status !== 'connecting') {
-        mcp.reconnect();
-      }
+      // Idempotent: reconnect() no-ops if the hook's mount probe is
+      // already in flight (CONNECTING) or has already paired (OPEN).
+      // Calling it unconditionally also covers the case where the
+      // probe gave up in idle mode and we need a fresh attempt.
+      mcp.reconnect();
     }
     // Strip the hash so a refresh doesn't re-trigger and the URL bar isn't
     // cluttered. `replaceState` keeps history clean (no stale forward entry).

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -703,8 +703,14 @@ function AIChatPanel() {
   const { currentUser } = useAuthContext();
   const setModal = useStore((state) => state.setModal);
   const rightPanelTab = useStore((state) => state.rightPanelTab);
+  const setRightPanelTab = useStore((state) => state.setRightPanelTab);
 
   const modelRef = useRef(null);
+  // Set when the user explicitly opts into MCP (typed `/mcp` or arrived via
+  // the auto-pair URL). Used to gate the post-pair success message so users
+  // who never engaged with MCP don't see a "return to your MCP client"
+  // message they have no context for.
+  const awaitingPairRef = useRef(false);
 
   const mcp = useMCPClient({
     currentUser,
@@ -715,9 +721,54 @@ function AIChatPanel() {
   });
 
   // First successful pair "unlocks" the bar for the rest of the session.
+  // When the user explicitly engaged (`/mcp` or auto-pair URL), also post a
+  // confirmation in the chat so they know to switch back to their MCP
+  // client to continue the workflow.
   useEffect(() => {
-    if (mcp.status === 'connected') setMcpVisible(true);
+    if (mcp.status !== 'connected') return;
+    setMcpVisible(true);
+    if (!awaitingPairRef.current) return;
+    awaitingPairRef.current = false;
+    setMessages((prev) => [
+      ...prev,
+      {
+        role: 'assistant',
+        content:
+          '**MCP relay paired.** Tool calls from your MCP client are now wired through this tab. Return to **Claude** (or whichever MCP client you launched the relay from) to continue your workflow — you can leave this tab open in the background.',
+        timestamp: new Date()
+      }
+    ]);
   }, [mcp.status]);
+
+  // Auto-pair on `#mcp` (or `#mcp=PORT`) URL fragment. Equivalent to the
+  // user typing `/mcp` and clicking Reconnect, but skips the manual step
+  // entirely — the relay's startup banner prints this URL so the only
+  // pairing action is opening the link.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash || '';
+    if (!/^#mcp(?:=\d+)?$/.test(hash)) return;
+    setRightPanelTab('console');
+    setMcpVisible(true);
+    awaitingPairRef.current = true;
+    if (mcp.status !== 'connected' && mcp.status !== 'connecting') {
+      mcp.reconnect();
+    }
+    // Strip the hash so a refresh doesn't re-trigger and the URL bar isn't
+    // cluttered. `replaceState` keeps history clean (no stale forward entry).
+    try {
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      );
+    } catch {
+      // best-effort — older browsers without replaceState just keep the hash
+    }
+    // Mount-only: read the URL once at startup. Subsequent pairing should
+    // go through the normal `/mcp` command flow.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Interleave Gemini chat messages with incoming MCP frames so a single
   // chronological feed shows both LLM channels. Both arrays already carry
@@ -1221,6 +1272,7 @@ function AIChatPanel() {
 
   const showMCPHelpMessage = (rawInput) => {
     setMcpVisible(true);
+    awaitingPairRef.current = true;
     if (mcp.status !== 'connected' && mcp.status !== 'connecting') {
       mcp.reconnect();
     }

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -96,6 +96,9 @@ claude mcp add 3dstreet -- npx -y 3dstreet-mcp
 
 Then click **Reconnect** above. Once paired, the relay forwards Claude's tool calls to this tab. Toggle **Read-only** to block scene mutations. Source and docs: [github.com/3DStreet/3dstreet-mcp](https://github.com/3DStreet/3dstreet-mcp).`;
 
+const MCP_PAIR_SUCCESS_MARKDOWN =
+  '**MCP relay paired.** Tool calls from your MCP client are now wired through this tab. Return to **Claude** (or whichever MCP client you launched the relay from) to continue your workflow — you can leave this tab open in the background.';
+
 // Helper component for the copy button
 const CopyButton = ({ jsonData, textContent }) => {
   const [copied, setCopied] = useState(false);
@@ -720,24 +723,27 @@ function AIChatPanel() {
     persistRetries: mcpVisible
   });
 
+  const postPairSuccess = () => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        role: 'assistant',
+        content: MCP_PAIR_SUCCESS_MARKDOWN,
+        timestamp: new Date()
+      }
+    ]);
+  };
+
   // First successful pair "unlocks" the bar for the rest of the session.
-  // When the user explicitly engaged (`/mcp` or auto-pair URL), also post a
-  // confirmation in the chat so they know to switch back to their MCP
-  // client to continue the workflow.
+  // When the user explicitly engaged (`/mcp` or auto-pair URL) and the
+  // status transitions to 'connected', post a confirmation in the chat so
+  // they know to switch back to their MCP client to continue the workflow.
   useEffect(() => {
     if (mcp.status !== 'connected') return;
     setMcpVisible(true);
     if (!awaitingPairRef.current) return;
     awaitingPairRef.current = false;
-    setMessages((prev) => [
-      ...prev,
-      {
-        role: 'assistant',
-        content:
-          '**MCP relay paired.** Tool calls from your MCP client are now wired through this tab. Return to **Claude** (or whichever MCP client you launched the relay from) to continue your workflow — you can leave this tab open in the background.',
-        timestamp: new Date()
-      }
-    ]);
+    postPairSuccess();
   }, [mcp.status]);
 
   // Auto-pair on `#mcp` (or `#mcp=PORT`) URL fragment. Equivalent to the
@@ -750,9 +756,16 @@ function AIChatPanel() {
     if (!/^#mcp(?:=\d+)?$/.test(hash)) return;
     setRightPanelTab('console');
     setMcpVisible(true);
-    awaitingPairRef.current = true;
-    if (mcp.status !== 'connected' && mcp.status !== 'connecting') {
-      mcp.reconnect();
+    if (mcp.status === 'connected') {
+      // Already paired (panel remount, hot reload, etc). The transition
+      // effect won't fire because there's no status change, so emit the
+      // confirmation inline instead of leaving the user without feedback.
+      postPairSuccess();
+    } else {
+      awaitingPairRef.current = true;
+      if (mcp.status !== 'connecting') {
+        mcp.reconnect();
+      }
     }
     // Strip the hash so a refresh doesn't re-trigger and the URL bar isn't
     // cluttered. `replaceState` keeps history clean (no stale forward entry).

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -97,7 +97,7 @@ claude mcp add 3dstreet -- npx -y 3dstreet-mcp
 Then click **Reconnect** above. Once paired, the relay forwards Claude's tool calls to this tab. Toggle **Read-only** to block scene mutations. Source and docs: [github.com/3DStreet/3dstreet-mcp](https://github.com/3DStreet/3dstreet-mcp).`;
 
 const MCP_PAIR_SUCCESS_MARKDOWN =
-  '**MCP relay paired.** Tool calls from your MCP client are now wired through this tab. Return to **Claude** (or whichever MCP client you launched the relay from) to continue your workflow — you can leave this tab open in the background.';
+  '**MCP relay paired.** Tool calls from your MCP client are now wired through this tab. Return to **Claude** (or whichever MCP client you launched the relay from) to continue your workflow. Keep this tab open in the background.';
 
 // Helper component for the copy button
 const CopyButton = ({ jsonData, textContent }) => {

--- a/src/editor/lib/mcp/useMCPClient.js
+++ b/src/editor/lib/mcp/useMCPClient.js
@@ -22,16 +22,23 @@ const MAX_BACKOFF_MS = 30_000;
 const PAIRED_ELSEWHERE_CODE = 4001;
 
 // `#mcp` (auto-pair URL emitted by the relay) optionally encodes a port as
-// `#mcp=PORT`. Take the hash first since it's the documented form; fall back
-// to the legacy `?mcp=PORT` query for backwards compatibility.
+// `#mcp=PORT`. The hash, when present, takes precedence — bare `#mcp`
+// resolves to DEFAULT_PORT even if a `?mcp=PORT` query is also set, since
+// the auto-pair URL is the explicit user intent. The legacy `?mcp=PORT`
+// query remains as a fallback for URLs without the hash.
 const resolvePort = () => {
   if (typeof window === 'undefined') return DEFAULT_PORT;
   const hashMatch = (window.location.hash || '').match(/^#mcp(?:=(\d+))?$/);
-  if (hashMatch && hashMatch[1]) {
-    const fromHash = parseInt(hashMatch[1], 10);
-    if (Number.isFinite(fromHash) && fromHash > 0 && fromHash < 65536) {
-      return fromHash;
+  if (hashMatch) {
+    if (hashMatch[1]) {
+      const fromHash = parseInt(hashMatch[1], 10);
+      if (Number.isFinite(fromHash) && fromHash > 0 && fromHash < 65536) {
+        return fromHash;
+      }
+      // Out-of-range port digits in the hash: don't silently fall through
+      // to the query param, since the user wrote a hash. Use the default.
     }
+    return DEFAULT_PORT;
   }
   const params = new URLSearchParams(window.location.search);
   const fromQuery = parseInt(params.get('mcp'), 10);

--- a/src/editor/lib/mcp/useMCPClient.js
+++ b/src/editor/lib/mcp/useMCPClient.js
@@ -21,8 +21,18 @@ const MAX_TRANSCRIPT = 200;
 const MAX_BACKOFF_MS = 30_000;
 const PAIRED_ELSEWHERE_CODE = 4001;
 
+// `#mcp` (auto-pair URL emitted by the relay) optionally encodes a port as
+// `#mcp=PORT`. Take the hash first since it's the documented form; fall back
+// to the legacy `?mcp=PORT` query for backwards compatibility.
 const resolvePort = () => {
   if (typeof window === 'undefined') return DEFAULT_PORT;
+  const hashMatch = (window.location.hash || '').match(/^#mcp(?:=(\d+))?$/);
+  if (hashMatch && hashMatch[1]) {
+    const fromHash = parseInt(hashMatch[1], 10);
+    if (Number.isFinite(fromHash) && fromHash > 0 && fromHash < 65536) {
+      return fromHash;
+    }
+  }
   const params = new URLSearchParams(window.location.search);
   const fromQuery = parseInt(params.get('mcp'), 10);
   if (Number.isFinite(fromQuery) && fromQuery > 0 && fromQuery < 65536) {

--- a/src/editor/lib/mcp/useMCPClient.js
+++ b/src/editor/lib/mcp/useMCPClient.js
@@ -227,6 +227,16 @@ export function useMCPClient({ currentUser, readOnly, persistRetries }) {
     // successful pairing so subsequent drops trigger backoff retries.
     everConnectedRef.current = true;
     if (wsRef.current) {
+      const state = wsRef.current.readyState;
+      if (state === WebSocket.OPEN || state === WebSocket.CONNECTING) {
+        // Already paired or handshake in flight — don't tear it down.
+        // Without this guard, an auto-pair URL that fires reconnect()
+        // during the hook's own mount probe races a fresh socket
+        // against the relay's still-set peer, landing on close code
+        // 4001 `paired-elsewhere` and showing the user a red status
+        // bar plus a transient "MCP relay paired" chat message.
+        return;
+      }
       try {
         wsRef.current.close(1000, 'manual-reconnect');
       } catch {

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -610,6 +610,12 @@ AFRAME.registerComponent('set-loader-from-hash', {
       if (!streetURL) {
         return;
       }
+      // `#mcp` (with optional `=PORT`) is the MCP relay auto-pair URL —
+      // handled by AIChatPanel, not the scene loader. Without this bail,
+      // the dispatcher would fall through to fetchJSON('mcp.json') below.
+      if (/^mcp(=\d+)?$/.test(streetURL)) {
+        return;
+      }
       if (streetURL.startsWith('crushed-3dstreet-json:')) {
         const fragment = window.location.hash;
         const prefix = '#crushed-3dstreet-json:';


### PR DESCRIPTION
## Summary

- Adds a one-click pairing flow for the MCP relay: opening `https://3dstreet.app/#mcp` (or `#mcp=PORT` for non-default ports) auto-switches to the **Console** tab, opens the MCP status bar, and triggers reconnect — equivalent to typing `/mcp` and clicking Reconnect, but with zero manual steps. The relay's startup banner already prints this URL ([3DStreet/3dstreet-mcp main](https://github.com/3DStreet/3dstreet-mcp/commits/main/)), so pairing becomes "click the link the relay printed."
- Posts a success message in the Console after pairing that points the user back to their MCP client (Claude Desktop / Claude Code / etc.) to continue the workflow there. Users who never opted in still see nothing — the message is gated on explicit `/mcp` or `#mcp` engagement.
- `?mcp=PORT` query param is preserved as a fallback for backwards compatibility.

## Files

- `src/editor/lib/mcp/useMCPClient.js` — `resolvePort()` now also reads `#mcp=PORT` from the URL hash (hash takes precedence over query).
- `src/editor/components/scenegraph/AIChatPanel.jsx` — adds the auto-pair-on-hash mount effect, threads an `awaitingPair` flag through `/mcp` and the auto-pair effect, and emits a confirmation message on the next `status === 'connected'` transition.

## Pairs with

[3DStreet/3dstreet-mcp](https://github.com/3DStreet/3dstreet-mcp) `main` — relay now logs the `https://3dstreet.app/#mcp` URL on startup and includes it in the "no peer connected" timeout error so the LLM can hand it back to the user.

## Test plan

- [ ] Open `https://3dstreet.app/#mcp` (with relay running on 51735) → console tab opens, status bar shows pairing → connected → success message appears
- [ ] Open `https://3dstreet.app/#mcp=12345` (relay on `--port 12345`) → same flow, port respected
- [ ] Refresh the page after auto-pair: hash is stripped, no re-trigger
- [ ] Type `/mcp` manually → success message still appears on first connect
- [ ] Open `https://3dstreet.app` with no hash → no MCP UI surfaces (existing behavior preserved)
- [ ] `?mcp=PORT` legacy form still resolves the port correctly