### PR TITLE
Fix React hooks linting issues in Save, MeshDetailsModal, and ScenesModal

### DIFF
--- a/src/editor/components/elements/Save/Save.component.jsx
+++ b/src/editor/components/elements/Save/Save.component.jsx
@@ -71,12 +71,6 @@ export const Save = ({ currentUser }) => {
     };
   }, [currentUser]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (isSavingScene) {
-      handleSave(doSaveAs, doPromptTitle);
-    }
-  }, [isSavingScene]); // eslint-disable-line react-hooks/exhaustive-deps
-
   const isAuthor = () => {
     return currentUser?.uid === STREET.utils.getAuthorId();
   };
@@ -94,6 +88,12 @@ export const Save = ({ currentUser }) => {
       setSavedScene(true);
     }
   };
+
+  useEffect(() => {
+    if (isSavingScene) {
+      handleSave(doSaveAs, doPromptTitle);
+    }
+  }, [isSavingScene]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleUnsignedSave = () => {
     setModal('signin');

--- a/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -76,6 +76,9 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
       // Pass data and memory (which now contains snapshots) to createElementsForScenesFromJSON
       useStore.getState().startLoadingScene('Loading scene from cloud...');
       createElementsForScenesFromJSON(sceneData.data, sceneData.memory);
+      // This runs in a click handler, not during render — the immutability rule
+      // can't see that and flags the global write as a false positive.
+      // eslint-disable-next-line react-hooks/immutability
       window.location.hash = `#/scenes/${scene.id}`;
 
       const sceneId = scene.id;

--- a/src/shared/assets/components/MeshDetailsModal.jsx
+++ b/src/shared/assets/components/MeshDetailsModal.jsx
@@ -296,7 +296,12 @@ const MeshDetailsModal = ({
     captureCurrentFrame();
     onClose();
   };
-  onCloseRef.current = handleClose;
+  // Keep the ref pointing at the latest handleClose. Writing it during render
+  // trips react-hooks/refs; an effect runs after commit, which is the supported
+  // pattern for a "latest value" ref read by the set-up-once keydown effect.
+  useEffect(() => {
+    onCloseRef.current = handleClose;
+  });
   const nameDirty = isOwner && name.trim() !== savedName && name.trim() !== '';
   const attributionDirty =
     isOwner && !attributionEquals(attribution, savedAttribution);


### PR DESCRIPTION
## Summary
This PR addresses three React hooks linting violations by reorganizing code to follow the hooks rules and adding clarifying comments for intentional exceptions.

## Key Changes

- **Save.component.jsx**: Moved `useEffect` hook that depends on `isSavingScene` to after the `handleSave` function definition, ensuring all dependencies are defined before the effect runs.

- **MeshDetailsModal.jsx**: Converted direct ref assignment (`onCloseRef.current = handleClose`) during render into a `useEffect` hook. This follows the supported pattern for keeping a ref pointing to the latest value, avoiding the `react-hooks/refs` violation.

- **ScenesModal.component.jsx**: Added `eslint-disable-next-line react-hooks/immutability` comment with explanation for the `window.location.hash` assignment, which occurs in a click handler (not during render) and is a false positive from the linter.

## Implementation Details

- The ref update in MeshDetailsModal now runs in an effect after commit, which is the recommended pattern for "latest value" refs that are read by other effects set up once.
- All changes maintain existing functionality while bringing the code into compliance with React hooks best practices.
- Comments explain the rationale for each change to aid future maintainers.

https://claude.ai/code/session_01WcaqQHLffERzxKj2ita5TC