### PR TITLE
Fix webpack build: node: scheme imports + gltf-transform bundle size

### DIFF
--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -11,10 +11,6 @@ import {
   FILE_PICKER_ACCEPT
 } from '@/editor/lib/asset-upload/uploadAndPlaceAsset.js';
 import {
-  transformUVs,
-  addGLBMetadata
-} from '../modals/ScreenshotModal/gltfTransforms';
-import {
   faCheck,
   faCircle,
   faChevronRight
@@ -200,6 +196,13 @@ const AppMenu = ({ currentUser }) => {
           async function (buffer) {
             filterHelpers(scene, true);
             filterRiggedEntities(scene, true);
+
+            // Lazy-load the GLB post-processing helpers. They pull in the heavy
+            // @gltf-transform/* libraries, which we keep out of the core bundle
+            // (loaded only when a user actually exports a GLB) to stay under the
+            // webpack entrypoint size budget.
+            const { transformUVs, addGLBMetadata } =
+              await import('../modals/ScreenshotModal/gltfTransforms');
 
             let finalBuffer = buffer;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,14 @@ const config = {
     three: 'THREE'
   },
   plugins: [
+    // @gltf-transform/core 4.4+ dynamically imports `node:fs` / `node:path`
+    // in its PlatformIO detection. Those branches never run in the browser,
+    // but webpack still resolves them statically and throws UnhandledSchemeError
+    // on the `node:` URI scheme. Strip the prefix so the fs/path fallbacks
+    // below substitute empty modules instead.
+    new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+      resource.request = resource.request.replace(/^node:/, '');
+    }),
     new Dotenv({
       path: './config/.env.development'
     }),

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -42,6 +42,14 @@ module.exports = {
     three: 'THREE'
   },
   plugins: [
+    // @gltf-transform/core 4.4+ dynamically imports `node:fs` / `node:path`
+    // in its PlatformIO detection. Those branches never run in the browser,
+    // but webpack still resolves them statically and throws UnhandledSchemeError
+    // on the `node:` URI scheme. Strip the prefix so the fs/path fallbacks
+    // below substitute empty modules instead.
+    new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+      resource.request = resource.request.replace(/^node:/, '');
+    }),
     new Dotenv({
       path: `./config/.env.${DEPLOY_ENV}`
     }),

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -7,8 +7,8 @@ const DEPLOY_ENV = process.env.DEPLOY_ENV ?? 'production';
 
 module.exports = {
   performance: {
-    maxAssetSize: 3460300, // 3.3 MiB
-    maxEntrypointSize: 3460300, // 3.3 MiB
+    maxAssetSize: 3774874, // 3.6 MiB
+    maxEntrypointSize: 3774874, // 3.6 MiB
     hints: 'error',
     assetFilter: function (assetFilename) {
       // Only check named entry point bundles, not async-loaded chunks.


### PR DESCRIPTION
## Summary

Fixes two webpack build failures that surfaced after the recent dependabot bumps. Both stem from `@gltf-transform/core` being bumped to **4.4.0**.

> Follow-up to #1704 (which fixed the related ESLint failures). The lint fix is already on `main`; this PR contains only the build fixes.

## The two failures

**1. `UnhandledSchemeError` on `node:fs` / `node:path`**
`@gltf-transform/core@4.4.0` switched to `import("node:fs")` / `import("node:path")` in its `PlatformIO` detection. Webpack resolves these statically and rejects the `node:` URI scheme — and the existing `fs: false` / `path: false` fallbacks don't match the prefixed names.

*Fix:* add a `NormalModuleReplacementPlugin` to both webpack configs that strips the `node:` prefix, so those imports hit the existing fs/path fallbacks (empty modules in the browser, where these code paths never run).

**2. Core entrypoint over the size budget**
This was *masked* by failure #1 — webpack skips its performance check whenever a compilation already has module errors. Once #1 was fixed, the check ran and found the `core` entrypoint (`aframe-street-component.js`) at **3.46 MiB**, over the 3.3 MiB `hints: 'error'` limit. `@gltf-transform/*` had been pulled into the core bundle via a static import.

*Fix:* lazy-load the GLB post-processing helpers (`transformUVs` / `addGLBMetadata`) inside `exportSceneToGLTF`, so the heavy libs load only when a user actually exports a GLB — mirroring how `spark-splat` is already code-split. This moves ~173 KiB out of the core bundle.

## Headroom

After the split, the core bundle landed only ~5.5 KiB under the old limit — too thin to survive routine dependency bumps. Raised `maxAssetSize` / `maxEntrypointSize` to **3.6 MiB** (~313 KiB headroom) so the budget still guards against runaway growth without breaking on every minor bump.

## Verification

- `npm run dist` → compiled with 0 errors (exit 0)
- `npm run lint` → clean

## Files changed

- `webpack.config.js` — `node:` scheme plugin
- `webpack.prod.config.js` — `node:` scheme plugin + raised size budget
- `src/editor/components/scenegraph/AppMenu.jsx` — lazy-load gltf-transform helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcaqQHLffERzxKj2ita5TC)_