### PR TITLE
Generator: 360 → Splat from raw .insv (direct dual-fisheye vid2scene path)

### DIFF
--- a/public/functions/replicate-models.js
+++ b/public/functions/replicate-models.js
@@ -201,13 +201,17 @@ const REPLICATE_MODELS = {
   // images reject the unknown kwarg and the job fails at the SfM stage.
   // RESEARCH-PREVIEW TIER: priced at Max (the insv path renders ~800 frame
   // pairs x 18 virtual views ≈ 1,600 SfM images — Max-like COGS until a
-  // calibration run says otherwise).
+  // calibration run says otherwise). MAX-PLAN ONLY: raw .insv files run
+  // ~900 MB/min, so the upload rides the MAX tier's 5 GB per-file cap, and
+  // the processing cost matches the top plan anyway. Enforced server-side in
+  // generateReplicateSplat via resolvePlanForUser (fresh custom claims).
   'vid2scene-360': {
     name: 'vid2scene 360 (.insv to Splat)',
     modelName: 'kfarr/vid2scene',
     type: 'splat',
     inputKind: 'video',
     provider: 'modal',
+    requiresPlan: 'MAX',
     assetSlug: 'vid2scene-splat',
     assetLabel: 'vid2scene Splat',
     attribution: {

--- a/public/functions/replicate-models.js
+++ b/public/functions/replicate-models.js
@@ -191,6 +191,39 @@ const REPLICATE_MODELS = {
       resolution: 1920
     },
     tokenCost: 60
+  },
+  // 360 → Splat: a raw Insta360 .insv recording in, reconstructed DIRECTLY
+  // from its two fisheye sensor streams (no Insta360 Studio stitch). The
+  // `insv_fisheye` knob rides the enqueue body like every other pipeline knob;
+  // it must be explicit because the staged Modal input file has no extension,
+  // so the pipeline's .insv auto-detection never fires. Requires the cog image
+  // built from vid2scene-cog#insv-fisheye (upstream pin cog-phase2) — older
+  // images reject the unknown kwarg and the job fails at the SfM stage.
+  // RESEARCH-PREVIEW TIER: priced at Max (the insv path renders ~800 frame
+  // pairs x 18 virtual views ≈ 1,600 SfM images — Max-like COGS until a
+  // calibration run says otherwise).
+  'vid2scene-360': {
+    name: 'vid2scene 360 (.insv to Splat)',
+    modelName: 'kfarr/vid2scene',
+    type: 'splat',
+    inputKind: 'video',
+    provider: 'modal',
+    assetSlug: 'vid2scene-splat',
+    assetLabel: 'vid2scene Splat',
+    attribution: {
+      model: 'samuelm2/vid2scene',
+      modelName: 'vid2scene 360 (.insv to Splat)',
+      sourceType: 'video'
+    },
+    pipeline: {
+      // The pipeline floors the .insv image budget at 800 anyway; state it.
+      target_framecount: 800,
+      training_num_steps: 30000,
+      training_max_num_gaussians: 2000000,
+      resolution: 1920,
+      insv_fisheye: true
+    },
+    tokenCost: 60
   }
 };
 

--- a/public/functions/replicate.js
+++ b/public/functions/replicate.js
@@ -5,6 +5,8 @@ const crypto = require('crypto');
 const { Readable } = require('stream');
 const { pipeline } = require('stream/promises');
 const { checkAndRefillImageTokensInternal } = require('./token-management.js');
+// Plan-tier resolution for plan-gated models (e.g. vid2scene-360 is MAX-only).
+const { resolvePlanForUser } = require('./asset-quota.js');
 const { AI_MODEL_NAMES, DEFAULT_MODEL_VERSION, MODEL_VERSIONS, REPLICATE_MODELS } = require('./replicate-models.js');
 // Modal compute backend — vid2scene runs there (Replicate's on-demand tier
 // preempts long jobs). Provider adapter only; the job/billing machinery in
@@ -830,6 +832,22 @@ const generateReplicateSplat = functions
     // Which compute backend runs this model. Everything except the submit /
     // status-fetch / result-save mechanics is provider-agnostic.
     const provider = modelConfig?.provider || 'replicate';
+
+    // Plan gate: some models (vid2scene-360's multi-GB .insv uploads at
+    // Max-tier COGS) are restricted to a minimum plan tier. resolvePlanForUser
+    // reads fresh custom claims server-side; ALLOWED_PRO_TEAM_DOMAINS (its
+    // team-domain fallback) is already in this function's secrets. The client
+    // pre-checks the same gate before uploading, so this is the backstop.
+    if (modelConfig?.requiresPlan) {
+      const planRanks = { FREE: 0, PRO: 1, MAX: 2 };
+      const { tier } = await resolvePlanForUser(userId);
+      if ((planRanks[tier] ?? 0) < (planRanks[modelConfig.requiresPlan] ?? 0)) {
+        throw new functions.https.HttpsError(
+          'permission-denied',
+          `${modelConfig.name} requires the ${modelConfig.requiresPlan} plan.`
+        );
+      }
+    }
 
     let tokenData;
     try {

--- a/public/functions/replicate.js
+++ b/public/functions/replicate.js
@@ -1176,6 +1176,78 @@ async function cleanupSplatTempFile(tempFilePath) {
   }
 }
 
+// FAILED jobs retain their staged source instead of deleting it, so a
+// research-preview failure (e.g. an .insv whose factory calibration didn't
+// parse) can be debugged and re-run against the exact input — re-uploading a
+// multi-GB raw recording to reproduce a failure is not acceptable. The file is
+// flipped back to private (enqueue makePublic()'d it for the provider fetch),
+// and a pointer doc drives the reconciler's GC sweep, which deletes retained
+// sources after RETAINED_SOURCE_TTL_DAYS. Success and user-cancel still clean
+// up immediately. Best-effort: never lets retention break job finalization.
+async function retainSplatTempFile(db, userId, jobId, job, reason) {
+  const tempFilePath = job.tempFilePath;
+  if (!tempFilePath) return null;
+  try {
+    await admin
+      .storage()
+      .bucket()
+      .file(tempFilePath)
+      .makePrivate()
+      .catch((err) =>
+        console.warn('Failed to make retained splat source private:', err.message)
+      );
+    await db.collection('retainedSplatSources').doc(jobId).set({
+      path: tempFilePath,
+      userId,
+      jobId,
+      modelId: job.modelId || null,
+      provider: job.provider || 'replicate',
+      error: (reason || 'unknown').slice(0, 1000),
+      failedAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+    console.warn(
+      `Retained failed splat source for job ${jobId}: ${tempFilePath}`
+    );
+    return tempFilePath;
+  } catch (err) {
+    console.warn('Failed to retain splat source:', err);
+    return null;
+  }
+}
+
+// Operator notification for failed splat jobs — same Discord webhook the image
+// generator posts to. Fire-and-forget; a research-preview failure the team
+// never hears about is a failure that never gets fixed.
+async function postSplatFailureToDiscord(userId, jobId, job, reason, retainedPath) {
+  if (!process.env.DISCORD_WEBHOOK_URL) return;
+  try {
+    const embed = {
+      title: `Splat job failed: ${job.modelId || job.model || 'unknown model'}`,
+      description: (reason || 'unknown error').slice(0, 2000),
+      color: 0xef4444,
+      fields: [
+        { name: 'Job', value: jobId, inline: true },
+        { name: 'User', value: userId, inline: true },
+        { name: 'Provider', value: job.provider || 'replicate', inline: true },
+        ...(retainedPath
+          ? [{ name: 'Source retained for re-run', value: retainedPath }]
+          : [])
+      ],
+      timestamp: new Date().toISOString()
+    };
+    const response = await fetch(process.env.DISCORD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds: [embed] })
+    });
+    if (!response.ok) {
+      console.warn(`Discord splat-failure post failed: HTTP ${response.status}`);
+    }
+  } catch (err) {
+    console.warn('Discord splat-failure post failed:', err.message);
+  }
+}
+
 // How long a `status: 'saving'` claim is trusted before another caller may
 // re-take it. A save that's killed mid-flight (e.g. an OOM while downloading a
 // large .ply) never releases its claim, so without this the job would wedge in
@@ -1512,7 +1584,12 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
     if (!splatUrl) {
       console.error('Unexpected SHARP output:', JSON.stringify(prediction.output, null, 2));
       const remainingTokens = await refundSplatToken(db, userId, jobRef, job);
-      await cleanupSplatTempFile(job.tempFilePath);
+      const retained = await retainSplatTempFile(
+        db, userId, jobRef.id, job, 'Invalid output from model.'
+      );
+      postSplatFailureToDiscord(
+        userId, jobRef.id, job, 'Invalid output from model.', retained
+      ).catch(() => {});
       await jobRef.update({
         status: 'failed',
         error: 'Invalid output from model.',
@@ -1573,7 +1650,16 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
     const snap = await jobRef.get();
     const job = snap.data() || {};
     const remainingTokens = await refundSplatToken(db, userId, jobRef, job);
-    await cleanupSplatTempFile(job.tempFilePath);
+    // Failure → retain the staged source (debuggable, re-runnable) and tell
+    // the team. User-cancel is not a defect: clean up immediately as before.
+    if (normalized === 'failed') {
+      const reason = prediction.error || 'Splat generation failed.';
+      const retained = await retainSplatTempFile(db, userId, jobRef.id, job, reason);
+      postSplatFailureToDiscord(userId, jobRef.id, job, reason, retained)
+        .catch(() => {});
+    } else {
+      await cleanupSplatTempFile(job.tempFilePath);
+    }
     await jobRef.update({
       status: normalized,
       providerStatus: prediction.status,
@@ -1632,7 +1718,8 @@ async function ackClientSeen(jobRef, job) {
 
 const getGenerationJobStatus = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', ...MODAL_SECRETS],
+    // DISCORD_WEBHOOK_URL: failure finalization posts an operator notification.
+    secrets: ['REPLICATE_API_TOKEN', 'DISCORD_WEBHOOK_URL', ...MODAL_SECRETS],
     // saveSplatToGallery streams the .ply through (no full-file buffering), so
     // memory no longer scales with splat size. 512 MB is fixed headroom over the
     // firebase-admin cold-start baseline, not sized to the file.
@@ -1831,7 +1918,8 @@ const replicateJobWebhook = functions
   .runWith({
     // POSTMARK_API_KEY: the webhook sends the completion email in real time
     // (sendGenerationReadyEmail), so it needs the Postmark secret in its env.
-    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY'],
+    // DISCORD_WEBHOOK_URL: failure finalization posts an operator notification.
+    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL'],
     // Same streamed save as the poll path; 512 MB is fixed cold-start headroom,
     // not sized to the splat.
     memory: '512MB',
@@ -1847,7 +1935,7 @@ const replicateJobWebhook = functions
 // (no streaming), but the memory/timeout stay matched to the shared path.
 const modalJobWebhook = functions
   .runWith({
-    secrets: [...MODAL_SECRETS, 'POSTMARK_API_KEY'],
+    secrets: [...MODAL_SECRETS, 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL'],
     memory: '512MB',
     timeoutSeconds: 300
   })
@@ -1866,5 +1954,7 @@ module.exports = {
   processTerminalPrediction,
   refundSplatToken,
   cleanupSplatTempFile,
+  retainSplatTempFile,
+  postSplatFailureToDiscord,
   normalizeReplicateStatus
 };

--- a/public/functions/scheduled/generation-job-reconcile.js
+++ b/public/functions/scheduled/generation-job-reconcile.js
@@ -30,7 +30,8 @@ const Replicate = require('replicate');
 const {
   processTerminalPrediction,
   refundSplatToken,
-  cleanupSplatTempFile
+  retainSplatTempFile,
+  postSplatFailureToDiscord
 } = require('../replicate.js');
 const {
   MODAL_SECRETS,
@@ -153,7 +154,14 @@ async function fetchProviderPrediction(job, replicate, jobId) {
 // processTerminalPrediction so behavior is identical regardless of who notices.
 async function failJob(db, uid, jobRef, job, reason) {
   const remainingTokens = await refundSplatToken(db, uid, jobRef, job);
-  await cleanupSplatTempFile(job.tempFilePath);
+  // Retain (not delete) the staged input so the failure can be debugged and
+  // re-run against the exact bytes; gcRetainedSplatSources deletes it after
+  // the retention window. Also tell the team — a reconciler-killed job had
+  // no worker around to report anything.
+  const retained = await retainSplatTempFile(db, uid, jobRef.id, job, reason);
+  postSplatFailureToDiscord(uid, jobRef.id, job, reason, retained).catch(
+    () => {}
+  );
   // A killed modal job may still produce a late result into the staging
   // prefix (or already have one nobody will consume) — without this it sits
   // there forever, since the success path's cleanup only runs on a save.
@@ -176,6 +184,48 @@ async function failJob(db, uid, jobRef, job, reason) {
     completedAt: admin.firestore.FieldValue.serverTimestamp()
   });
   return remainingTokens;
+}
+
+// GC sweep for retained failed-job sources (retainSplatTempFile): delete the
+// staged file and its pointer doc once the retention window passes. The window
+// is the debugging budget — long enough to notice a failure notification and
+// re-run the job against the exact input, short enough that multi-GB .insv
+// uploads don't accumulate storage cost indefinitely.
+const RETAINED_SOURCE_TTL_DAYS = 7;
+const MAX_RETAINED_GC_PER_RUN = 25;
+
+async function gcRetainedSplatSources(db, { dryRun }) {
+  const cutoff = admin.firestore.Timestamp.fromMillis(
+    Date.now() - RETAINED_SOURCE_TTL_DAYS * 24 * 60 * 60 * 1000
+  );
+  let snap;
+  try {
+    snap = await db
+      .collection('retainedSplatSources')
+      .where('failedAt', '<', cutoff)
+      .limit(MAX_RETAINED_GC_PER_RUN)
+      .get();
+  } catch (err) {
+    console.warn('[generation-job-reconcile] retained-source GC query failed:', err.message);
+    return 0;
+  }
+  let deleted = 0;
+  for (const doc of snap.docs) {
+    const { path } = doc.data();
+    if (dryRun) {
+      console.log(`[generation-job-reconcile] dry-run: would GC retained source ${path}`);
+      continue;
+    }
+    if (path) {
+      await admin.storage().bucket().file(path).delete().catch(() => {});
+    }
+    await doc.ref.delete().catch(() => {});
+    deleted++;
+  }
+  if (deleted) {
+    console.log(`[generation-job-reconcile] GC'd ${deleted} retained splat sources past ${RETAINED_SOURCE_TTL_DAYS}d`);
+  }
+  return deleted;
 }
 
 async function reconcile({ dryRun }) {
@@ -428,6 +478,10 @@ async function reconcile({ dryRun }) {
     if (summary.samples.length < 25) summary.samples.push(sample);
   }
 
+  // Piggyback the retained-source GC on every sweep (scheduled + manual
+  // trigger) — it shares the cadence and needs no schedule of its own.
+  summary.gcRetainedSources = await gcRetainedSplatSources(db, { dryRun });
+
   return summary;
 }
 
@@ -539,7 +593,7 @@ function escalateIfNeeded(summary, notify) {
 
 const reconcileGenerationJobs = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', ...MODAL_SECRETS],
+    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL', ...MODAL_SECRETS],
     // processTerminalPrediction may stream a .ply save (no full-file buffering);
     // 512 MB is fixed headroom, not sized to the file. 540s covers a backlog.
     timeoutSeconds: 540,
@@ -580,7 +634,7 @@ const reconcileGenerationJobs = functions
 
 const triggerReconcileGenerationJobs = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', ...MODAL_SECRETS],
+    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL', ...MODAL_SECRETS],
     timeoutSeconds: 540,
     memory: '512MB'
   })

--- a/src/generator/splat.js
+++ b/src/generator/splat.js
@@ -96,6 +96,27 @@ const SPLAT_MODELS = {
     blurb:
       'Model: vid2scene Max · best for a ~50–90 second sweep of a large scene · maximum detail (4x the gaussians, large file), can take 1–2 hours.',
     notice: VID2SCENE_NOTICE
+  },
+  // 360 → Splat: a raw Insta360 .insv recording in, reconstructed directly
+  // from its two fisheye sensor streams — no Insta360 Studio export needed,
+  // and far better ground/sky coverage than a pre-stitched equirectangular.
+  // Research-preview single tier while the path is validated on real footage.
+  // `.insv` has no registered MIME type, so the file input needs an explicit
+  // extension `accept` (otherwise pickers grey the files out), and raw .insv
+  // bitrates (~120 Mbps on an X4) need a bigger upload ceiling than phone
+  // clips — both per-model overrides below.
+  'vid2scene-360': {
+    label: '360 → Splat (vid2scene, .insv)',
+    inputKind: 'video',
+    accept: '.insv',
+    requiredExt: '.insv',
+    maxBytes: 1024 * 1024 * 1024, // 1 GB ≈ a ~60s X4/X5 recording
+    videoHint: '~10–60s .insv recording',
+    tokenCost: 60,
+    etaText: '1–2 hours',
+    blurb:
+      'Model: vid2scene 360 · a raw Insta360 .insv recording straight off the camera (no Studio export) · reconstructs directly from the dual fisheye streams for full ground and sky coverage · research preview, usually 1–2 hours.',
+    notice: VID2SCENE_NOTICE
   }
 };
 
@@ -105,6 +126,11 @@ const DEFAULT_SPLAT_MODEL = 'sharp-ml';
 // Storage rules backstop is far higher). Keep videos short — a 10–30s orbit is
 // plenty and keeps reconstruction time and cost reasonable.
 const VIDEO_MAX_BYTES = 200 * 1024 * 1024; // 200 MB
+
+// File-picker filter for regular video models; models can override via their
+// `accept` (e.g. vid2scene-360 takes only `.insv`, which has no MIME type).
+// Must match the accept attribute baked into the video input markup.
+const DEFAULT_VIDEO_ACCEPT = 'video/mp4, video/quicktime, video/webm, video/*';
 
 const SplatTab = {
   elements: {},
@@ -439,6 +465,19 @@ const SplatTab = {
       btn.classList.toggle('selected', btn.dataset.tierId === modelId);
     });
 
+    // Per-model file filter (e.g. `.insv` — extension-only, since it has no
+    // MIME type). A previously chosen file that no longer fits the filter is
+    // cleared so the submit pre-check matches what the picker would allow.
+    if (isVideo && els.videoInput) {
+      els.videoInput.accept = model.accept || DEFAULT_VIDEO_ACCEPT;
+      if (
+        this.sourceVideoFile &&
+        !this.videoFileFitsModel(this.sourceVideoFile)
+      ) {
+        this.clearSourceVideo();
+      }
+    }
+
     els.modelBlurb.textContent = model.blurb;
     els.modelNotice.innerHTML = model.notice;
     // The dropdown carries one entry per group, valued at the group's default
@@ -476,10 +515,28 @@ const SplatTab = {
     this.elements.sourceUploadLabel.classList.remove('hidden');
   },
 
+  // Does this file suit the active model? Only models with a `requiredExt`
+  // restrict the type (e.g. vid2scene-360 needs a raw .insv — a regular video
+  // submitted with the insv flag would fail server-side after a long upload).
+  videoFileFitsModel(file) {
+    const requiredExt = this.currentModel().requiredExt;
+    return !requiredExt || file.name.toLowerCase().endsWith(requiredExt);
+  },
+
   setSourceVideo(file) {
-    if (file.size > VIDEO_MAX_BYTES) {
+    const model = this.currentModel();
+    const maxBytes = model.maxBytes || VIDEO_MAX_BYTES;
+    if (file.size > maxBytes) {
       FluxUI.showNotification(
-        `Video is too large (max ${Math.round(VIDEO_MAX_BYTES / (1024 * 1024))} MB). Trim it to a short orbit and try again.`,
+        `Video is too large (max ${Math.round(maxBytes / (1024 * 1024))} MB). Trim it to a short orbit and try again.`,
+        'error'
+      );
+      this.clearSourceVideo();
+      return;
+    }
+    if (!this.videoFileFitsModel(file)) {
+      FluxUI.showNotification(
+        `This model needs a ${model.requiredExt} file (a raw Insta360 recording, not an exported video).`,
         'error'
       );
       this.clearSourceVideo();
@@ -518,6 +575,13 @@ const SplatTab = {
     if (this.currentModel().inputKind === 'video') {
       if (!this.sourceVideoFile) {
         FluxUI.showNotification('Please choose a source video first.', 'error');
+        return false;
+      }
+      if (!this.videoFileFitsModel(this.sourceVideoFile)) {
+        FluxUI.showNotification(
+          `This model needs a ${this.currentModel().requiredExt} file. Please choose a raw Insta360 recording.`,
+          'error'
+        );
         return false;
       }
     } else if (!this.sourceImageData) {
@@ -610,7 +674,11 @@ const SplatTab = {
     const ext = (file.name.split('.').pop() || 'mp4').toLowerCase();
     const path = `users/${uid}/assets/splat-sources/${crypto.randomUUID()}.${ext}`;
     const task = uploadBytesResumable(storageRef(storage, path), file, {
-      contentType: file.type || 'video/mp4'
+      // .insv (and other raw camera formats) have no browser MIME type; an
+      // honest octet-stream beats mislabeling them video/mp4. The pipeline
+      // sniffs the container with ffprobe, so the type is informational only.
+      contentType:
+        file.type || (ext === 'insv' ? 'application/octet-stream' : 'video/mp4')
     });
     await new Promise((resolve, reject) => {
       task.on(

--- a/src/generator/splat.js
+++ b/src/generator/splat.js
@@ -103,19 +103,22 @@ const SPLAT_MODELS = {
   // Research-preview single tier while the path is validated on real footage.
   // `.insv` has no registered MIME type, so the file input needs an explicit
   // extension `accept` (otherwise pickers grey the files out), and raw .insv
-  // bitrates (~120 Mbps on an X4) need a bigger upload ceiling than phone
-  // clips — both per-model overrides below.
+  // bitrates (~120 Mbps on an X4, ≈900 MB/min) need a far bigger upload
+  // ceiling than phone clips — hence the Max-plan requirement: the 5 GB cap
+  // below is exactly the MAX tier's per-file limit (and the Storage-rules
+  // backstop), and these jobs carry Max-tier COGS anyway.
   'vid2scene-360': {
     label: '360 → Splat (vid2scene, .insv)',
     inputKind: 'video',
     accept: '.insv',
     requiredExt: '.insv',
-    maxBytes: 1024 * 1024 * 1024, // 1 GB ≈ a ~60s X4/X5 recording
-    videoHint: '~10–60s .insv recording',
+    requiresPlan: 'MAX',
+    maxBytes: 5 * 1000 * 1000 * 1000, // decimal 5 GB — matches storage.rules and MAX_FILE_BYTES_BY_PLAN
+    videoHint: '~10s–5min .insv recording',
     tokenCost: 60,
     etaText: '1–2 hours',
     blurb:
-      'Model: vid2scene 360 · a raw Insta360 .insv recording straight off the camera (no Studio export) · reconstructs directly from the dual fisheye streams for full ground and sky coverage · research preview, usually 1–2 hours.',
+      'Model: vid2scene 360 · a raw Insta360 .insv recording straight off the camera (no Studio export) · reconstructs directly from the dual fisheye streams for full ground and sky coverage · research preview, usually 1–2 hours · requires the Max plan.',
     notice: VID2SCENE_NOTICE
   }
 };
@@ -523,12 +526,33 @@ const SplatTab = {
     return !requiredExt || file.name.toLowerCase().endsWith(requiredExt);
   },
 
+  // Does the signed-in user's plan tier meet a model's `requiresPlan`?
+  // Tier comes from getUploadQuota (fresh server-side claims — same source the
+  // assets panel uses). Fails open: if the check is unavailable, the server-side
+  // gate in generateReplicateSplat still has the final word.
+  async planMeets(requiredTier) {
+    const ranks = { FREE: 0, PRO: 1, MAX: 2 };
+    try {
+      const getUploadQuota = httpsCallable(functions, 'getUploadQuota');
+      const { data } = await getUploadQuota({ proposedBytes: 0 });
+      return (ranks[data.tier] ?? 0) >= (ranks[requiredTier] ?? 0);
+    } catch (err) {
+      console.warn('[splat] plan check unavailable, deferring to server', err);
+      return true;
+    }
+  },
+
   setSourceVideo(file) {
     const model = this.currentModel();
     const maxBytes = model.maxBytes || VIDEO_MAX_BYTES;
     if (file.size > maxBytes) {
+      const GB = 1000 * 1000 * 1000;
+      const maxLabel =
+        maxBytes >= GB
+          ? `${maxBytes / GB} GB`
+          : `${Math.round(maxBytes / (1024 * 1024))} MB`;
       FluxUI.showNotification(
-        `Video is too large (max ${Math.round(maxBytes / (1024 * 1024))} MB). Trim it to a short orbit and try again.`,
+        `Video is too large (max ${maxLabel}). Trim it to a shorter clip and try again.`,
         'error'
       );
       this.clearSourceVideo();
@@ -706,6 +730,17 @@ const SplatTab = {
 
     try {
       const model = this.currentModel();
+
+      // Plan gate, pre-flight. The server enforces this too (generateReplicateSplat
+      // rejects with permission-denied), but a multi-GB .insv upload precedes the
+      // callable — check first so a non-Max user fails in seconds, not after the
+      // whole upload.
+      if (model.requiresPlan && !(await this.planMeets(model.requiresPlan))) {
+        throw new Error(
+          `This model requires the ${model.requiresPlan === 'MAX' ? 'Max' : model.requiresPlan} plan. Upgrade your plan to process raw .insv recordings.`
+        );
+      }
+
       const generateReplicateSplat = httpsCallable(
         functions,
         'generateReplicateSplat'


### PR DESCRIPTION
## What

Adds a **"360 → Splat (vid2scene, .insv)"** model to the generator splat tab: a raw Insta360 `.insv` recording straight off the camera goes in, and vid2scene reconstructs **directly from the two fisheye sensor streams** — no Insta360 Studio stitch, and full ground/sky coverage (the equirectangular path's known weak spot: the ER stitch smears the nadir across the bottom pixel row, and the ER virtual rig never looks below −80°).

Single research-preview tier priced at Max (60 tokens) and **gated to the Max plan** while the path is calibrated on real footage — raw .insv runs ~900 MB/min, so uploads ride the Max tier's 5 GB per-file cap, and the processing carries Max-tier COGS anyway.

## Changes

- **`public/functions/replicate-models.js`** — `vid2scene-360` entry with a new `requiresPlan: 'MAX'` knob. The `insv_fisheye: true` knob rides the Modal enqueue body like every other pipeline knob.
- **`public/functions/replicate.js`** — `generateReplicateSplat` enforces `requiresPlan` via `resolvePlanForUser` (fresh custom claims; the needed secret was already on the function) and rejects with `permission-denied`. The flag must be explicit: the Modal worker stages the downloaded input as an extensionless file, so the pipeline's `.insv` auto-detection by extension never fires through this route.
- **`src/generator/splat.js`** — standalone dropdown entry plus three pre-sanded rough edges:
  - per-model `accept=".insv"` — `.insv` has no registered MIME type, so without an extension filter the file picker greys the files out;
  - per-model 5 GB upload ceiling — decimal 5 GB, exactly the MAX plan's per-file cap and the Storage-rules backstop (which already allows `application/octet-stream`); ≈5 min of X4/X5 footage;
  - a Max-plan pre-flight (via `getUploadQuota`) before the multi-GB upload, so a non-Max user fails in seconds rather than after the upload; fails open — the server gate is the backstop;
  - an extension pre-check at file-pick and at submit, so a wrong file fails before the long upload rather than 20 minutes into a job;
  - honest `application/octet-stream` contentType for `.insv` uploads instead of mislabeling them `video/mp4` (informational only — the pipeline sniffs the container with ffprobe).

## Failure handling (research preview)

The pipeline **fails .insv jobs early** when the factory lens calibration cannot be parsed (vid2scene `253e52c`) instead of silently degrading to the idealized lens model — real X4/X5 sensors are portrait-mounted (~90° roll), so a degraded run burns a full SfM+training pass on a rig that cannot register. On the app side, every failure finalization path now:

- **retains the staged source** (flipped back to private) instead of deleting it, so the failure can be re-run against the exact input — a `retainedSplatSources` doc drives a GC pass on the 10-min reconciler sweep (7-day retention);
- **posts to the existing Discord webhook** with the error, job/user ids, and retained path (`DISCORD_WEBHOOK_URL` added to the finalizing functions' secrets).

Success and user-cancel clean up immediately, as before.

## Backend prerequisites (deploy in this order)

Each layer rejects the new flag until the layer below it knows it:

1. **Cog image rebuild** from [`vid2scene-cog#insv-fisheye`](https://github.com/3DStreet/vid2scene-cog/tree/insv-fisheye) (pins upstream at `cog-phase2` = the [direct-.insv ingestion PR](https://github.com/3DStreet/vid2scene/pull/1) head) → push to `r8.im/kfarr/vid2scene`.
2. **`modal deploy modal_app.py`** from that branch.
3. **Functions deploy**, then this UI.

Smoke-test the backend before the UI: `modal run --detach modal_app.py --video-url <signed .insv URL> --insv --split` exercises the identical path with full pipeline logs.

## Notes

- This branch is the single UI/config commit rebased onto `main`; the earlier `insv-360-splat` branch carried the already-squash-merged `modal-splat-backend` history and can be deleted.
- The insv path internally floors its image budget at ~800 frame pairs × 18 virtual views ≈ 1,600 SfM images (Max-like COGS); repricing awaits a measured calibration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


