### PR TITLE
fix(analytics): attach source to modal_opened in checkout funnel

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -145,7 +145,10 @@ const useStore = create(
           // we accept losing the deeper return in that case rather than
           // building a multi-level stack.
           const currentModal = useStore.getState().modal;
-          posthog.capture('modal_opened', { modal: 'payment' });
+          posthog.capture('modal_opened', {
+            modal: 'payment',
+            source: postCheckout
+          });
           set({
             modal: 'payment',
             postCheckout,


### PR DESCRIPTION
## Summary

Closes #1622.

`modal_opened` (with `modal: 'payment'`) was the only event in the embedded-checkout funnel that did not carry a `source` property, blocking per-surface segmentation of top-of-funnel opens in PostHog. Every downstream event (`checkout_started`, `checkout_session_created`, `checkout_canceled`, `payment_completed`) already captures `source`, derived from the same `postCheckout` argument that `startCheckout()` receives.

This adds `source: postCheckout` to the `posthog.capture('modal_opened', …)` call in `src/store.js`. All existing call sites (`geo`, `watermark`, `image`, `export`, `profile`, `addlayer` — see `src/shared/components/UpgradeModal/paywallSurfaces.jsx`) already pass a surface string, so no call-site changes are needed.

## Test plan

- [ ] Trigger each paywall surface (geo, watermark, image, export, profile, addlayer) and confirm the resulting `modal_opened` event in PostHog has `source` set to the matching surface
- [ ] Confirm `source` aligns with the value on the subsequent `checkout_started` event for the same session
- [ ] Spot-check that no `modal_opened` events with `modal: 'payment'` are emitted with `source: null` after rollout

https://claude.ai/code/session_01VnuqPr5TxPPkWG3iVTeVPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnuqPr5TxPPkWG3iVTeVPS)_