### PR TITLE
Auto-increment dev server port when default is in use

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,35 @@
 const webpack = require('webpack');
 const path = require('path');
+const net = require('net');
 const Dotenv = require('dotenv-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = {
+const DEFAULT_PORT = 3333;
+
+// Find a free port, starting at `basePort` and incrementing on conflict.
+// Lets multiple dev servers (e.g. one per git worktree) run at once instead
+// of failing with EADDRINUSE on the hardcoded default.
+function findFreePort(basePort) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        resolve(findFreePort(basePort + 1));
+      } else {
+        reject(err);
+      }
+    });
+    server.listen(basePort, () => {
+      server.close(() => resolve(basePort));
+    });
+  });
+}
+
+const config = {
   mode: 'development',
   devServer: {
     liveReload: false,
-    port: 3333,
     allowedHosts: 'all',
     static: [
       {
@@ -132,4 +154,9 @@ module.exports = {
       '@shared': path.resolve(__dirname, 'src/shared')
     }
   }
+};
+
+module.exports = async () => {
+  config.devServer.port = await findFreePort(DEFAULT_PORT);
+  return config;
 };


### PR DESCRIPTION
## Summary

The webpack dev server port was hardcoded to `3333`, so starting a second instance (e.g. one dev server per git worktree) fails with `EADDRINUSE`.

This resolves the port at config-load time: start at `3333` and increment until a free port is found. A single dev server still binds `3333` exactly as before — only a conflict triggers the bump.

## How it works

- `webpack.config.js` now exports an `async` config function (a form webpack supports) so it can `await` a port probe before returning.
- `findFreePort(basePort)` uses Node's built-in `net` module to attempt to listen; on `EADDRINUSE` it retries `basePort + 1`. No new dependency.
- `webpack-dev-server` logs the chosen port on startup, and `npm start`'s `--open` opens the browser at the port actually bound.

## Testing

- With `3333` free, the server binds `3333` (unchanged behaviour).
- With `3333` (and `3334`) already in use, it correctly selects the next free port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)