### PR TITLE
Add Bollard Buddy catalog entries (15 street props)

### DIFF
--- a/src/catalog.json
+++ b/src/catalog.json
@@ -1204,5 +1204,140 @@
         "category": "dividers",
         "attribution": "StreetPlan.net. Used with permission.",
         "attributionUrl": "https://www.urbaninnovators.com/streetplan"
+    },
+    {
+        "id": "bb-bollard",
+        "name": "Bollard (Bollard Buddy)",
+        "img": "sets/bollard-buddy/gltf-exports/draco/bb-bollard.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/bb-bollard.glb",
+        "category": "dividers",
+        "attribution": "Creative Commons Attribution: 'Bollard #3b' by aecoviz (Vissy)",
+        "attributionUrl": "https://sketchfab.com/3d-models/bollard-3b-aec0c2bf563546518bf60237cc023bbd"
+    },
+    {
+        "id": "cone",
+        "name": "Traffic Cone",
+        "img": "sets/bollard-buddy/gltf-exports/draco/cone.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/cone.glb",
+        "category": "dividers",
+        "attribution": "Creative Commons Attribution: 'Traffic Cone Low-poly PBR' by MaX3Dd",
+        "attributionUrl": "https://sketchfab.com/3d-models/traffic-cone-low-poly-pbr-05d3184730f942a3a94465b72dfc766d"
+    },
+    {
+        "id": "royal-bollard",
+        "name": "Royal Bollard",
+        "img": "sets/bollard-buddy/gltf-exports/draco/royal-bollard.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/royal-bollard.glb",
+        "category": "dividers",
+        "attribution": "Creative Commons Attribution: 'Street Bollard' by Faheem Yusuf (FameProductions)",
+        "attributionUrl": "https://sketchfab.com/3d-models/street-bollard-9b9db79ae21c4e118423efae658e7fb7"
+    },
+    {
+        "id": "concrete-bollard",
+        "name": "Concrete Bollard",
+        "img": "sets/bollard-buddy/gltf-exports/draco/concrete-bollard.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/concrete-bollard.glb",
+        "category": "dividers",
+        "attribution": "Creative Commons Attribution: 'Concrete Bollard Scan 01 | Retopologized' by Kai Moisch",
+        "attributionUrl": "https://sketchfab.com/3d-models/concrete-bollard-scan-01-retopologized-f475b7954bae4acdb00183171744aece"
+    },
+    {
+        "id": "green-planter-tree",
+        "name": "Planter Tree",
+        "img": "sets/bollard-buddy/gltf-exports/draco/green-planter-tree.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/green-planter-tree.glb",
+        "category": "plants",
+        "attribution": "Creative Commons Attribution: 'Potted Tree' by dylanheyes",
+        "attributionUrl": "https://sketchfab.com/3d-models/potted-tree-dd6c9d90421b4a99acdfebbddd4ccf75"
+    },
+    {
+        "id": "green-planter-snake-plant",
+        "name": "Potted Plant",
+        "img": "sets/bollard-buddy/gltf-exports/draco/green-planter-snake-plant.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/green-planter-snake-plant.glb",
+        "category": "plants",
+        "attribution": "Creative Commons Attribution: 'potted_plant-1' by attben",
+        "attributionUrl": "https://sketchfab.com/3d-models/potted-plant-1-9c6eccd1a8eb434981317bf3e66ec2bb"
+    },
+    {
+        "id": "green-planter-fan-palm",
+        "name": "Fan Palm",
+        "img": "sets/bollard-buddy/gltf-exports/draco/green-planter-fan-palm.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/green-planter-fan-palm.glb",
+        "category": "plants",
+        "attribution": "Creative Commons Attribution: 'Livistona Chinensis - Fan Palm' by AllQuad",
+        "attributionUrl": "https://sketchfab.com/3d-models/free-livistona-chinensis-fan-palm-f59bab2a81244b869e1ca5aefd4ad94a"
+    },
+    {
+        "id": "green-planter-cactus",
+        "name": "Cactus",
+        "img": "sets/bollard-buddy/gltf-exports/draco/green-planter-cactus.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/green-planter-cactus.glb",
+        "category": "plants",
+        "attribution": "Creative Commons Attribution: 'Cereus Peruvianus - Potted Cactus' by AllQuad",
+        "attributionUrl": "https://sketchfab.com/3d-models/free-cereus-peruvianus-potted-cactus-4dfdf2971fca42a292de7ac6bf97a26b"
+    },
+    {
+        "id": "green-garden-urn",
+        "name": "Garden Urn",
+        "img": "sets/bollard-buddy/gltf-exports/draco/green-garden-urn.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/green-garden-urn.glb",
+        "category": "plants",
+        "attribution": "Creative Commons Attribution: 'Garden Urn' by Lyskilde (longtail)",
+        "attributionUrl": "https://sketchfab.com/3d-models/garden-urn-c0c7f5fa24704a23b0f3cbdd689b8176"
+    },
+    {
+        "id": "green-flowers",
+        "name": "Flowers",
+        "img": "sets/bollard-buddy/gltf-exports/draco/green-flowers.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/green-flowers.glb",
+        "category": "plants",
+        "attribution": "Creative Commons Attribution: 'Stylized flower' by Zayfert1999",
+        "attributionUrl": "https://sketchfab.com/3d-models/stylized-flower-c076c78cc47f49cfb68e24c8731d60ed"
+    },
+    {
+        "id": "fixture-bus-stop",
+        "name": "Bus Stop",
+        "img": "sets/bollard-buddy/gltf-exports/draco/fixture-bus-stop.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/fixture-bus-stop.glb",
+        "category": "fixtures",
+        "attribution": "Creative Commons Attribution: 'Abribus, Bus stop, bus station' by Configcars (maxipub)",
+        "attributionUrl": "https://sketchfab.com/3d-models/abribus-bus-stop-bus-station-ab3c98bf93de498bb45c129afa4c3ab3"
+    },
+    {
+        "id": "fixture-bench-modern",
+        "name": "Modern Bench",
+        "img": "sets/bollard-buddy/gltf-exports/draco/fixture-bench-modern.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/fixture-bench-modern.glb",
+        "category": "fixtures",
+        "attribution": "Creative Commons Attribution: 'Bench - street furniture' by YouniqueĪdeaStudio (sinnervoncrawsz)",
+        "attributionUrl": "https://sketchfab.com/3d-models/bench-street-furniture-2eec0b2d47f94db38ea31e8c3d2aab07"
+    },
+    {
+        "id": "fixture-bike-rack",
+        "name": "Bike Rack",
+        "img": "sets/bollard-buddy/gltf-exports/draco/fixture-bike-rack.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/fixture-bike-rack.glb",
+        "category": "fixtures",
+        "attribution": "Creative Commons Attribution: 'Bike Rack #4' by aecoviz (Vissy)",
+        "attributionUrl": "https://sketchfab.com/3d-models/bike-rack-4-8c8fd4fa06eb4b1c8db5bd3584892f3c"
+    },
+    {
+        "id": "fixture-trash-can",
+        "name": "Trash Can",
+        "img": "sets/bollard-buddy/gltf-exports/draco/fixture-trash-can.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/fixture-trash-can.glb",
+        "category": "fixtures",
+        "attribution": "Creative Commons Attribution: 'street trash can' by YouniqueĪdeaStudio (sinnervoncrawsz)",
+        "attributionUrl": "https://sketchfab.com/3d-models/street-trash-can-0debf0ba50304951b32b44c7578468dd"
+    },
+    {
+        "id": "fixture-picnic-table",
+        "name": "Picnic Table",
+        "img": "sets/bollard-buddy/gltf-exports/draco/fixture-picnic-table.webp",
+        "src": "sets/bollard-buddy/gltf-exports/draco/fixture-picnic-table.glb",
+        "category": "fixtures",
+        "attribution": "Creative Commons Attribution: 'Wooden Picnic Table - 4096px²' by Mark Peters",
+        "attributionUrl": "https://sketchfab.com/3d-models/wooden-picnic-table-4096px2-c7d39c0bcee04553894d0de081d3aa9c"
     }
 ]


### PR DESCRIPTION
Registers the 15 placeable objects from the **Bollard Buddy** iOS app as catalog entries so scenes saved from the app render correctly on web.

## How it works
`assets.js` auto-generates an `<a-mixin id="…">` for every catalog entry that has a `src`. The iOS app writes each placed object as `"mixin": "<objectType>"`, so a matching catalog id is all that's needed for a saved scene to resolve to geometry.

## What's here
- **14 entries** use the exact iOS mixin id (`cone`, `royal-bollard`, `concrete-bollard`, `green-*`, `fixture-*`).
- The app bollard ships as **`bb-bollard`** ("Bollard (Bollard Buddy)") so the existing red-ringed `bollard` is **left untouched** — app scenes already resolve to it.
- `img` thumbnails reuse the app's bundled 256×256 object thumbnails (converted to WebP, <6 KB each).
- All 15 models are **CC-BY-4.0** with attribution + attributionUrl.

Diff is additive only: 135 insertions, no deletions.

## Companion PR (must merge for assets to resolve)
GLBs + thumbnails live in **3dstreet-assets-dist** under `sets/bollard-buddy/gltf-exports/draco/` — see the companion PR there. The `src`/`img` paths in this catalog point at `assets.3dstreet.app/sets/bollard-buddy/…`, so they 404 until that PR is merged + deployed.

GLBs generated from the app's *baked* USDZ (sizing matched: cone 0.61 m, bus stop 2.75 m), optimized to 7.1 MB total (WebP @1024 + Draco).

🤖 Generated with [Claude Code](https://claude.com/claude-code)