### PR TITLE
fix: resolve logic bugs in Stripe webhook handlers

### DIFF
--- a/public/functions/index.js
+++ b/public/functions/index.js
@@ -313,16 +313,13 @@ exports.handleSubscriptionWebhook = functions
 
     const collectionRef = admin.firestore().collection("userProfile");
     const querySnapshot = await collectionRef.where("stripeCustomerId", "==", subscription.customer).get();
-    let userId = null;
-    querySnapshot.forEach((doc) => {
-      userId = doc.data().userId;
-      return; // only need the first one
-    });
 
-    if (!userId) {
-      // add stripeCustomerId to userProfile
-      return res.sendStatus(500);
+    if (querySnapshot.empty) {
+      console.error(`Subscription deleted for customer ${subscription.customer}, but no user found in userProfile.`);
+      return res.sendStatus(200);
     }
+
+    const userId = querySnapshot.docs[0].data().userId;
 
     // Set custom user claims on this update.
     const customClaims = {
@@ -331,8 +328,6 @@ exports.handleSubscriptionWebhook = functions
     await getAuth().setCustomUserClaims(userId, customClaims);
 
     return res.sendStatus(200);
-
-
   });
 
 // function for Stripe webhook checkout.session.completed
@@ -402,20 +397,17 @@ exports.stripeWebhook = functions
 
     const collectionRef = admin.firestore().collection("userProfile");
     const querySnapshot = await collectionRef.where("userId", "==", checkoutSession.metadata.userId).get();
-    let stripeCustomerId = null;
 
-    querySnapshot.forEach((doc) => {
-      stripeCustomerId = doc.data().stripeCustomerId;
-      return; // only need the first one
-    });
-
-    // Update or create user profile with stripeCustomerId
-    if (!stripeCustomerId) {
-      // add stripeCustomerId to userProfile
-      await admin.firestore().collection('userProfile').doc().set({
-        userId: checkoutSession.metadata.userId,
-        stripeCustomerId: checkoutSession.customer
-      });
+    if (querySnapshot.empty) {
+        // Create new profile
+        await admin.firestore().collection('userProfile').add({
+          userId: checkoutSession.metadata.userId,
+          stripeCustomerId: checkoutSession.customer
+        });
+    } else {
+        // Update existing
+        const doc = querySnapshot.docs[0];
+        await doc.ref.update({ stripeCustomerId: checkoutSession.customer });
     }
 
     // Set custom user claims on this update.


### PR DESCRIPTION
This PR addresses critical logic bugs within the Stripe webhook processing functions in `public/functions/index.js`:

1. **Corrected `userProfile` Upsert Logic (`stripeWebhook`):** Previously, the implementation of `stripeWebhook` incorrectly used `doc().set()` on a new, random document reference when a `stripeCustomerId` was missing, rather than updating the existing `userProfile` document associated with the `userId`. This has been updated to properly check for an existing profile and either update it or create a new one correctly using `.add()`.

2. **Improved Webhook Robustness (`handleSubscriptionWebhook`):** The previous implementation of `handleSubscriptionWebhook` returned a 500 error if a user was not found for a given `stripeCustomerId`. This could trigger unnecessary and unproductive retries from Stripe. The logic has been updated to log the inconsistency for internal investigation and return a 200 OK status, acknowledging the event without attempting a non-recoverable operation.

3. **General Cleanup:** Removed misleading placeholders and incomplete logic comments in the webhook handlers.

These changes improve system reliability and ensure that user profile data remains synchronized with Stripe's state.