### PR TITLE
chore: group dependabot major bumps to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,16 +12,17 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-      # Roll routine version bumps into grouped PRs by update type
-      production-minor-patch:
+      # Routine, low-risk bumps batched together
+      minor-patch:
         applies-to: version-updates
-        dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
-      dev-dependencies:
+      # Breaking bumps batched together, kept out of the minor-patch PR
+      major:
         applies-to: version-updates
-        dependency-type: "development"
+        update-types:
+          - "major"
 
   # Firebase Cloud Functions
   - package-ecosystem: "npm"
@@ -39,6 +40,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      major:
+        applies-to: version-updates
+        update-types:
+          - "major"
 
   # rad-converter Cloud Run service
   - package-ecosystem: "npm"
@@ -56,3 +61,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      major:
+        applies-to: version-updates
+        update-types:
+          - "major"


### PR DESCRIPTION
## Problem

Even with the grouped config from #1680, dependabot is still opening ~11 PRs because **major version bumps are ungrouped** — the existing groups only match `minor`/`patch`, so every major spawns its own PR (date-fns 2→4, firebase-admin 13→14, express 4→5, eslint 8→10, @google-cloud/tasks 5→6, etc.).

## Fix

Add a `major` group per ecosystem so all breaking bumps batch into a single PR, kept separate from the `minor-patch` group (so a breaking major can't block routine patches). Also collapses the root prod/dev split into one `minor-patch` group.

**Expected result per directory/month:** at most 1 minor-patch PR + 1 major PR + 1 security PR, instead of one-per-major.

## Notes

- Takes effect once merged to `main` (dependabot reads config from the default branch only).
- Most of the current 11-PR pile is the first run after #1680 merged (all dated 2026-06-16); the monthly schedule won't repeat that. Safe to bulk-close the existing major PRs after this merges — dependabot will re-batch them next run.