### PR TITLE
perf: reduce initial bundle size (#1624)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
   <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@6a054e85953bbcc71854bcd64f9abde0897be649/dist/aframe-master.min.js"></script>
   <!-- 3dstreet -->
   <script src="/dist/aframe-street-component.js"></script>
-  <!-- mapbox -->
-  <script src="/dist/aframe-mapbox-component.min.js"></script>
 
   <!-- viewer controls - vr teleport -->
   <script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls@0.4.3/dist/aframe-blink-controls.min.js"></script>

--- a/public/functions/webxr-variant.js
+++ b/public/functions/webxr-variant.js
@@ -13,8 +13,6 @@ exports.serveWebXRVariant = functions.https.onRequest((req, res) => {
   <script src="https://aframe.io/releases/1.7.1/aframe.min.js"></script>
   <!-- 3dstreet -->
   <script src="/dist/aframe-street-component.js"></script>
-  <!-- mapbox -->
-  <script src="/dist/aframe-mapbox-component.min.js"></script>
 
   <!-- viewer controls - vr teleport -->
   <script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls@0.4.3/dist/aframe-blink-controls.min.js"></script>

--- a/src/aframe-components/street-geo.js
+++ b/src/aframe-components/street-geo.js
@@ -132,32 +132,48 @@ AFRAME.registerComponent('street-geo', {
   mapbox2dCreate: function () {
     const data = this.data;
     const el = this.el;
+    const self = this;
 
-    const mapbox2dElement = document.createElement('a-entity');
-    mapbox2dElement.setAttribute('data-layer-name', 'Mapbox Satellite Streets');
-    mapbox2dElement.setAttribute(
-      'geometry',
-      'primitive: plane; width: 512; height: 512;'
-    );
-    mapbox2dElement.setAttribute(
-      'material',
-      'color: #ffffff; shader: flat; side: both; transparent: true;'
-    );
-    mapbox2dElement.setAttribute('rotation', '-90 -90 0');
-    mapbox2dElement.setAttribute('anisotropy', '');
-    mapbox2dElement.setAttribute('mapbox', {
-      accessToken: MAPBOX_ACCESS_TOKEN_VALUE,
-      center: `${data.longitude}, ${data.latitude}`,
-      zoom: 18,
-      style: 'mapbox://styles/mapbox/satellite-streets-v11',
-      pxToWorldRatio: 4
-    });
-    mapbox2dElement.classList.add('autocreated');
-    mapbox2dElement.setAttribute('data-ignore-raycaster', '');
-    mapbox2dElement.setAttribute('data-no-transform', '');
-    el.appendChild(mapbox2dElement);
-    this['mapbox2d'] = mapbox2dElement;
-    document.getElementById('map-copyright').textContent = 'MapBox';
+    const createMapbox2dElement = () => {
+      const mapbox2dElement = document.createElement('a-entity');
+      mapbox2dElement.setAttribute(
+        'data-layer-name',
+        'Mapbox Satellite Streets'
+      );
+      mapbox2dElement.setAttribute(
+        'geometry',
+        'primitive: plane; width: 512; height: 512;'
+      );
+      mapbox2dElement.setAttribute(
+        'material',
+        'color: #ffffff; shader: flat; side: both; transparent: true;'
+      );
+      mapbox2dElement.setAttribute('rotation', '-90 -90 0');
+      mapbox2dElement.setAttribute('anisotropy', '');
+      mapbox2dElement.setAttribute('mapbox', {
+        accessToken: MAPBOX_ACCESS_TOKEN_VALUE,
+        center: `${data.longitude}, ${data.latitude}`,
+        zoom: 18,
+        style: 'mapbox://styles/mapbox/satellite-streets-v11',
+        pxToWorldRatio: 4
+      });
+      mapbox2dElement.classList.add('autocreated');
+      mapbox2dElement.setAttribute('data-ignore-raycaster', '');
+      mapbox2dElement.setAttribute('data-no-transform', '');
+      el.appendChild(mapbox2dElement);
+      self['mapbox2d'] = mapbox2dElement;
+      document.getElementById('map-copyright').textContent = 'MapBox';
+    };
+
+    // check whether the library has been imported. Download if not
+    if (AFRAME.components['mapbox']) {
+      createMapbox2dElement();
+    } else {
+      loadScript(
+        new URL('/src/lib/aframe-mapbox-component.min.js', import.meta.url),
+        createMapbox2dElement
+      );
+    }
   },
   google3dCreate: function () {
     const data = this.data;

--- a/src/editor/components/elements/CommonComponents.js
+++ b/src/editor/components/elements/CommonComponents.js
@@ -63,9 +63,10 @@ export default class CommonComponents extends React.Component {
     });
   }
 
-  exportToGLTF() {
+  async exportToGLTF() {
     const entity = this.props.entity;
-    AFRAME.INSPECTOR.exporters.gltf.parse(
+    const exporter = await AFRAME.INSPECTOR.getGLTFExporter();
+    exporter.parse(
       entity.object3D,
       function (buffer) {
         const blob = new Blob([buffer], { type: 'application/octet-stream' });

--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -167,7 +167,7 @@ const AppMenu = ({ currentUser }) => {
     setRightPanelTab('console');
   };
 
-  const exportSceneToGLTF = (arReady) => {
+  const exportSceneToGLTF = async (arReady) => {
     if (authUser?.isPro) {
       try {
         posthog.capture('export_initiated', {
@@ -190,8 +190,9 @@ const AppMenu = ({ currentUser }) => {
           filterRiggedEntities(scene, false);
         }
         filterHelpers(scene, false);
+        const gltfExporter = await AFRAME.INSPECTOR.getGLTFExporter();
         // Modified to handle post-processing
-        AFRAME.INSPECTOR.exporters.gltf.parse(
+        gltfExporter.parse(
           scene,
           async function (buffer) {
             filterHelpers(scene, true);

--- a/src/editor/index.jsx
+++ b/src/editor/index.jsx
@@ -1,7 +1,6 @@
 import './instrument';
 import '../styles/tailwind.css';
 import { createRoot } from 'react-dom/client';
-import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter';
 import MainWrapper from './components/MainWrapper';
 import { ARControls, VisibilityToggle } from './components/viewport/ARControls';
 import { AuthProvider, GeoProvider } from './contexts';
@@ -26,7 +25,16 @@ function isViewerModeRequested() {
 
 function Inspector(configOverrides) {
   this.assetsLoader = new AssetsLoader();
-  this.exporters = { gltf: new GLTFExporter() };
+  let gltfExporterPromise = null;
+  this.getGLTFExporter = () => {
+    if (!gltfExporterPromise) {
+      gltfExporterPromise = import(
+        /* webpackChunkName: "gltf-exporter" */
+        'three/examples/jsm/exporters/GLTFExporter'
+      ).then(({ GLTFExporter }) => new GLTFExporter());
+    }
+    return gltfExporterPromise;
+  };
   this.config = new Config(configOverrides);
   this.history = new History();
   this.isFirstOpen = true;


### PR DESCRIPTION
Draft PR for #1624 — incrementally landing the bundle-size wins from the issue.

## Summary

The eagerly-loaded JS for a fresh page load is approaching ~3MB for `aframe-street-component.js` plus an additional 821KB for the Mapbox component that most users never touch. This PR chips away at the contributors identified in #1624, starting with the lowest-risk, highest-leverage quick wins.

## Checklist

**Geo libraries**
- [x] **Mapbox (821KB)** — defer via dynamic script injection (mirrors the existing OSM4VR pattern in `street-geo.js`)
- [ ] **Google 3D Tiles (50–90KB gz)** — convert to dynamic import in `google-maps-aerial`

**Path A quick wins**
- [x] Dynamic-import `GLTFExporter` at the call site (was `src/editor/index.jsx:4`)
- [ ] Fetch `catalog.json` asynchronously instead of bundling via `require()` in `src/assets.js`
- [ ] Lazy-init Vertex AI / Firebase Functions in `src/shared/services/firebase.js`
- [ ] Defer Sentry + PostHog initialization until after first paint

**Path A bigger structural win**
- [ ] Configure `optimization.splitChunks` so the React editor only loads when entering edit mode

**Smaller wins**
- [ ] Trim FontAwesome icons to those actually rendered
- [ ] Audit Radix UI imports for tree-shaking
- [ ] Audit `@gltf-transform/*` packages

**Path B (optional, in parallel)**
- [ ] Milestone-based progress indicator for the loader

## What's in this draft

### Mapbox lazy-load (~821KB saved per page load for non-Mapbox users)

- Removed the eager `<script src="/dist/aframe-mapbox-component.min.js">` from `index.html` and `public/functions/webxr-variant.js`.
- `street-geo.js → mapbox2dCreate` now checks `AFRAME.components['mapbox']` and `loadScript()`s the bundle on first use, exactly like the existing `osm3dCreate` does for OSM4VR.

### GLTFExporter dynamic import

- Removed eager `import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter'` from `src/editor/index.jsx`.
- Replaced `this.exporters = { gltf: new GLTFExporter() }` with a memoised `this.getGLTFExporter()` that dynamic-imports the module on first use (webpack will emit a separate `gltf-exporter` chunk).
- Updated both call sites (`AppMenu.jsx`, `CommonComponents.js`) to `await AFRAME.INSPECTOR.getGLTFExporter()` before calling `.parse()`.

## Test plan

- [ ] `npm run dist` and verify `aframe-mapbox-component.min.js` is no longer fetched on initial page load when the scene doesn't use `maps: mapbox2d`
- [ ] Verify a separate `gltf-exporter` chunk is emitted and `aframe-street-component.js` shrinks below baseline
- [ ] Switch the Geo layer to **Mapbox 2D** in the editor and confirm tiles render (lazy script load works)
- [ ] Switch back to **Google 3D** and **OSM 3D** to confirm no regression
- [ ] Manually trigger **Export → GLB** from the app menu and confirm the file downloads
- [ ] Manually trigger **Export → AR Ready GLB** and confirm post-processing still runs
- [ ] Export a single entity via the per-entity export button (CommonComponents path)
- [ ] Confirm no console errors on initial editor load, and that the WebXR variant page (`webxr-variant.js`) still loads Mapbox on demand when needed

https://claude.ai/code/session_011BWEq8GFhW3ydhB2QKz2iB