### PR TITLE
fix(build): restore CSS-module default export under css-loader v7 (prod white-screen)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,7 +119,14 @@ const config = {
           {
             loader: 'css-loader',
             options: {
-              modules: true,
+              // css-loader v7 flipped modules.namedExport to true, which drops
+              // the default export — breaking `import styles from './x.module.scss'`
+              // app-wide (undefined styles). Restore v6 behavior: default export
+              // with class names kept as-is (our SCSS classes are already camelCase).
+              modules: {
+                namedExport: false,
+                exportLocalsConvention: 'as-is'
+              },
               sourceMap: true
             }
           },

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -97,7 +97,14 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              modules: true,
+              // css-loader v7 flipped modules.namedExport to true, which drops
+              // the default export — breaking `import styles from './x.module.scss'`
+              // app-wide (undefined styles). Restore v6 behavior: default export
+              // with class names kept as-is (our SCSS classes are already camelCase).
+              modules: {
+                namedExport: false,
+                exportLocalsConvention: 'as-is'
+              },
               sourceMap: false
             }
           },


### PR DESCRIPTION
## Why — production is white-screening

```
Button.component.jsx:8 Uncaught TypeError: Cannot read properties of undefined (reading 'filledButton')
```

The dependabot css-loader 6→7 bump flipped `modules.namedExport` to **true** by default, which removes the default export from `*.module.scss`. Every `import styles from './x.module.scss'` (53 across the app) then resolves to `undefined`, so the first `styles.<class>` access throws at module-eval and the whole app fails to mount.

The build compiles fine — the failure is **runtime**, which is why CI (unit tests, no rendered bundle) didn't catch it. Both the dev and prod webpack configs used the same `modules: true`, so `npm start` hits it too.

## What

Set `modules: { namedExport: false, exportLocalsConvention: 'as-is' }` in both `webpack.config.js` and `webpack.prod.config.js` to restore the css-loader v6 default-export behavior. Our SCSS classes are already camelCase, so `as-is` maps 1:1; all 53 imports are default-style (no named/namespace imports), so zero collateral.

Verified with a clean `npm run dist` (exit 0; the `filledButton` local is present in the output bundle).

## Deploy

Needs a hosting redeploy (`npm run deploy`) after merge — this is a client bundle fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)