### PR TITLE
fix(mcp): skip mount probe unless URL signals MCP intent

### DIFF
--- a/src/editor/lib/mcp/useMCPClient.js
+++ b/src/editor/lib/mcp/useMCPClient.js
@@ -48,6 +48,21 @@ const resolvePort = () => {
   return DEFAULT_PORT;
 };
 
+// True when the URL carries explicit MCP pairing intent (the relay's
+// auto-pair `#mcp` hash or the legacy `?mcp=PORT` query). Used to gate the
+// mount probe — without this, every page load opens a WebSocket to the
+// relay port and the browser logs `WebSocket connection failed` for users
+// who never installed the relay. JS error handlers can't suppress that
+// log, so the only fix is to not open the socket. Users who later opt in
+// via `/mcp` still trigger a connect through `reconnect()`.
+const hasMCPIntent = () => {
+  if (typeof window === 'undefined') return false;
+  if (/^#mcp(?:=\d+)?$/.test(window.location.hash || '')) return true;
+  const params = new URLSearchParams(window.location.search);
+  const fromQuery = parseInt(params.get('mcp'), 10);
+  return Number.isFinite(fromQuery) && fromQuery > 0 && fromQuery < 65536;
+};
+
 export function useMCPClient({ currentUser, readOnly, persistRetries }) {
   const [status, setStatus] = useState('disconnected');
   const [lastError, setLastError] = useState(null);
@@ -202,10 +217,14 @@ export function useMCPClient({ currentUser, readOnly, persistRetries }) {
     connectRef.current = connect;
   }, [connect]);
 
-  // Probe on mount, tear down on unmount.
+  // Probe on mount only when the URL signals explicit intent; tear down on
+  // unmount. Skipping the probe for everyone else keeps the browser from
+  // logging a `WebSocket connection failed` line on every session for users
+  // who don't run the MCP relay. Typing `/mcp` later still pairs via
+  // `reconnect()`.
   useEffect(() => {
     backoffRef.current = 1000;
-    connect();
+    if (hasMCPIntent()) connect();
     return () => {
       clearReconnectTimer();
       const sock = wsRef.current;


### PR DESCRIPTION
## Summary

Fixes the `WebSocket connection to 'ws://127.0.0.1:51735/' failed` console error that appears on every editor session for users who don't run the MCP relay.

## Root cause

`useMCPClient.js` opened a probe WebSocket on every mount, intending to be "quiet" if the relay wasn't running (see existing comment at `useMCPClient.js:102-103`: *"Probe mode: one shot, then idle. Avoids spamming console with connection errors for users who never installed the relay."*). The intent was correct, but browsers log `WebSocket connection failed` unconditionally when a socket fails to open — no JS error handler can suppress that line. So every user, MCP or not, got a console error per session.

## Fix

Gate the mount probe on a new `hasMCPIntent()` helper that checks for the explicit pairing signals already used by the rest of the hook:

- `#mcp` / `#mcp=PORT` — the auto-pair URL the relay banner prints
- `?mcp=PORT` — legacy query fallback

Users without those signals get no probe and no console error. The existing opt-in paths still work unchanged:

- Auto-pair URL → `hasMCPIntent()` is true, probes immediately
- `/mcp` slash command → calls `mcp.reconnect()` (`AIChatPanel.jsx:1312`), which connects regardless of mount probe state
- `?mcp=PORT` → `hasMCPIntent()` is true, probes immediately

## Test plan

- [ ] Load the editor with no `#mcp` hash and no `?mcp` query — verify no `WebSocket connection failed` line in console
- [ ] Load the editor with `#mcp` — verify it auto-pairs and the chat shows the pair-success message
- [ ] Load the editor with `?mcp=51735` — verify it probes and pairs
- [ ] Type `/mcp` in the chat with no relay running — verify the MCP UI appears and surfaces the connection failure status (existing behavior, not regressed)
- [ ] Type `/mcp` with the relay running — verify it pairs successfully


---
_Generated by [Claude Code](https://claude.ai/code/session_015KfqrZMUZRtGDHrH2sEczb)_