### PR TITLE
fix(street-generated-stencil): guard atlas-uvs update against uninitialized component

### DIFF
--- a/src/aframe-components/managed-street.js
+++ b/src/aframe-components/managed-street.js
@@ -600,7 +600,7 @@ AFRAME.registerComponent('managed-street', {
       // Drive lane and turn lane combination would go here if needed
     }
 
-    // Special case for parking lanes - use dashed line between parking and drive lanes
+    // Special case for parking lanes - use solid line between parking and drive lanes
     if (
       currentSegment.type === 'parking-lane' ||
       previousSegment.type === 'parking-lane'

--- a/src/aframe-components/street-generated-stencil.js
+++ b/src/aframe-components/street-generated-stencil.js
@@ -172,7 +172,7 @@ AFRAME.registerComponent('street-generated-stencil', {
         // Handle stencil height if specified
         if (data.stencilHeight > 0) {
           clone.setAttribute('geometry', 'height', data.stencilHeight);
-          clone.components['atlas-uvs'].update();
+          clone.components['atlas-uvs']?.update();
         }
 
         // Set rotation - either specified facing, or inbound/outbound


### PR DESCRIPTION
Add optional chaining to clone.components['atlas-uvs'].update() so it no-ops when the mixin's components haven't synchronously initialized yet. The throw was aborting segment setup mid-flight, leaving angled/perpendicular/sideways parking lanes without stripes or surface. Matches the pattern already used in aframe-streetmix-parsers.js from 7e0676de