### PR TITLE
Feat/PLG upsell part2

### DIFF
--- a/src/aframe-components/managed-street.js
+++ b/src/aframe-components/managed-street.js
@@ -5,6 +5,7 @@ import {
   STREETPLAN_OBJECT_TO_GENERATED_CLONES_MAPPING
 } from './street-mapping-streetplan.js';
 import useStore from '../store.js';
+import { GEO_SOURCES } from '@shared/constants/geoSources.js';
 const { segmentVariants } = require('../segments-variants.js');
 const streetmixUtils = require('../tested/streetmix-utils');
 const streetmixParsersTested = require('../tested/aframe-streetmix-parsers-tested');
@@ -662,7 +663,7 @@ AFRAME.registerComponent('managed-street', {
             longitude: streetmixLatLng.lng,
             locationString: streetData.location.label || '',
             maps: 'none',
-            source: 'streetmix'
+            source: GEO_SOURCES.STREETMIX
           });
         }
       }

--- a/src/aframe-components/managed-street.js
+++ b/src/aframe-components/managed-street.js
@@ -641,6 +641,31 @@ AFRAME.registerComponent('managed-street', {
       const streetmixName = streetmixResponseObject.name;
 
       this.el.setAttribute('data-layer-name', 'Street • ' + streetmixName);
+
+      // Import the Streetmix location (if the street has one) so the scene
+      // carries a geospatial origin we can attribute. We set coordinates with
+      // maps: 'none' so nothing auto-activates; running the elevation service
+      // stays a deliberate, token-charged action via "Add Geo Layer" in the
+      // Geospatial panel (which flips maps back on). Guarded so a saved scene
+      // re-fetching its Streetmix source never clobbers a location it already
+      // has.
+      const streetmixLatLng = streetData.location?.latlng;
+      const geoLayer = document.getElementById('reference-layers');
+      if (streetmixLatLng && geoLayer) {
+        const existingGeo = geoLayer.getAttribute('street-geo');
+        const alreadyLocated =
+          existingGeo &&
+          (existingGeo.latitude !== 0 || existingGeo.longitude !== 0);
+        if (!alreadyLocated) {
+          geoLayer.setAttribute('street-geo', {
+            latitude: streetmixLatLng.lat,
+            longitude: streetmixLatLng.lng,
+            locationString: streetData.location.label || '',
+            maps: 'none',
+            source: 'streetmix'
+          });
+        }
+      }
       // const streetWidth = streetmixSegments.reduce(
       //   (streetWidth, segmentData) => streetWidth + segmentData.width,
       //   0

--- a/src/aframe-components/street-geo.js
+++ b/src/aframe-components/street-geo.js
@@ -86,8 +86,10 @@ AFRAME.registerComponent('street-geo', {
     // activated", preserving the location for a later activation, and
     // switching a map type on re-runs update() and re-prompts. The modal
     // check avoids reopening if it is already showing.
-    const { modal, setModal } = useStore.getState();
+    const { modal, setModal, setGeoModalFromActivationGate } =
+      useStore.getState();
     if (modal !== 'geo') {
+      setGeoModalFromActivationGate(true);
       setModal('geo');
     }
   },

--- a/src/aframe-components/street-geo.js
+++ b/src/aframe-components/street-geo.js
@@ -29,7 +29,13 @@ AFRAME.registerComponent('street-geo', {
     },
     blendingEnabled: { type: 'boolean', default: false },
     locationString: { type: 'string', default: '' },
-    intersectionString: { type: 'string', default: '' }
+    intersectionString: { type: 'string', default: '' },
+    // Provenance of the geo location: where the coordinates came from. One
+    // of: 'streetmix' | 'geojson' | 'manual' | 'bollard-buddy' (the 3DStreet
+    // mobile app) | 'ai-assistant'. Empty when unknown (e.g. legacy scenes).
+    // Stamped wherever a location is first established; preserved across a
+    // later activation so the original origin is retained.
+    source: { type: 'string', default: '' }
   },
   init: function () {
     /*

--- a/src/aframe-components/street-geo.js
+++ b/src/aframe-components/street-geo.js
@@ -30,11 +30,12 @@ AFRAME.registerComponent('street-geo', {
     blendingEnabled: { type: 'boolean', default: false },
     locationString: { type: 'string', default: '' },
     intersectionString: { type: 'string', default: '' },
-    // Provenance of the geo location: where the coordinates came from. One
-    // of: 'streetmix' | 'geojson' | 'manual' | 'bollard-buddy' (the 3DStreet
-    // mobile app) | 'ai-assistant'. Empty when unknown (e.g. legacy scenes).
-    // Stamped wherever a location is first established; preserved across a
-    // later activation so the original origin is retained.
+    // Provenance of the geo location: where the coordinates came from. Values
+    // are the GEO_SOURCES enum in @shared/constants/geoSources.js (streetmix,
+    // geojson, manual, bollard-buddy = the 3DStreet mobile app, ai-assistant).
+    // Empty when unknown (e.g. legacy scenes). Stamped wherever a location is
+    // first established; preserved across a later activation so the original
+    // origin is retained.
     source: { type: 'string', default: '' }
   },
   init: function () {

--- a/src/editor/components/elements/AssetInfoPanel.jsx
+++ b/src/editor/components/elements/AssetInfoPanel.jsx
@@ -27,11 +27,15 @@ const AssetInfoPanel = ({ entity }) => {
   const isQuotaBlocked =
     state.reason === 'over_quota' || state.reason === 'file_too_large';
   const slotFile = useAssetUploadStore.getState().uploads[entity?.id]?.file;
+  // Retry only helps when the same File can succeed on a re-run: a generic
+  // failure, or over_quota (the user may free up space, or upgrade, then
+  // retry). file_too_large would fail identically without an upgrade, so we
+  // show only the Upgrade CTA for it — no dead Retry button.
   const canRetry =
     !!slotFile &&
     !!entity &&
     (state.status === 'failed' ||
-      (state.status === 'local_error' && isQuotaBlocked));
+      (state.status === 'local_error' && state.reason === 'over_quota'));
   const retryUpload = () => uploadAndPlaceAsset(slotFile, null, entity);
   const upgradeForStorage = () => {
     posthog.capture('storage_upsell_clicked', {

--- a/src/editor/components/elements/AssetInfoPanel.jsx
+++ b/src/editor/components/elements/AssetInfoPanel.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
+import posthog from 'posthog-js';
 import useAssetUploadStatus, {
   STATUS_LABELS,
   REASON_TEXT
@@ -9,6 +10,7 @@ import useCurrentUploadStore from '@shared/assets/state/currentUploadStore.js';
 import { uploadAndPlaceAsset } from '@/editor/lib/asset-upload/uploadAndPlaceAsset.js';
 import { AssetDetailModal, formatBytes } from '@shared/assets';
 import { openInGenerator } from '@/editor/lib/asset-modal-handlers.js';
+import useStore from '@/store.js';
 
 const AssetInfoPanel = ({ entity }) => {
   const state = useAssetUploadStatus(entity);
@@ -18,6 +20,26 @@ const AssetInfoPanel = ({ entity }) => {
   const meta = STATUS_LABELS[state.status] || STATUS_LABELS.uploaded;
   const sizeStr = state.sizeBytes ? formatBytes(state.sizeBytes) : '';
   const { isOwned } = state;
+
+  // Upload blocked by the plan's storage quota (#1644). The upload slot
+  // keeps the original File, so after a Pro upgrade the same Retry button
+  // re-runs the upload without the user having to re-drop the file.
+  const isQuotaBlocked =
+    state.reason === 'over_quota' || state.reason === 'file_too_large';
+  const slotFile = useAssetUploadStore.getState().uploads[entity?.id]?.file;
+  const canRetry =
+    !!slotFile &&
+    !!entity &&
+    (state.status === 'failed' ||
+      (state.status === 'local_error' && isQuotaBlocked));
+  const retryUpload = () => uploadAndPlaceAsset(slotFile, null, entity);
+  const upgradeForStorage = () => {
+    posthog.capture('storage_upsell_clicked', {
+      severity: 'upload_blocked',
+      reason: state.reason
+    });
+    useStore.getState().startCheckout('storage');
+  };
 
   let detail = '';
   if (state.status === 'uploading' && state.progress > 0) {
@@ -77,14 +99,10 @@ const AssetInfoPanel = ({ entity }) => {
             Cancel
           </button>
         )}
-        {state.status === 'failed' && (
+        {canRetry && (
           <button
             type="button"
-            onClick={() => {
-              const slot = useAssetUploadStore.getState().uploads[entity?.id];
-              if (!slot?.file || !entity) return;
-              uploadAndPlaceAsset(slot.file, null, entity);
-            }}
+            onClick={retryUpload}
             style={{
               marginLeft: 'auto',
               background: 'transparent',
@@ -111,6 +129,27 @@ const AssetInfoPanel = ({ entity }) => {
         >
           {reasonText}
         </div>
+      )}
+      {isQuotaBlocked && (
+        <button
+          type="button"
+          onClick={upgradeForStorage}
+          style={{
+            display: 'block',
+            width: '100%',
+            marginTop: 6,
+            background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+            border: 'none',
+            color: 'white',
+            borderRadius: 4,
+            padding: '6px 8px',
+            fontSize: 11,
+            fontWeight: 600,
+            cursor: 'pointer'
+          }}
+        >
+          Upgrade for 5 GB storage
+        </button>
       )}
       {state.assetId && (
         <div

--- a/src/editor/components/elements/AssetInfoPanel.jsx
+++ b/src/editor/components/elements/AssetInfoPanel.jsx
@@ -11,6 +11,7 @@ import { uploadAndPlaceAsset } from '@/editor/lib/asset-upload/uploadAndPlaceAss
 import { AssetDetailModal, formatBytes } from '@shared/assets';
 import { openInGenerator } from '@/editor/lib/asset-modal-handlers.js';
 import useStore from '@/store.js';
+import { Button } from './Button';
 
 const AssetInfoPanel = ({ entity }) => {
   const state = useAssetUploadStatus(entity);
@@ -135,25 +136,19 @@ const AssetInfoPanel = ({ entity }) => {
         </div>
       )}
       {isQuotaBlocked && (
-        <button
-          type="button"
+        <Button
+          variant="upgrade"
           onClick={upgradeForStorage}
           style={{
-            display: 'block',
             width: '100%',
             marginTop: 6,
-            background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-            border: 'none',
-            color: 'white',
             borderRadius: 4,
             padding: '6px 8px',
-            fontSize: 11,
-            fontWeight: 600,
-            cursor: 'pointer'
+            fontSize: 11
           }}
         >
           Upgrade for 5 GB storage
-        </button>
+        </Button>
       )}
       {state.assetId && (
         <div

--- a/src/editor/components/elements/Button/Button.component.jsx
+++ b/src/editor/components/elements/Button/Button.component.jsx
@@ -11,7 +11,8 @@ const variants = {
   toolbtn: styles.toolButton,
   white: styles.whiteButton,
   custom: styles.customButton,
-  save: styles.saveButton
+  save: styles.saveButton,
+  upgrade: styles.upgradeButton
 };
 
 /**

--- a/src/editor/components/elements/Button/Button.module.scss
+++ b/src/editor/components/elements/Button/Button.module.scss
@@ -205,6 +205,28 @@
   }
 }
 
+/* Shared upgrade / "Go Pro" CTA treatment (#1644 / #1654). Single home for the
+   purple gradient + hover lift used by every paywall entry point. */
+.upgradeButton {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: variables.$white;
+  border: none;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(118, 75, 162, 0.3);
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
+    transition: all 0.3s;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    transform: none;
+    box-shadow: none;
+  }
+}
+
 .icon {
   display: flex;
   justify-content: center;

--- a/src/editor/components/elements/GeoSidebar.jsx
+++ b/src/editor/components/elements/GeoSidebar.jsx
@@ -234,8 +234,41 @@ const EnvironmentSection = () => {
 // copy names the action ("Add Geo Layer"), the payoff (real-world maps), and
 // the cost (one geo token) so the token economy is legible at the point of
 // spend. Plan/token state only changes the CTA, not the layout.
-const GeoHero = ({ hasLocation, isPro, geoToken, onAdd, onUpgrade }) => {
+// Human phrase for where a saved-but-not-activated location came from. Empty
+// string means "don't attribute a source" (e.g. a manual set that somehow
+// never activated). Legacy scenes with no stamped source are, in practice,
+// from the mobile app (the only path that leaves a location unactivated), so
+// an empty source defaults to the app.
+const geoSourcePhrase = (source) => {
+  switch (source) {
+    case 'streetmix':
+      return 'imported from Streetmix';
+    case 'geojson':
+      return 'imported from GeoJSON';
+    case 'ai-assistant':
+      return 'set by the AI assistant';
+    case 'bollard-buddy':
+    case '':
+    case undefined:
+      return 'from the 3DStreet app';
+    default:
+      return '';
+  }
+};
+
+const GeoHero = ({
+  hasLocation,
+  isPro,
+  geoToken,
+  source,
+  onAdd,
+  onUpgrade
+}) => {
   const outOfTokens = !isPro && geoToken === 0;
+  const sourcePhrase = geoSourcePhrase(source);
+  const savedLocationCopy = sourcePhrase
+    ? `This scene has a saved location ${sourcePhrase}. Add the geo layer to load 3D buildings, terrain, and satellite imagery.`
+    : 'This scene has a saved location. Add the geo layer to load 3D buildings, terrain, and satellite imagery.';
   return (
     <div
       style={{
@@ -257,7 +290,7 @@ const GeoHero = ({ hasLocation, isPro, geoToken, onAdd, onUpgrade }) => {
       </div>
       <div style={{ fontSize: '12px', lineHeight: 1.45, color: '#b8b8b8' }}>
         {hasLocation
-          ? 'This scene has a saved location. Add the geo layer to load 3D buildings, terrain, and satellite imagery.'
+          ? savedLocationCopy
           : 'Drop your scene onto real-world maps with 3D buildings, terrain, and satellite imagery.'}
       </div>
       <Button
@@ -310,6 +343,7 @@ GeoHero.propTypes = {
   hasLocation: PropTypes.bool,
   isPro: PropTypes.bool,
   geoToken: PropTypes.number,
+  source: PropTypes.string,
   onAdd: PropTypes.func.isRequired,
   onUpgrade: PropTypes.func.isRequired
 };
@@ -394,6 +428,7 @@ const GeoSidebar = ({ entity }) => {
                 hasLocation={hasLocation}
                 isPro={!!currentUser?.isPro}
                 geoToken={tokenProfile?.geoToken ?? 0}
+                source={geoData?.source}
                 onAdd={hasLocation ? activateFromCallout : openGeoModal}
                 onUpgrade={() => startCheckout('geo')}
               />

--- a/src/editor/components/elements/GeoSidebar.jsx
+++ b/src/editor/components/elements/GeoSidebar.jsx
@@ -228,6 +228,92 @@ const EnvironmentSection = () => {
   );
 };
 
+// Empty / not-activated hero (#1654 redesign). Until a scene has an activated
+// geospatial location, the map-type / location / blending controls are inert,
+// so we hide them (see GeoSidebar) and foreground a single honest CTA. The
+// copy names the action ("Add Geo Layer"), the payoff (real-world maps), and
+// the cost (one geo token) so the token economy is legible at the point of
+// spend. Plan/token state only changes the CTA, not the layout.
+const GeoHero = ({ hasLocation, isPro, geoToken, onAdd, onUpgrade }) => {
+  const outOfTokens = !isPro && geoToken === 0;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: '8px',
+        margin: '4px 12px 16px',
+        padding: '18px 16px',
+        borderRadius: '10px',
+        background: 'rgba(119, 77, 238, 0.08)',
+        border: '1px solid rgba(119, 77, 238, 0.35)'
+      }}
+    >
+      <div style={{ fontSize: '30px', lineHeight: 1 }}>🌍</div>
+      <div style={{ fontWeight: 600, color: '#fff', fontSize: '14px' }}>
+        {hasLocation ? 'Map not loaded yet' : 'Add a real-world location'}
+      </div>
+      <div style={{ fontSize: '12px', lineHeight: 1.45, color: '#b8b8b8' }}>
+        {hasLocation
+          ? 'This scene has a saved location. Add the geo layer to load 3D buildings, terrain, and satellite imagery.'
+          : 'Drop your scene onto real-world maps with 3D buildings, terrain, and satellite imagery.'}
+      </div>
+      <Button
+        variant="toolbtn"
+        style={{
+          width: '100%',
+          justifyContent: 'center',
+          marginTop: '4px',
+          background: outOfTokens
+            ? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
+            : '#774dee',
+          border: 'none',
+          color: 'white',
+          fontWeight: 600,
+          fontSize: '13px',
+          padding: '10px 16px'
+        }}
+        onClick={outOfTokens ? onUpgrade : onAdd}
+      >
+        {outOfTokens ? 'Upgrade to Pro' : 'Add Geo Layer'}
+      </Button>
+      {!isPro && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '4px',
+            fontSize: '11px',
+            color: '#9ca3af'
+          }}
+        >
+          <img
+            src="/ui_assets/token-geo.png"
+            alt="Geo Token"
+            style={{ width: '16px', height: '16px', verticalAlign: 'middle' }}
+          />
+          <span>
+            {outOfTokens
+              ? "You're out of free geo tokens."
+              : `Uses 1 of ${geoToken} free geo tokens to add real-world map data.`}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+GeoHero.propTypes = {
+  hasLocation: PropTypes.bool,
+  isPro: PropTypes.bool,
+  geoToken: PropTypes.number,
+  onAdd: PropTypes.func.isRequired,
+  onUpgrade: PropTypes.func.isRequired
+};
+
 const GeoSidebar = ({ entity }) => {
   const setModal = useStore((state) => state.setModal);
   const { currentUser, tokenProfile } = useAuthContext();
@@ -278,16 +364,19 @@ const GeoSidebar = ({ entity }) => {
   // Check if entity and its components exist
   const component = entity?.components?.['street-geo'];
 
-  // Located but never activated (#1654): the scene carries a suggested
-  // lat/lon (e.g. from the mobile app) but the elevation service has never
-  // run, so the activation gate in street-geo suppresses all map tiles. If
-  // the user dismissed the auto-opened GeoModal there is otherwise no signal
-  // pointing back at the recovery path. Mirrors
-  // street-geo's hasSuggestedLocation() / isGeospatialActivated().
-  const isLocatedNotActivated =
-    component?.data &&
-    (component.data.latitude !== 0 || component.data.longitude !== 0) &&
-    !Number.isFinite(component.data.ellipsoidalHeight);
+  // Geo activation state (#1654). The scene can carry a suggested lat/lon
+  // (e.g. from the mobile app) without the elevation service ever having run,
+  // in which case the activation gate in street-geo suppresses all map tiles.
+  // A finite ellipsoidalHeight is the proxy for "activated" — only the
+  // elevation service writes it. Mirrors street-geo's hasSuggestedLocation()
+  // / isGeospatialActivated(). Until activated, the geo-specific controls
+  // (map type, location details, blending) are inert, so we hide them and
+  // show GeoHero instead — one honest CTA per state. Environment is general
+  // scene config (separate #environment entity) and stays visible throughout.
+  const geoData = component?.data;
+  const hasLocation =
+    !!geoData && (geoData.latitude !== 0 || geoData.longitude !== 0);
+  const isActivated = !!geoData && Number.isFinite(geoData.ellipsoidalHeight);
 
   const activateFromCallout = () => {
     posthog.capture('geo_activation_callout_clicked');
@@ -299,8 +388,18 @@ const GeoSidebar = ({ entity }) => {
       <div className="geo-sidebar">
         <div className="geo-controls">
           <div className="details">
+            {/* Empty / not-activated: single honest CTA, geo controls hidden */}
+            {!isActivated && (
+              <GeoHero
+                hasLocation={hasLocation}
+                isPro={!!currentUser?.isPro}
+                geoToken={tokenProfile?.geoToken ?? 0}
+                onAdd={hasLocation ? activateFromCallout : openGeoModal}
+                onUpgrade={() => startCheckout('geo')}
+              />
+            )}
             {/* Map Source Selection */}
-            {component && component.schema && component.data && (
+            {isActivated && component && component.schema && component.data && (
               <div className="propertyRow" style={{ marginBottom: '16px' }}>
                 <div className="fakePropertyRowLabel">Map Type</div>
                 <div
@@ -445,162 +544,125 @@ const GeoSidebar = ({ entity }) => {
               </div>
             )}
 
-            {/* Combined location header with button */}
-            <div className="propertyRow" style={{ marginBottom: '12px' }}>
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  width: '100%',
-                  paddingRight: '12px'
-                }}
-              >
-                <div
-                  style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
-                >
-                  <TooltipWrapper
-                    content={
-                      component && component.data && component.data.latitude
-                        ? `This scene's centerpoint is ${component.data.latitude}, ${component.data.longitude}`
-                        : 'This scene has a geolocation centerpoint defined.'
-                    }
-                  >
-                    <span
-                      className="success-badge"
-                      style={{
-                        background: '#2d2d2d',
-                        border:
-                          component && component.data && component.data.latitude
-                            ? '1px solid #10b981'
-                            : '1px solid #6b7280',
-                        color: 'white',
-                        padding: '4px 8px',
-                        borderRadius: '4px',
-                        fontSize: '11px',
-                        fontWeight: '500'
-                      }}
-                    >
-                      {component && component.data && component.data.latitude
-                        ? '✅ Location Set'
-                        : '📍 No Location'}
-                    </span>
-                  </TooltipWrapper>
-                  {!currentUser?.isPro && tokenProfile && (
-                    <TooltipWrapper content="Use geo tokens to set or change a geolocation for your scene.">
-                      <span
-                        className="token-badge"
-                        style={{
-                          background: '#2d2d2d',
-                          color: '#9ca3af',
-                          padding: '4px 8px',
-                          borderRadius: '4px',
-                          fontSize: '10px'
-                        }}
-                      >
-                        <img
-                          src="/ui_assets/token-geo.png"
-                          alt="Geo Token"
-                          style={{
-                            width: '20px',
-                            height: '20px',
-                            marginRight: '3px',
-                            display: 'inline-block',
-                            verticalAlign: 'middle'
-                          }}
-                        />
-                        {tokenProfile.geoToken} free
-                      </span>
-                    </TooltipWrapper>
-                  )}
-                </div>
-                <Button variant="toolbtn" onClick={openGeoModal}>
-                  <Magnifier20Icon />
-                  {entity && entity.components
-                    ? 'Change Location'
-                    : 'Set Location'}
-                </Button>
-              </div>
-            </div>
-
-            {/* Located-but-not-activated callout (#1654) */}
-            {isLocatedNotActivated && (
-              <div
-                className="propertyRow"
-                style={{ marginBottom: '12px', paddingRight: '12px' }}
-              >
+            {/* Activated: location status + change-location entry point */}
+            {isActivated && (
+              <div className="propertyRow" style={{ marginBottom: '12px' }}>
                 <div
                   style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
                     width: '100%',
-                    background: 'rgba(244, 160, 26, 0.08)',
-                    border: '1px solid rgba(244, 160, 26, 0.45)',
-                    borderRadius: '6px',
-                    padding: '10px 12px',
-                    fontSize: '12px',
-                    lineHeight: 1.45,
-                    color: '#f4a01a'
+                    paddingRight: '12px'
                   }}
                 >
-                  <div style={{ fontWeight: 600, marginBottom: '4px' }}>
-                    📍 Location detected — map not activated
-                  </div>
-                  <div style={{ color: '#d1d5db', marginBottom: '8px' }}>
-                    This scene has a saved location, but the 3D map isn&apos;t
-                    loaded yet. Activate to fetch elevation and map tiles.
-                  </div>
-                  <Button
-                    variant="toolbtn"
-                    style={{ width: '100%' }}
-                    onClick={activateFromCallout}
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px'
+                    }}
                   >
-                    Activate Map
+                    <TooltipWrapper
+                      content={`This scene's centerpoint is ${geoData.latitude}, ${geoData.longitude}`}
+                    >
+                      <span
+                        className="success-badge"
+                        style={{
+                          background: '#2d2d2d',
+                          border: '1px solid #10b981',
+                          color: 'white',
+                          padding: '4px 8px',
+                          borderRadius: '4px',
+                          fontSize: '11px',
+                          fontWeight: '500'
+                        }}
+                      >
+                        ✅ Location Set
+                      </span>
+                    </TooltipWrapper>
+                    {!currentUser?.isPro && tokenProfile && (
+                      <TooltipWrapper content="Use geo tokens to set or change a geolocation for your scene.">
+                        <span
+                          className="token-badge"
+                          style={{
+                            background: '#2d2d2d',
+                            color: '#9ca3af',
+                            padding: '4px 8px',
+                            borderRadius: '4px',
+                            fontSize: '10px'
+                          }}
+                        >
+                          <img
+                            src="/ui_assets/token-geo.png"
+                            alt="Geo Token"
+                            style={{
+                              width: '20px',
+                              height: '20px',
+                              marginRight: '3px',
+                              display: 'inline-block',
+                              verticalAlign: 'middle'
+                            }}
+                          />
+                          {tokenProfile.geoToken} free
+                        </span>
+                      </TooltipWrapper>
+                    )}
+                  </div>
+                  <Button variant="toolbtn" onClick={openGeoModal}>
+                    <Magnifier20Icon />
+                    Change Location
                   </Button>
                 </div>
               </div>
             )}
 
-            {/* Upgrade prompt for users with 0 tokens */}
-            {!currentUser?.isPro && tokenProfile?.geoToken === 0 && (
-              <div
-                className="propertyRow"
-                style={{ marginTop: '8px', paddingRight: '12px' }}
-              >
-                <Button
-                  variant="toolbtn"
-                  style={{
-                    width: '100%',
-                    background:
-                      'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                    border: 'none',
-                    color: 'white',
-                    fontWeight: '600',
-                    fontSize: '12px',
-                    padding: '12px 16px',
-                    borderRadius: '8px',
-                    cursor: 'pointer',
-                    transition: 'all 0.3s ease',
-                    boxShadow: '0 4px 12px rgba(118, 75, 162, 0.3)',
-                    ':hover': {
-                      transform: 'translateY(-1px)',
-                      boxShadow: '0 6px 20px rgba(118, 75, 162, 0.4)'
-                    }
-                  }}
-                  onClick={() => startCheckout('geo')}
-                  onMouseEnter={(e) => {
-                    e.target.style.transform = 'translateY(-1px)';
-                    e.target.style.boxShadow =
-                      '0 6px 20px rgba(118, 75, 162, 0.4)';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.target.style.transform = 'translateY(0px)';
-                    e.target.style.boxShadow =
-                      '0 4px 12px rgba(118, 75, 162, 0.3)';
-                  }}
+            {/* Upgrade prompt for activated scenes whose free user is out of
+                tokens (so they can still change location). Not-activated
+                scenes get the upsell inside GeoHero instead. */}
+            {isActivated &&
+              !currentUser?.isPro &&
+              tokenProfile?.geoToken === 0 && (
+                <div
+                  className="propertyRow"
+                  style={{ marginTop: '8px', paddingRight: '12px' }}
                 >
-                  Upgrade to Pro for unlimited geo lookups
-                </Button>
-              </div>
-            )}
+                  <Button
+                    variant="toolbtn"
+                    style={{
+                      width: '100%',
+                      background:
+                        'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                      border: 'none',
+                      color: 'white',
+                      fontWeight: '600',
+                      fontSize: '12px',
+                      padding: '12px 16px',
+                      borderRadius: '8px',
+                      cursor: 'pointer',
+                      transition: 'all 0.3s ease',
+                      boxShadow: '0 4px 12px rgba(118, 75, 162, 0.3)',
+                      ':hover': {
+                        transform: 'translateY(-1px)',
+                        boxShadow: '0 6px 20px rgba(118, 75, 162, 0.4)'
+                      }
+                    }}
+                    onClick={() => startCheckout('geo')}
+                    onMouseEnter={(e) => {
+                      e.target.style.transform = 'translateY(-1px)';
+                      e.target.style.boxShadow =
+                        '0 6px 20px rgba(118, 75, 162, 0.4)';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.target.style.transform = 'translateY(0px)';
+                      e.target.style.boxShadow =
+                        '0 4px 12px rgba(118, 75, 162, 0.3)';
+                    }}
+                  >
+                    Upgrade to Pro for unlimited geo lookups
+                  </Button>
+                </div>
+              )}
 
             {/* Location details using standard label/value format */}
             {component && component.data && component.data.locationString && (
@@ -646,7 +708,7 @@ const GeoSidebar = ({ entity }) => {
 
             <EnvironmentSection />
 
-            {component && component.schema && component.data && (
+            {isActivated && component && component.schema && component.data && (
               <>
                 {/* only show this if google3d is selected */}
                 {component.data['maps'] === 'google3d' && (

--- a/src/editor/components/elements/GeoSidebar.jsx
+++ b/src/editor/components/elements/GeoSidebar.jsx
@@ -3,6 +3,7 @@ import { Button } from '../elements';
 import { useAuthContext } from '@/editor/contexts/index.js';
 import PropertyRow from './PropertyRow';
 import { Magnifier20Icon, SunIcon } from '@shared/icons';
+import { geoSourcePhrase } from '@shared/constants/geoSources.js';
 import posthog from 'posthog-js';
 import useStore from '@/store';
 import { useState, useEffect } from 'react';
@@ -233,29 +234,8 @@ const EnvironmentSection = () => {
 // so we hide them (see GeoSidebar) and foreground a single honest CTA. The
 // copy names the action ("Add Geo Layer"), the payoff (real-world maps), and
 // the cost (one geo token) so the token economy is legible at the point of
-// spend. Plan/token state only changes the CTA, not the layout.
-// Human phrase for where a saved-but-not-activated location came from. Empty
-// string means "don't attribute a source" (e.g. a manual set that somehow
-// never activated). Legacy scenes with no stamped source are, in practice,
-// from the mobile app (the only path that leaves a location unactivated), so
-// an empty source defaults to the app.
-const geoSourcePhrase = (source) => {
-  switch (source) {
-    case 'streetmix':
-      return 'imported from Streetmix';
-    case 'geojson':
-      return 'imported from GeoJSON';
-    case 'ai-assistant':
-      return 'set by the AI assistant';
-    case 'bollard-buddy':
-    case '':
-    case undefined:
-      return 'from the 3DStreet app';
-    default:
-      return '';
-  }
-};
-
+// spend. Plan/token state only changes the CTA, not the layout. The saved
+// location's provenance copy comes from geoSourcePhrase (@shared/constants).
 const GeoHero = ({
   hasLocation,
   isPro,
@@ -294,19 +274,21 @@ const GeoHero = ({
           : 'Drop your scene onto real-world maps with 3D buildings, terrain, and satellite imagery.'}
       </div>
       <Button
-        variant="toolbtn"
+        variant={outOfTokens ? 'upgrade' : 'toolbtn'}
         style={{
           width: '100%',
           justifyContent: 'center',
           marginTop: '4px',
-          background: outOfTokens
-            ? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
-            : '#774dee',
-          border: 'none',
-          color: 'white',
-          fontWeight: 600,
           fontSize: '13px',
-          padding: '10px 16px'
+          padding: '10px 16px',
+          ...(outOfTokens
+            ? {}
+            : {
+                background: '#774dee',
+                border: 'none',
+                color: 'white',
+                fontWeight: 600
+              })
         }}
         onClick={outOfTokens ? onUpgrade : onAdd}
       >
@@ -401,16 +383,15 @@ const GeoSidebar = ({ entity }) => {
   // Geo activation state (#1654). The scene can carry a suggested lat/lon
   // (e.g. from the mobile app) without the elevation service ever having run,
   // in which case the activation gate in street-geo suppresses all map tiles.
-  // A finite ellipsoidalHeight is the proxy for "activated" — only the
-  // elevation service writes it. Mirrors street-geo's hasSuggestedLocation()
-  // / isGeospatialActivated(). Until activated, the geo-specific controls
-  // (map type, location details, blending) are inert, so we hide them and
-  // show GeoHero instead — one honest CTA per state. Environment is general
-  // scene config (separate #environment entity) and stays visible throughout.
+  // Use the component's own predicates as the single source of truth so this
+  // panel can't drift from the gate's definition of "located" / "activated".
+  // Until activated, the geo-specific controls (map type, location details,
+  // blending) are inert, so we hide them and show GeoHero instead — one honest
+  // CTA per state. Environment is general scene config (separate #environment
+  // entity) and stays visible throughout.
   const geoData = component?.data;
-  const hasLocation =
-    !!geoData && (geoData.latitude !== 0 || geoData.longitude !== 0);
-  const isActivated = !!geoData && Number.isFinite(geoData.ellipsoidalHeight);
+  const hasLocation = !!component && component.hasSuggestedLocation();
+  const isActivated = !!component && component.isGeospatialActivated();
 
   const activateFromCallout = () => {
     posthog.capture('geo_activation_callout_clicked');
@@ -663,83 +644,66 @@ const GeoSidebar = ({ entity }) => {
                   style={{ marginTop: '8px', paddingRight: '12px' }}
                 >
                   <Button
-                    variant="toolbtn"
+                    variant="upgrade"
                     style={{
                       width: '100%',
-                      background:
-                        'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                      border: 'none',
-                      color: 'white',
-                      fontWeight: '600',
                       fontSize: '12px',
                       padding: '12px 16px',
-                      borderRadius: '8px',
-                      cursor: 'pointer',
-                      transition: 'all 0.3s ease',
-                      boxShadow: '0 4px 12px rgba(118, 75, 162, 0.3)',
-                      ':hover': {
-                        transform: 'translateY(-1px)',
-                        boxShadow: '0 6px 20px rgba(118, 75, 162, 0.4)'
-                      }
+                      borderRadius: '8px'
                     }}
                     onClick={() => startCheckout('geo')}
-                    onMouseEnter={(e) => {
-                      e.target.style.transform = 'translateY(-1px)';
-                      e.target.style.boxShadow =
-                        '0 6px 20px rgba(118, 75, 162, 0.4)';
-                    }}
-                    onMouseLeave={(e) => {
-                      e.target.style.transform = 'translateY(0px)';
-                      e.target.style.boxShadow =
-                        '0 4px 12px rgba(118, 75, 162, 0.3)';
-                    }}
                   >
                     Upgrade to Pro for unlimited geo lookups
                   </Button>
                 </div>
               )}
 
-            {/* Location details using standard label/value format */}
-            {component && component.data && component.data.locationString && (
-              <>
-                <div className="propertyRow">
-                  <div className="fakePropertyRowLabel">Location</div>
-                  <div
-                    className="fakePropertyRowValue"
-                    style={{ fontSize: '12px', color: '#ccc' }}
-                  >
-                    {component.data.locationString}
-                  </div>
-                </div>
-
-                {component.data.intersectionString && (
+            {/* Location details using standard label/value format. Gated on
+                isActivated so a located-but-not-activated scene shows only the
+                GeoHero, not an orphaned details block with no status badge. */}
+            {isActivated &&
+              component &&
+              component.data &&
+              component.data.locationString && (
+                <>
                   <div className="propertyRow">
-                    <div className="fakePropertyRowLabel">
-                      Nearest
-                      <br /> Intersection
-                    </div>
+                    <div className="fakePropertyRowLabel">Location</div>
                     <div
                       className="fakePropertyRowValue"
                       style={{ fontSize: '12px', color: '#ccc' }}
                     >
-                      {component.data.intersectionString}
+                      {component.data.locationString}
                     </div>
                   </div>
-                )}
 
-                {component.data.orthometricHeight && (
-                  <div className="propertyRow">
-                    <div className="fakePropertyRowLabel">Elevation</div>
-                    <div
-                      className="fakePropertyRowValue"
-                      style={{ fontSize: '12px', color: '#ccc' }}
-                    >
-                      {Math.round(component.data.orthometricHeight)}m
+                  {component.data.intersectionString && (
+                    <div className="propertyRow">
+                      <div className="fakePropertyRowLabel">
+                        Nearest
+                        <br /> Intersection
+                      </div>
+                      <div
+                        className="fakePropertyRowValue"
+                        style={{ fontSize: '12px', color: '#ccc' }}
+                      >
+                        {component.data.intersectionString}
+                      </div>
                     </div>
-                  </div>
-                )}
-              </>
-            )}
+                  )}
+
+                  {component.data.orthometricHeight && (
+                    <div className="propertyRow">
+                      <div className="fakePropertyRowLabel">Elevation</div>
+                      <div
+                        className="fakePropertyRowValue"
+                        style={{ fontSize: '12px', color: '#ccc' }}
+                      >
+                        {Math.round(component.data.orthometricHeight)}m
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
 
             <EnvironmentSection />
 

--- a/src/editor/components/elements/GeoSidebar.jsx
+++ b/src/editor/components/elements/GeoSidebar.jsx
@@ -278,6 +278,22 @@ const GeoSidebar = ({ entity }) => {
   // Check if entity and its components exist
   const component = entity?.components?.['street-geo'];
 
+  // Located but never activated (#1654): the scene carries a suggested
+  // lat/lon (e.g. from the mobile app) but the elevation service has never
+  // run, so the activation gate in street-geo suppresses all map tiles. If
+  // the user dismissed the auto-opened GeoModal there is otherwise no signal
+  // pointing back at the recovery path. Mirrors
+  // street-geo's hasSuggestedLocation() / isGeospatialActivated().
+  const isLocatedNotActivated =
+    component?.data &&
+    (component.data.latitude !== 0 || component.data.longitude !== 0) &&
+    !Number.isFinite(component.data.ellipsoidalHeight);
+
+  const activateFromCallout = () => {
+    posthog.capture('geo_activation_callout_clicked');
+    openGeoModal();
+  };
+
   return (
     <Tooltip.Provider>
       <div className="geo-sidebar">
@@ -506,6 +522,42 @@ const GeoSidebar = ({ entity }) => {
                 </Button>
               </div>
             </div>
+
+            {/* Located-but-not-activated callout (#1654) */}
+            {isLocatedNotActivated && (
+              <div
+                className="propertyRow"
+                style={{ marginBottom: '12px', paddingRight: '12px' }}
+              >
+                <div
+                  style={{
+                    width: '100%',
+                    background: 'rgba(244, 160, 26, 0.08)',
+                    border: '1px solid rgba(244, 160, 26, 0.45)',
+                    borderRadius: '6px',
+                    padding: '10px 12px',
+                    fontSize: '12px',
+                    lineHeight: 1.45,
+                    color: '#f4a01a'
+                  }}
+                >
+                  <div style={{ fontWeight: 600, marginBottom: '4px' }}>
+                    📍 Location detected — map not activated
+                  </div>
+                  <div style={{ color: '#d1d5db', marginBottom: '8px' }}>
+                    This scene has a saved location, but the 3D map isn&apos;t
+                    loaded yet. Activate to fetch elevation and map tiles.
+                  </div>
+                  <Button
+                    variant="toolbtn"
+                    style={{ width: '100%' }}
+                    onClick={activateFromCallout}
+                  >
+                    Activate Map
+                  </Button>
+                </div>
+              </div>
+            )}
 
             {/* Upgrade prompt for users with 0 tokens */}
             {!currentUser?.isPro && tokenProfile?.geoToken === 0 && (

--- a/src/editor/components/elements/useAssetUploadStatus.js
+++ b/src/editor/components/elements/useAssetUploadStatus.js
@@ -21,6 +21,8 @@ export const REASON_TEXT = {
   optimized_too_large:
     'Even after optimization the file is over the upload limit. Preview only.',
   over_quota: 'Storage full — delete assets or upgrade to sync this model.',
+  file_too_large:
+    "Larger than your plan's per-file limit — upgrade to sync this model.",
   not_signed_in: 'Sign in to save this model to your cloud.',
   upload_blocked: 'Cloud upload was blocked.',
   asset_deleted:

--- a/src/editor/components/modals/GeoModal/GeoModal.component.jsx
+++ b/src/editor/components/modals/GeoModal/GeoModal.component.jsx
@@ -47,6 +47,11 @@ const TooltipWrapper = ({ children, content, side = 'bottom', ...props }) => {
   );
 };
 
+// One-time-per-session throttle for the activation-recovery toast (#1654).
+// The gate re-prompts on every map-type change, so without this a user who
+// keeps declining would get the same hint on every cancel.
+let activationHintToastShown = false;
+
 const GeoModal = () => {
   const { currentUser, tokenProfile, refreshTokenProfile } = useAuthContext();
   const { isLoaded } = useJsApiLoader({
@@ -70,8 +75,35 @@ const GeoModal = () => {
   const startCheckout = useStore((state) => state.startCheckout);
   const geojsonImportData = useStore((state) => state.geojsonImportData);
   const setGeojsonImportData = useStore((state) => state.setGeojsonImportData);
+  const geoModalFromActivationGate = useStore(
+    (state) => state.geoModalFromActivationGate
+  );
+  const setGeoModalFromActivationGate = useStore(
+    (state) => state.setGeoModalFromActivationGate
+  );
 
   const onClose = () => {
+    // Dead-end recovery (#1654): the activation gate auto-opened this modal
+    // and the user is dismissing without activating. The location is
+    // preserved, but nothing on screen says how to resume — point at the
+    // sidebar entry point. Successful activation clears the flag before
+    // closing, so this only fires on a real decline.
+    if (geoModalFromActivationGate) {
+      setGeoModalFromActivationGate(false);
+      posthog.capture('geo_activation_prompt_dismissed', {
+        latitude: markerPosition.lat,
+        longitude: markerPosition.lng,
+        is_pro_user: currentUser?.isPro || false,
+        tokens_available: tokenProfile?.geoToken || 0,
+        scene_id: STREET.utils.getCurrentSceneId()
+      });
+      if (!activationHintToastShown) {
+        activationHintToastShown = true;
+        STREET.notify.warningMessage(
+          'Location saved for later — use "Set Location" in the Geospatial panel to activate the 3D map.'
+        );
+      }
+    }
     returnToPreviousModal();
   };
 
@@ -191,6 +223,10 @@ const GeoModal = () => {
 
     if (result.success && result.data) {
       const data = result.data;
+
+      // Activation succeeded — the gate's offer was taken, so the dismissal
+      // handling in onClose must not fire when the success overlay closes.
+      setGeoModalFromActivationGate(false);
 
       // Refresh token profile to get updated count after successful save
       const previousTokenCount = tokenProfile?.geoToken || 0;

--- a/src/editor/components/modals/GeoModal/GeoModal.component.jsx
+++ b/src/editor/components/modals/GeoModal/GeoModal.component.jsx
@@ -47,11 +47,6 @@ const TooltipWrapper = ({ children, content, side = 'bottom', ...props }) => {
   );
 };
 
-// One-time-per-session throttle for the activation-recovery toast (#1654).
-// The gate re-prompts on every map-type change, so without this a user who
-// keeps declining would get the same hint on every cancel.
-let activationHintToastShown = false;
-
 const GeoModal = () => {
   const { currentUser, tokenProfile, refreshTokenProfile } = useAuthContext();
   const { isLoaded } = useJsApiLoader({
@@ -85,9 +80,10 @@ const GeoModal = () => {
   const onClose = () => {
     // Dead-end recovery (#1654): the activation gate auto-opened this modal
     // and the user is dismissing without activating. The location is
-    // preserved, but nothing on screen says how to resume — point at the
-    // sidebar entry point. Successful activation clears the flag before
-    // closing, so this only fires on a real decline.
+    // preserved and the Geospatial panel's status badge surfaces the
+    // "Location not activated" state with an Activate Map action, so no toast
+    // is needed here — we just record the decline. Successful activation
+    // clears the flag before closing, so this only fires on a real decline.
     if (geoModalFromActivationGate) {
       setGeoModalFromActivationGate(false);
       posthog.capture('geo_activation_prompt_dismissed', {
@@ -97,12 +93,6 @@ const GeoModal = () => {
         tokens_available: tokenProfile?.geoToken || 0,
         scene_id: STREET.utils.getCurrentSceneId()
       });
-      if (!activationHintToastShown) {
-        activationHintToastShown = true;
-        STREET.notify.warningMessage(
-          'Location saved for later — use "Set Location" in the Geospatial panel to activate the 3D map.'
-        );
-      }
     }
     returnToPreviousModal();
   };

--- a/src/editor/components/modals/GeoModal/GeoModal.component.jsx
+++ b/src/editor/components/modals/GeoModal/GeoModal.component.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { SavingModal } from '../SavingModal';
 import styles from './GeoModal.module.scss';
 import { Magnifier20Icon } from '@shared/icons';
@@ -17,6 +17,7 @@ import { setSceneLocation } from '../../../lib/utils.js';
 import useStore from '@/store.js';
 import { useAuthContext } from '../../../contexts/index.js';
 import { canUseGeoFeature } from '@shared/utils/tokens';
+import { GEO_SOURCES } from '@shared/constants/geoSources.js';
 import posthog from 'posthog-js';
 import { Tooltip } from 'radix-ui';
 
@@ -63,6 +64,11 @@ const GeoModal = () => {
   const [successData, setSuccessData] = useState(null);
   const [wasOpenedFromGeojson, setWasOpenedFromGeojson] = useState(false);
   const [currentLocationString, setCurrentLocationString] = useState('');
+  // True once the user actively picks a new spot (map click, search, manual
+  // coordinates) this session, as opposed to the prefill from the scene's
+  // existing location. Drives provenance: a deliberate change stamps source
+  // 'manual', while just activating the prefilled location keeps its origin.
+  const userChangedLocationRef = useRef(false);
   const returnToPreviousModal = useStore(
     (state) => state.returnToPreviousModal
   );
@@ -99,6 +105,9 @@ const GeoModal = () => {
 
   useEffect(() => {
     if (isOpen) {
+      // Fresh open: nothing the user touched yet, so the prefill below isn't a
+      // "change". Marker interactions flip this back to true.
+      userChangedLocationRef.current = false;
       // Check if we have GeoJSON import data first (takes priority)
       if (geojsonImportData && geojsonImportData.lat && geojsonImportData.lon) {
         const lat = roundCoord(geojsonImportData.lat);
@@ -119,7 +128,14 @@ const GeoModal = () => {
           .getElementById('reference-layers')
           ?.getAttribute('street-geo');
 
-        if (streetGeo && streetGeo['latitude'] && streetGeo['longitude']) {
+        // Use a real lat/lng prefill even at the equator / prime meridian — a
+        // 0 coordinate is valid, so test for presence, not truthiness.
+        const hasCoords =
+          streetGeo &&
+          streetGeo['latitude'] != null &&
+          streetGeo['longitude'] != null &&
+          (streetGeo['latitude'] !== 0 || streetGeo['longitude'] !== 0);
+        if (hasCoords) {
           const lat = roundCoord(parseFloat(streetGeo['latitude']));
           const lng = roundCoord(parseFloat(streetGeo['longitude']));
 
@@ -136,8 +152,22 @@ const GeoModal = () => {
     }
   }, [isOpen, geojsonImportData, setGeojsonImportData]);
 
+  // Safety net for the activation-gate flag (#1654). onClose consumes it for
+  // the dismissal event and clears it, and a successful save clears it too —
+  // but other exits bypass onClose entirely (e.g. the 0-token Save that
+  // switches to the checkout modal). Clear it on any close so the flag can't
+  // leak into a later, unrelated open and mis-fire geo_activation_prompt_dismissed.
+  useEffect(() => {
+    if (!isOpen) {
+      setGeoModalFromActivationGate(false);
+    }
+  }, [isOpen, setGeoModalFromActivationGate]);
+
   const setMarkerPositionAndElevation = useCallback((lat, lng) => {
     if (!isNaN(lat) && !isNaN(lng)) {
+      // A user-driven pick (map click, search, manual coords) — provenance
+      // becomes 'manual' on save.
+      userChangedLocationRef.current = true;
       setMarkerPosition({
         lat: roundCoord(lat),
         lng: roundCoord(lng)
@@ -176,9 +206,12 @@ const GeoModal = () => {
   }, [autocomplete]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onCloseCheck = (evt) => {
-    // do not close geoModal when clicking on a list with suggestions for addresses
-    const autocompleteContatiner = document.querySelector('.pac-container');
-    if (autocompleteContatiner.children.length === 0) {
+    // do not close geoModal when clicking on a list with suggestions for
+    // addresses. The .pac-container is injected by Google Places only once
+    // Autocomplete mounts, so it can be absent (geojson mode, API not loaded)
+    // — treat "no container" as "no open suggestions" and allow the close.
+    const autocompleteContainer = document.querySelector('.pac-container');
+    if (!autocompleteContainer || autocompleteContainer.children.length === 0) {
       onClose();
     }
   };
@@ -206,9 +239,15 @@ const GeoModal = () => {
       tokens_available: tokenProfile?.geoToken || 0
     });
 
-    // Use the shared utility function to set the scene location
+    // Use the shared utility function to set the scene location. A deliberate
+    // change of location stamps 'manual' provenance; just activating the
+    // prefilled location (or a geojson import) leaves the source resolution to
+    // setSceneLocation so the original origin is preserved.
     const result = await setSceneLocation(latitude, longitude, {
-      fromGeojsonImport: wasOpenedFromGeojson
+      fromGeojsonImport: wasOpenedFromGeojson,
+      ...(userChangedLocationRef.current && !wasOpenedFromGeojson
+        ? { source: GEO_SOURCES.MANUAL }
+        : {})
     });
 
     if (result.success && result.data) {

--- a/src/editor/components/scenegraph/AssetsPanel.jsx
+++ b/src/editor/components/scenegraph/AssetsPanel.jsx
@@ -13,6 +13,7 @@ import {
 import { openInGenerator } from '@/editor/lib/asset-modal-handlers.js';
 import pickPointOnGroundPlane from '@/editor/lib/pick-point-on-ground-plane';
 import { signIn } from '../../api';
+import useStore from '@/store';
 
 const handlePlaceAsset = (asset) => {
   const position = pickPointOnGroundPlane({
@@ -31,6 +32,7 @@ const AssetsPanel = () => (
     onUseForGenerator={(item) => openInGenerator(item, 'modify')}
     onUseForVideo={(item) => openInGenerator(item, 'video')}
     onSignIn={() => signIn()}
+    onUpgrade={() => useStore.getState().startCheckout('storage')}
   />
 );
 

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -13,6 +13,7 @@
 
 import * as THREE from 'three';
 import Events from '../Events.js';
+import { GEO_SOURCES } from '@shared/constants/geoSources.js';
 
 /**
  * Compose a managed-street entity from a flat segments array and create it
@@ -348,7 +349,7 @@ async function setLatLonHandler(args, currentUser) {
 
   const { setSceneLocation } = await import('../utils.js');
   const result = await setSceneLocation(latitude, longitude, {
-    source: 'ai-assistant'
+    source: GEO_SOURCES.AI_ASSISTANT
   });
 
   if (result.success) {

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -347,7 +347,9 @@ async function setLatLonHandler(args, currentUser) {
   }
 
   const { setSceneLocation } = await import('../utils.js');
-  const result = await setSceneLocation(latitude, longitude);
+  const result = await setSceneLocation(latitude, longitude, {
+    source: 'ai-assistant'
+  });
 
   if (result.success) {
     const data = result.data;

--- a/src/editor/lib/utils.js
+++ b/src/editor/lib/utils.js
@@ -113,22 +113,42 @@ export async function setSceneLocation(latitude, longitude, options = {}) {
       // Get the reference layers element
       const geoLayer = document.getElementById('reference-layers');
 
+      // Resolve provenance: an explicit caller source wins (e.g. the AI
+      // assistant), then geojson import, then the existing source if this is
+      // re-setting an already-tagged location (keeps the original origin),
+      // falling back to 'manual' for a fresh web "Set Location".
+      const existingGeo = geoLayer.hasAttribute('street-geo')
+        ? geoLayer.getAttribute('street-geo')
+        : null;
+      const existingSource = existingGeo?.source || '';
+      const source =
+        options.source ||
+        (options.fromGeojsonImport ? 'geojson' : existingSource || 'manual');
+
+      const value = {
+        latitude: lat,
+        longitude: lng,
+        ellipsoidalHeight: data.ellipsoidalHeight,
+        orthometricHeight: data.orthometricHeight,
+        geoidHeight: data.geoidHeight,
+        locationString: data.location?.locationString || '',
+        intersectionString: data.nearestIntersection?.intersectionString || '',
+        source
+      };
+
+      // Streetmix imports park the location with maps: 'none' so they don't
+      // auto-activate. Activating now means turning a map back on.
+      if (existingGeo?.maps === 'none') {
+        value.maps = 'google3d';
+      }
+
       // Update or add the street-geo component
       AFRAME.INSPECTOR.execute(
         geoLayer.hasAttribute('street-geo') ? 'entityupdate' : 'componentadd',
         {
           entity: geoLayer,
           component: 'street-geo',
-          value: {
-            latitude: lat,
-            longitude: lng,
-            ellipsoidalHeight: data.ellipsoidalHeight,
-            orthometricHeight: data.orthometricHeight,
-            geoidHeight: data.geoidHeight,
-            locationString: data.location?.locationString || '',
-            intersectionString:
-              data.nearestIntersection?.intersectionString || ''
-          }
+          value
         }
       );
 

--- a/src/editor/lib/utils.js
+++ b/src/editor/lib/utils.js
@@ -1,3 +1,5 @@
+import { GEO_SOURCES } from '@shared/constants/geoSources.js';
+
 export function equal(var1, var2) {
   var keys1;
   var keys2;
@@ -114,16 +116,19 @@ export async function setSceneLocation(latitude, longitude, options = {}) {
       const geoLayer = document.getElementById('reference-layers');
 
       // Resolve provenance: an explicit caller source wins (e.g. the AI
-      // assistant), then geojson import, then the existing source if this is
-      // re-setting an already-tagged location (keeps the original origin),
-      // falling back to 'manual' for a fresh web "Set Location".
+      // assistant, or the GeoModal stamping 'manual' when the user actually
+      // changes the location), then geojson import, then the existing source if
+      // this is re-activating an already-tagged location (keeps the original
+      // origin), falling back to 'manual' for a fresh web "Set Location".
       const existingGeo = geoLayer.hasAttribute('street-geo')
         ? geoLayer.getAttribute('street-geo')
         : null;
       const existingSource = existingGeo?.source || '';
       const source =
         options.source ||
-        (options.fromGeojsonImport ? 'geojson' : existingSource || 'manual');
+        (options.fromGeojsonImport
+          ? GEO_SOURCES.GEOJSON
+          : existingSource || GEO_SOURCES.MANUAL);
 
       const value = {
         latitude: lat,

--- a/src/shared/assets/components/AssetsPanelBody.jsx
+++ b/src/shared/assets/components/AssetsPanelBody.jsx
@@ -270,33 +270,23 @@ const AssetsPanelBody = ({
           />
         </div>
       </div>
-      {showStorageUpsell && isNearFull && (
-        <div className={styles.storageWarnRow}>
-          <span>Almost out of space for custom models.</span>
-          <button
-            type="button"
-            className={styles.upgradePill}
-            onClick={() => handleUpgradeClick('near_full')}
-          >
-            Upgrade →
-          </button>
-        </div>
-      )}
-      {showStorageUpsell && isFull && !fullCardDismissed && (
+      {showStorageUpsell && (isNearFull || isFull) && !fullCardDismissed && (
         <div className={styles.storageFullCard}>
           <div className={styles.storageFullTitle}>
-            You&apos;ve filled your free storage
+            {isFull
+              ? "You've filled your free storage"
+              : "You've almost filled your free storage"}
           </div>
           <div className={styles.storageFullCopy}>
-            Your work is safe. Pro gives you 5 GB to grow into — 50× more space
-            for custom models and textures.
+            {isFull ? 'Your work is safe. ' : ''}Pro gives you 5 GB to grow
+            into, 50× more space for custom models and textures.
           </div>
           <button
             type="button"
             className={styles.goProButton}
-            onClick={() => handleUpgradeClick('full')}
+            onClick={() => handleUpgradeClick(isFull ? 'full' : 'near_full')}
           >
-            Go Pro — unlock 5 GB <span className={styles.pricePill}>$7/mo</span>
+            Go Pro: unlock 5 GB <span className={styles.pricePill}>$7/mo</span>
           </button>
           <button
             type="button"
@@ -324,9 +314,8 @@ const AssetsPanelBody = ({
             You&apos;ve got{' '}
             <strong>
               {formatBytes(usage.planLimit - usage.bytesUsed)} to play with
-            </strong>{' '}
-            — that&apos;s room for HDRIs, ground textures, and a few hero
-            models.
+            </strong>
+            , room for HDRIs, ground textures, and a few hero models.
           </div>
         </div>
       )}

--- a/src/shared/assets/components/AssetsPanelBody.jsx
+++ b/src/shared/assets/components/AssetsPanelBody.jsx
@@ -80,31 +80,42 @@ const AssetsPanelBody = ({
     setHintDismissed(true);
   };
 
+  // Storage usage thresholds (#1644), computed once and shared by the
+  // impression effect below and the render. tier is null until getUploadQuota
+  // responds (no flicker); upsells only apply to the FREE tier with a
+  // host-provided checkout entry (the generator passes none).
+  const planKnown = usage.planLimit != null;
+  const usageRatio =
+    planKnown && usage.planLimit > 0
+      ? Math.min(1, usage.bytesUsed / usage.planLimit)
+      : 0;
+  const isFull = planKnown && usageRatio >= 1;
+  const isNearFull = planKnown && !isFull && usageRatio >= 0.8;
+  const showStorageUpsell = usage.tier === 'FREE' && !!onUpgrade;
+  // Severity of the upgrade card that actually renders — null when no card can
+  // show, so we never log an impression for a prompt the user can't see.
+  const upsellSeverity =
+    showStorageUpsell && isFull
+      ? 'full'
+      : showStorageUpsell && isNearFull
+        ? 'near_full'
+        : null;
+
   // Funnel: log each time the meter crosses into a new upsell severity so
   // PostHog can compare prompt impressions against storage_upsell_clicked /
   // checkout_started. Ref-guarded to once per severity per mount. Lives
   // above the early returns to keep hook order stable.
   const shownSeverityRef = useRef(null);
-  const ratioForEffect =
-    usage.planLimit > 0 ? usage.bytesUsed / usage.planLimit : 0;
-  const severityForEffect =
-    usage.tier === 'FREE' && usage.planLimit != null
-      ? ratioForEffect >= 1
-        ? 'full'
-        : ratioForEffect >= 0.8
-          ? 'near_full'
-          : null
-      : null;
   useEffect(() => {
-    if (!severityForEffect) return;
-    if (shownSeverityRef.current === severityForEffect) return;
-    shownSeverityRef.current = severityForEffect;
+    if (!upsellSeverity) return;
+    if (shownSeverityRef.current === upsellSeverity) return;
+    shownSeverityRef.current = upsellSeverity;
     posthog.capture('storage_upsell_shown', {
-      severity: severityForEffect,
+      severity: upsellSeverity,
       bytes_used: usage.bytesUsed,
       plan_limit: usage.planLimit
     });
-  }, [severityForEffect, usage.bytesUsed, usage.planLimit]);
+  }, [upsellSeverity, usage.bytesUsed, usage.planLimit]);
 
   useEffect(() => {
     const node = sentinelRef.current;
@@ -165,16 +176,6 @@ const AssetsPanelBody = ({
     );
   }
 
-  const planKnown = usage.planLimit != null;
-  const usageRatio =
-    planKnown && usage.planLimit > 0
-      ? Math.min(1, usage.bytesUsed / usage.planLimit)
-      : 0;
-  const isFull = planKnown && usageRatio >= 1;
-  const isNearFull = planKnown && !isFull && usageRatio >= 0.8;
-  // Upsells only make sense on the FREE tier with a host-provided checkout
-  // entry point. tier is null until getUploadQuota responds — no flicker.
-  const showStorageUpsell = usage.tier === 'FREE' && !!onUpgrade;
   const showLowUsageHint =
     usage.tier === 'FREE' &&
     planKnown &&

--- a/src/shared/assets/components/AssetsPanelBody.jsx
+++ b/src/shared/assets/components/AssetsPanelBody.jsx
@@ -316,7 +316,7 @@ const AssetsPanelBody = ({
             <strong>
               {formatBytes(usage.planLimit - usage.bytesUsed)} to play with
             </strong>
-            , room for HDRIs, ground textures, and a few hero models.
+            , room for 3D models, splats, images, videos and more.
           </div>
         </div>
       )}

--- a/src/shared/assets/components/AssetsPanelBody.jsx
+++ b/src/shared/assets/components/AssetsPanelBody.jsx
@@ -9,6 +9,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import posthog from 'posthog-js';
 import {
   useAssets,
   AssetsContent,
@@ -51,7 +52,11 @@ const AssetsPanelBody = ({
   // doesn't inspect it. Only the default shared uploader returns
   // { ok, error } and is the only branch where the body forwards errors to
   // onNotification.
-  onUpload
+  onUpload,
+  // Storage upsell entry point (#1644). Editor passes a startCheckout
+  // wrapper; when omitted (generator today) the usage meter still warns but
+  // no upgrade CTAs render — keeps this shared body free of checkout wiring.
+  onUpgrade
 }) => {
   const assetsState = useAssets();
   const { items, isLoggedIn, isLoadingMore, hasMore, reloadItems, loadMore } =
@@ -61,6 +66,45 @@ const AssetsPanelBody = ({
   const [filter, setFilter] = useState('all');
   const usage = useStorageUsage(isLoggedIn);
   const isUploading = useCurrentUploadStore((s) => !!s.upload);
+
+  // Storage upsell state (#1644). The full-storage card's soft decline
+  // ("free up space instead") hides it for this mount only — it returns next
+  // session while the account is still full. The low-usage hint dismisses
+  // permanently via localStorage.
+  const [fullCardDismissed, setFullCardDismissed] = useState(false);
+  const [hintDismissed, setHintDismissed] = useState(
+    () => localStorage.getItem('assetsLowUsageHintDismissed') === '1'
+  );
+  const dismissHint = () => {
+    localStorage.setItem('assetsLowUsageHintDismissed', '1');
+    setHintDismissed(true);
+  };
+
+  // Funnel: log each time the meter crosses into a new upsell severity so
+  // PostHog can compare prompt impressions against storage_upsell_clicked /
+  // checkout_started. Ref-guarded to once per severity per mount. Lives
+  // above the early returns to keep hook order stable.
+  const shownSeverityRef = useRef(null);
+  const ratioForEffect =
+    usage.planLimit > 0 ? usage.bytesUsed / usage.planLimit : 0;
+  const severityForEffect =
+    usage.tier === 'FREE' && usage.planLimit != null
+      ? ratioForEffect >= 1
+        ? 'full'
+        : ratioForEffect >= 0.8
+          ? 'near_full'
+          : null
+      : null;
+  useEffect(() => {
+    if (!severityForEffect) return;
+    if (shownSeverityRef.current === severityForEffect) return;
+    shownSeverityRef.current = severityForEffect;
+    posthog.capture('storage_upsell_shown', {
+      severity: severityForEffect,
+      bytes_used: usage.bytesUsed,
+      plan_limit: usage.planLimit
+    });
+  }, [severityForEffect, usage.bytesUsed, usage.planLimit]);
 
   useEffect(() => {
     const node = sentinelRef.current;
@@ -127,6 +171,26 @@ const AssetsPanelBody = ({
       ? Math.min(1, usage.bytesUsed / usage.planLimit)
       : 0;
   const isFull = planKnown && usageRatio >= 1;
+  const isNearFull = planKnown && !isFull && usageRatio >= 0.8;
+  // Upsells only make sense on the FREE tier with a host-provided checkout
+  // entry point. tier is null until getUploadQuota responds — no flicker.
+  const showStorageUpsell = usage.tier === 'FREE' && !!onUpgrade;
+  const showLowUsageHint =
+    usage.tier === 'FREE' &&
+    planKnown &&
+    !hintDismissed &&
+    items.length > 0 &&
+    usageRatio > 0 &&
+    usageRatio < 0.5;
+
+  const handleUpgradeClick = (severity) => {
+    posthog.capture('storage_upsell_clicked', {
+      severity,
+      bytes_used: usage.bytesUsed,
+      plan_limit: usage.planLimit
+    });
+    onUpgrade();
+  };
 
   const filteredAssetsState = { ...assetsState, items: filteredItems };
 
@@ -188,7 +252,9 @@ const AssetsPanelBody = ({
           </button>
         ))}
       </div>
-      <div className={styles.usageRow}>
+      <div
+        className={`${styles.usageRow} ${isNearFull || isFull ? styles.usageRowWarn : ''}`}
+      >
         {planKnown ? (
           <>
             Uploads: {formatBytes(usage.bytesUsed)} /{' '}
@@ -199,11 +265,71 @@ const AssetsPanelBody = ({
         )}
         <div className={styles.usageBar}>
           <div
-            className={`${styles.usageFill} ${isFull ? styles.full : ''}`}
+            className={`${styles.usageFill} ${isFull ? styles.full : ''} ${isNearFull ? styles.warn : ''}`}
             style={{ width: `${Math.round(usageRatio * 100)}%` }}
           />
         </div>
       </div>
+      {showStorageUpsell && isNearFull && (
+        <div className={styles.storageWarnRow}>
+          <span>Almost out of space for custom models.</span>
+          <button
+            type="button"
+            className={styles.upgradePill}
+            onClick={() => handleUpgradeClick('near_full')}
+          >
+            Upgrade →
+          </button>
+        </div>
+      )}
+      {showStorageUpsell && isFull && !fullCardDismissed && (
+        <div className={styles.storageFullCard}>
+          <div className={styles.storageFullTitle}>
+            You&apos;ve filled your free storage
+          </div>
+          <div className={styles.storageFullCopy}>
+            Your work is safe. Pro gives you 5 GB to grow into — 50× more space
+            for custom models and textures.
+          </div>
+          <button
+            type="button"
+            className={styles.goProButton}
+            onClick={() => handleUpgradeClick('full')}
+          >
+            Go Pro — unlock 5 GB <span className={styles.pricePill}>$7/mo</span>
+          </button>
+          <button
+            type="button"
+            className={styles.linkButton}
+            onClick={() => setFullCardDismissed(true)}
+          >
+            or free up space instead
+          </button>
+        </div>
+      )}
+      {showLowUsageHint && (
+        <div className={styles.hintCard}>
+          <div className={styles.hintHeader}>
+            <span className={styles.hintTitle}>Make your scenes feel real</span>
+            <button
+              type="button"
+              className={styles.hintDismiss}
+              onClick={dismissHint}
+              aria-label="Dismiss hint"
+            >
+              ✕
+            </button>
+          </div>
+          <div className={styles.hintCopy}>
+            You&apos;ve got{' '}
+            <strong>
+              {formatBytes(usage.planLimit - usage.bytesUsed)} to play with
+            </strong>{' '}
+            — that&apos;s room for HDRIs, ground textures, and a few hero
+            models.
+          </div>
+        </div>
+      )}
       <div className={styles.scrollArea}>
         <AssetsContent
           gallery={filteredAssetsState}

--- a/src/shared/assets/components/AssetsPanelBody.module.scss
+++ b/src/shared/assets/components/AssetsPanelBody.module.scss
@@ -135,33 +135,6 @@
 
 /* Storage upsell (#1644) */
 
-.storageWarnRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 0 12px 8px;
-  font-size: 11px;
-  color: #f4a01a;
-  flex-shrink: 0;
-}
-
-.upgradePill {
-  all: unset;
-  padding: 4px 10px;
-  background: #f4a01a;
-  color: #1a1a1a;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 11px;
-  font-weight: 600;
-  white-space: nowrap;
-
-  &:hover {
-    background: #ffb53d;
-  }
-}
-
 .storageFullCard {
   display: flex;
   flex-direction: column;

--- a/src/shared/assets/components/AssetsPanelBody.module.scss
+++ b/src/shared/assets/components/AssetsPanelBody.module.scss
@@ -125,6 +125,155 @@
   background: #e0473d;
 }
 
+.usageFill.warn {
+  background: #f4a01a;
+}
+
+.usageRowWarn {
+  color: #f4a01a;
+}
+
+/* Storage upsell (#1644) */
+
+.storageWarnRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 12px 8px;
+  font-size: 11px;
+  color: #f4a01a;
+  flex-shrink: 0;
+}
+
+.upgradePill {
+  all: unset;
+  padding: 4px 10px;
+  background: #f4a01a;
+  color: #1a1a1a;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+
+  &:hover {
+    background: #ffb53d;
+  }
+}
+
+.storageFullCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 12px 10px;
+  padding: 12px;
+  border-radius: 8px;
+  background: rgba(137, 101, 239, 0.08);
+  border: 1px solid rgba(137, 101, 239, 0.4);
+  color: #dbdbdb;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.storageFullTitle {
+  font-weight: 600;
+  color: #fff;
+  font-size: 13px;
+}
+
+.storageFullCopy {
+  line-height: 1.45;
+  color: #bbb;
+}
+
+.goProButton {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #8965ef;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+
+  &:hover {
+    background: #6a4ac3;
+  }
+}
+
+.pricePill {
+  background: rgba(255, 255, 255, 0.85);
+  color: #4c1d95;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.linkButton {
+  all: unset;
+  cursor: pointer;
+  color: #9ca3af;
+  font-size: 11px;
+  text-align: center;
+
+  &:hover {
+    color: #fff;
+    text-decoration: underline;
+  }
+}
+
+/* Low-usage hint (#1644 pt 3) */
+
+.hintCard {
+  margin: 0 12px 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(43, 182, 115, 0.07);
+  border: 1px solid rgba(43, 182, 115, 0.35);
+  font-size: 12px;
+  color: #dbdbdb;
+  flex-shrink: 0;
+}
+
+.hintHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.hintTitle {
+  font-weight: 600;
+  color: #2bb673;
+}
+
+.hintDismiss {
+  all: unset;
+  cursor: pointer;
+  color: #9ca3af;
+  font-size: 12px;
+  padding: 0 2px;
+
+  &:hover {
+    color: #fff;
+  }
+}
+
+.hintCopy {
+  line-height: 1.45;
+  color: #bbb;
+
+  strong {
+    color: #2bb673;
+  }
+}
+
 .scrollArea {
   flex: 1 1 auto;
   min-height: 0;

--- a/src/shared/components/UpgradeModal/paywallSurfaces.jsx
+++ b/src/shared/components/UpgradeModal/paywallSurfaces.jsx
@@ -169,7 +169,7 @@ export const PAYWALL_SURFACES = {
     subtitle: 'Custom models & textures',
     headline: '50× more space for custom models',
     description:
-      'Your work is safe. The Free plan includes 100 MB of asset storage — Pro gives you 5 GB to grow into for custom models, textures, and splats.',
+      'Your work is safe. The Free plan includes 100 MB of asset storage; Pro gives you 5 GB to grow into for custom models, textures, and splats.',
     features: [
       '5 GB custom model & asset storage',
       'Import custom 3D models & SVG / glTF files',

--- a/src/shared/components/UpgradeModal/paywallSurfaces.jsx
+++ b/src/shared/components/UpgradeModal/paywallSurfaces.jsx
@@ -62,6 +62,23 @@ const SparklesIcon = () => (
   </svg>
 );
 
+const DatabaseIcon = () => (
+  <svg
+    width="22"
+    height="22"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <ellipse cx="12" cy="5" rx="9" ry="3" />
+    <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
+    <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
+  </svg>
+);
+
 const MapPinIcon = () => (
   <svg
     width="22"
@@ -138,6 +155,26 @@ export const PAYWALL_SURFACES = {
       'Download JPEG snapshots without watermark',
       'GLB glTF & AR Ready GLB export',
       'Import custom 3D models & SVG / glTF files',
+      TOKEN_FEATURE_LINE
+    ]
+  },
+
+  // Cloud storage for custom assets — fired by the assets panel's 80%/100%
+  // usage prompts and by the sidebar Upgrade button on an upload blocked by
+  // quota (#1644). Copy works for both "almost full" and "full" triggers;
+  // FREE 100 MB → PRO 5 GB is the 50× claim.
+  storage: {
+    icon: <DatabaseIcon />,
+    title: 'Cloud Storage',
+    subtitle: 'Custom models & textures',
+    headline: '50× more space for custom models',
+    description:
+      'Your work is safe. The Free plan includes 100 MB of asset storage — Pro gives you 5 GB to grow into for custom models, textures, and splats.',
+    features: [
+      '5 GB custom model & asset storage',
+      'Import custom 3D models & SVG / glTF files',
+      'Download JPEG snapshots without watermark',
+      'Unlimited geospatial maps & location changes',
       TOKEN_FEATURE_LINE
     ]
   },

--- a/src/shared/constants/geoSources.js
+++ b/src/shared/constants/geoSources.js
@@ -1,0 +1,39 @@
+/**
+ * Geo location provenance — single source of truth for the street-geo `source`
+ * field (#1644 / #1654). Every producer that establishes a scene's geospatial
+ * location should stamp one of these values, and the Geospatial panel maps them
+ * to human copy via geoSourcePhrase(). An empty source means "unknown" (legacy
+ * scenes saved before this field existed).
+ */
+export const GEO_SOURCES = {
+  STREETMIX: 'streetmix',
+  GEOJSON: 'geojson',
+  MANUAL: 'manual',
+  // The 3DStreet mobile app (Bollard Buddy, separate iOS repo).
+  BOLLARD_BUDDY: 'bollard-buddy',
+  AI_ASSISTANT: 'ai-assistant'
+};
+
+// Human phrase for where a saved-but-not-activated location came from, shown in
+// the Geospatial panel hero. A source with no entry here (e.g. MANUAL) renders
+// with no attribution.
+const GEO_SOURCE_PHRASES = {
+  [GEO_SOURCES.STREETMIX]: 'imported from Streetmix',
+  [GEO_SOURCES.GEOJSON]: 'imported from GeoJSON',
+  [GEO_SOURCES.AI_ASSISTANT]: 'set by the AI assistant',
+  [GEO_SOURCES.BOLLARD_BUDDY]: 'from the 3DStreet app'
+};
+
+/**
+ * Map a source value to display copy. Legacy scenes with no stamped source are,
+ * in practice, from the mobile app (historically the only path that left a
+ * location unactivated), so an empty/undefined source defaults to the app
+ * phrasing. Unknown non-empty values return '' so we don't attribute a source
+ * we can't name.
+ */
+export const geoSourcePhrase = (source) => {
+  if (source === undefined || source === '') {
+    return GEO_SOURCE_PHRASES[GEO_SOURCES.BOLLARD_BUDDY];
+  }
+  return GEO_SOURCE_PHRASES[source] || '';
+};

--- a/src/store.js
+++ b/src/store.js
@@ -172,6 +172,14 @@ const useStore = create(
         // GeoJSON import data for pre-filling the Geo Modal
         geojsonImportData: null,
         setGeojsonImportData: (data) => set({ geojsonImportData: data }),
+        // True while the geo modal was auto-opened by the street-geo
+        // activation gate (scene located but never activated). Lets the
+        // modal distinguish "user dismissed the activation offer" from a
+        // normal close so it can surface the recovery path. Cleared on
+        // activation success and on dismiss.
+        geoModalFromActivationGate: false,
+        setGeoModalFromActivationGate: (value) =>
+          set({ geoModalFromActivationGate: value }),
         isGridVisible: true,
         setIsGridVisible: (newIsGridVisible) => {
           Events.emit('gridvisibilitychanged', newIsGridVisible);


### PR DESCRIPTION
## Summary

PLG upsell part 2: asset storage upgrade prompts and the geospatial activation redesign.

### Asset storage upsell
- Unified near-full / full upgrade card in the Assets panel ("You've almost / already filled your free storage"), low-usage hint, and a blocked-upload upgrade CTA + retry in AssetInfoPanel.
- New `storage` paywall surface and PostHog funnel events (storage_upsell_shown / clicked).

### Geospatial panel redesign + location provenance
- `GeoHero` spine: geo-specific controls (map type, location details, blending) are gated behind an activated location; empty and located-but-not-activated states show a single honest "Add Geo Layer" CTA with geo-token reinforcement. Removed the contradictory badge and the dismiss toast.
- New `street-geo` `source` field for location provenance, stamped across every origin: streetmix, geojson, manual, bollard-buddy (mobile app, separate iOS repo), and ai-assistant. Source-aware copy in the hero.
- Streetmix imports now carry their location (parked with `maps: 'none'`, activated on demand).

Closes #1644
Closes #1654

Follow-up geo work (GeoModal redesign, activated "Location Set" panel, 3D-canvas callout) tracked in #1677.