### PR TITLE
chore(dependabot): ignore firebase-admin major bumps in functions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,12 @@ updates:
         applies-to: version-updates
         update-types:
           - "major"
+    # firebase-functions 7.x (latest) only peers to firebase-admin <=13, so a
+    # major firebase-admin bump breaks the Cloud Build install (#1692 -> #1713).
+    # Drop this ignore once firebase-functions ships admin-14 support.
+    ignore:
+      - dependency-name: "firebase-admin"
+        update-types: ["version-update:semver-major"]
 
   # rad-converter Cloud Run service
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Why

Dependabot's `major` group auto-opened a PR bumping the functions' `firebase-admin` to `^14` (#1692). No released `firebase-functions` supports admin 14 (latest peers to `^11/12/13`), so it broke the Cloud Build install and blocked every functions deploy — fixed by pinning back to `^13` in #1713.

This is the recurrence guard: ignore **major** `firebase-admin` bumps for `/public/functions` so the same incompatible PR can't auto-open again. Minor/patch admin updates and all other deps are unaffected.

## What

Added to the `/public/functions` update block:
```yaml
ignore:
  - dependency-name: "firebase-admin"
    update-types: ["version-update:semver-major"]
```

Drop this once `firebase-functions` ships admin-14 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)