### PR TITLE
fix(storybook): unbreak Storybook (css-loader v7 + CJS config)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -26,7 +26,14 @@ const config = {
         {
           loader: 'css-loader',
           options: {
-            modules: true,
+            // css-loader v7 defaults modules.namedExport to true, dropping the
+            // default export and breaking `import styles from './x.module.scss'`
+            // (white-screens any story importing one). Keep v6 behavior, matching
+            // webpack.config.js / webpack.prod.config.js.
+            modules: {
+              namedExport: false,
+              exportLocalsConvention: 'as-is'
+            },
             sourceMap: true
           }
         },

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -90,4 +90,4 @@ const config = {
   }
 };
 
-export default config;
+module.exports = config;


### PR DESCRIPTION
Follow-up to #1718 (review comment) — plus a pre-existing breakage found while verifying it. **Storybook was fully broken on `main`** (couldn't boot); this fixes both issues so it builds again.

## 1. css-loader v7 (the review comment)
`.storybook/main.js` had the same `modules: true` css-loader option as the app webpack configs, so css-loader v7's `namedExport: true` default would white-screen any story importing a `*.module.scss` (the shared/ library has several). Applies the same `modules: { namedExport: false, exportLocalsConvention: 'as-is' }` for consistency with `webpack.config.js` / `webpack.prod.config.js`.

## 2. Storybook 10 ESM/CJS mismatch (found while verifying #1)
The dependabot Storybook 9→10 bump loads `main.js` as ESM, but the file mixed CommonJS (`require`/`__dirname`) with `export default config` → `ReferenceError: require is not defined in ES module scope`, so Storybook didn't boot at all. Switched the export to `module.exports = config` so the whole file is consistent CJS (Storybook 10 supports CJS config).

Verified: `npm run build-storybook` completes (exit 0, output produced) with both changes. (4th dependabot-bump casualty in this batch, after eslint 10 / firebase-admin 14 / css-loader 7.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)