### PR TITLE
feat(perf): Low Power Mode toggle for demo/screenshare on fanless machines

### DIFF
--- a/docs/low-power-mode-wip.md
+++ b/docs/low-power-mode-wip.md
@@ -1,0 +1,96 @@
+# Low Power Mode — WIP notes
+
+Status as of 2026-06-29. Branch `feat/low-power-mode`, PR #1723.
+
+Continuation notes for the splat-performance work layered on top of the original
+pixel-ratio toggle. The component is `src/aframe-components/low-power-mode.js`.
+
+## Problem being solved
+
+Heavy scene (Google 3D Tiles + Gaussian splats + managed-street geometry) on a
+fanless M2 Air sits at ~9 FPS and **gets worse as the scene loads**, because
+more splat LOD pages stream in over time.
+
+## Key finding: Spark LOD is not FPS-reactive
+
+Spark's `SparkRenderer` LOD is distance / screen-size driven against a **fixed
+splat budget**, not a frame-rate governor. There is no built-in "FPS dropped,
+shed detail" loop. On desktop-class hardware (the M2 Air is detected as desktop)
+the target is **2.5M splats**, and Spark fills toward it as pages load — which is
+why FPS degrades the longer the scene is open.
+
+Relevant Spark source (`node_modules/@sparkjsdev/spark/dist/spark.module.js`):
+- `defaultSplatTarget()` ~line 10361 → desktop 2.5M, iOS 1.5M, Android 1M, VisionPro 750K, Oculus 500K
+- `driveLod()` ~line 10372: `const maxSplats = (this.lodSplatCount ?? defaultSplatTarget()) * this.lodSplatScale;`
+- `pixelScaleLimit *= this.lodRenderScale;` ~line 10384 (sub-pixel cull threshold)
+- `maxStdDev` field → uniform copy ~line 10093 (Gaussian quad / fragment discard radius)
+- `SplatPager` built once with `maxSplats: this.maxPagedSplats` ~line 10443 (so
+  `maxPagedSplats` only bites at pager-creation time, i.e. when low-power is on
+  *before* the splat loads)
+
+All of `lodSplatScale`, `lodRenderScale`, `maxStdDev` are read live each frame,
+so changing them takes effect next frame with no reload.
+
+## Measured so far
+
+- Pixel-ratio cap to 1: **9 → 15 FPS** (the bulk of the win; global, immediate)
+- Tiles alone (3D Tiles + mesh, no splat): already 30 FPS — so the splat is the
+  bottleneck, not tiles or geometry.
+- Target: get the splat-heavy case from 15 → 30.
+
+## What the master toggle currently applies (`SPLAT_LEVERS` + the rest)
+
+| lever | default | low-power | notes |
+|---|---|---|---|
+| pixel ratio | devicePixelRatio (2) | 1 | global; the 9→15 win |
+| `lodSplatScale` | 1.0 | **0.5** | LOD count target 2.5M → 1.25M; the fix for "loads toward max LOD". Safe (renders fewer). |
+| `maxStdDev` | √8 ≈ 2.83 | **2.0** | shrinks quad → ~half fill-rate. Safe (smaller, not culled). |
+| `maxPagedSplats` | platform default | half | only bites at pager creation; reliable only if on before splat load |
+| tiles `errorTarget` | 16 | 40 | coarser/cheaper tiles |
+
+### Dangerous knob, console-only (NOT in the toggle)
+
+- `lodRenderScale` (default 1.0): raises the sub-pixel cull threshold. At **2.0
+  it made entire splats vanish at distance** (caused the "no splats show" bug).
+  If revisited, only try gentle values (1.1–1.5) via the console handle.
+
+## Console handle for tuning (`STREET.lowPower`)
+
+```js
+STREET.lowPower.status()                     // live values + captured defaults
+STREET.lowPower.pixelRatio(1)                // or window.devicePixelRatio
+STREET.lowPower.errorTarget(40)
+STREET.lowPower.splat('lodSplatScale', 0.3)  // set ANY SparkRenderer prop live
+STREET.lowPower.splat('maxStdDev', 1.85)
+STREET.lowPower.reset()                       // restore all captured defaults
+```
+
+Each captured-default is stored on first touch so `reset()` / toggle-off is exact.
+
+## How to measure
+
+- Chrome DevTools → Cmd+Shift+P → "Show Rendering" → check **Frame Rendering
+  Stats** (FPS + GPU memory overlay). Easiest, no code.
+- `STREET.splatDebug.start()` for splat LOD thrash warnings.
+
+## Next steps
+
+1. **Dial in the values** on a real heavy scene with low-power ON:
+   - `lodSplatScale` ~0.25–0.35 is the main dial for 15→30 (each halving ~halves
+     splat work). Push until the splat looks too sparse, back off one step.
+   - `maxStdDev` ~1.85–2.0 for extra fill-rate trim.
+   - Then update the `low:` values in `SPLAT_LEVERS` to the chosen numbers.
+2. **Decide on `lodRenderScale`**: test 1.1–1.5 by eye; promote into the toggle
+   only if it holds up while orbiting/zooming (watch for splats dropping out).
+3. **Optional follow-up (separate PR): FPS-reactive auto-scaler.** A small tick
+   loop that nudges `lodSplatScale` up/down to hold a target FPS — the
+   "adaptive" behavior Spark does not do itself. Real feature, not a one-liner.
+4. Re-verify the original PR caveat: pixel-ratio cap applies on first load (not
+   just after toggling) in the master A-Frame build.
+
+## Files
+
+- `src/aframe-components/low-power-mode.js` — the component (levers + console handle)
+- `src/store.js` — `lowPowerMode` persisted preference
+- `src/editor/components/scenegraph/AppMenu.jsx` — View menu checkbox
+- `index.html` — `low-power-mode` on `<a-scene>`

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
     reflection device-orientation-permission-ui="enabled: false"
     webxr="requiredFeatures:hit-test,local-floor;referenceSpaceType:local-floor;"
     xr-mode-ui="XRMode: ar; enterARButton: #viewer-mode-ar-play-button;"
-    css2d-renderer scene-timer="autoStart: false; format: mm:ss:ff">
+    css2d-renderer low-power-mode scene-timer="autoStart: false; format: mm:ss:ff">
     <a-assets>
       <!-- TODO: Add this to repo documentation  -->
       <!-- you can specify a custom asset path using below syntax  -->

--- a/src/aframe-components/low-power-mode.js
+++ b/src/aframe-components/low-power-mode.js
@@ -12,21 +12,85 @@ import useStore from '../store.js';
  * State lives in the Zustand store (`lowPowerMode`, persisted to localStorage)
  * and is toggled from the View menu. This component is the single consumer.
  *
- * Current lever (the big one):
- *  - Render pixel ratio is capped at 1. On a Retina display the default is 2,
- *    which is 4x the fragments. Capping to 1 roughly quarters the per-frame
- *    fragment workload and benefits EVERYTHING (tiles, splats, geometry) in one
- *    shot. This alone is usually the difference between stutter and smooth.
+ * Three levers, all applied at runtime (no scene reload):
+ *  1. Render pixel ratio capped at 1. On a Retina display the default is 2,
+ *     which is 4x the fragments. Capping to 1 roughly quarters the per-frame
+ *     fragment workload and benefits EVERYTHING (tiles, splats, geometry).
+ *  2. Google 3D Tiles errorTarget raised (16 -> 40) so the TilesRenderer
+ *     picks coarser, cheaper LODs. Read every update() tick, so it takes
+ *     effect on the next frame.
+ *  3. SparkRenderer splat cost (see SPLAT_LEVERS): lodSplatScale halves the LOD
+ *     splat-count target (the fix for Spark filling toward 2.5M splats on
+ *     desktop as pages load), and maxStdDev shrinks each quad to cut fill-rate.
  *
- * Extension hooks (see applyState) for the next layer of tuning:
- *  - Google 3D Tiles: raise TilesRenderer.errorTarget (16 -> ~40) for coarser,
- *    cheaper tiles.
- *  - Gaussian splats: lower the SparkRenderer paged-splat budget.
+ * One further SparkRenderer knob, lodRenderScale, is powerful but dangerous:
+ * it raises the sub-pixel cull threshold and at 2.0 made whole splats vanish at
+ * distance. It is exposed console-only via splat() so a safe value (try
+ * 1.1..1.5) can be dialed in by eye before considering promoting it:
+ *   STREET.lowPower.status()         // dump current + captured-default values
+ *   STREET.lowPower.pixelRatio(1)    // 1 = capped, or pass window.devicePixelRatio
+ *   STREET.lowPower.errorTarget(40)  // higher = coarser/cheaper tiles
+ *   STREET.lowPower.splat('lodSplatScale', 0.3)  // set any SparkRenderer prop live
+ *   STREET.lowPower.reset()          // restore everything to captured defaults
  */
+
+// Low-power lever targets.
+const LOW_POWER_ERROR_TARGET = 40;
+const DEFAULT_ERROR_TARGET = 16; // TilesRenderer default
+
+// SparkRenderer props the master toggle applies. `low` is the low-power value;
+// a function form computes it from the captured full-quality default.
+//
+// The big one is lodSplatScale: Spark targets a fixed splat budget per platform
+// (2.5M on desktop) and fills toward it as pages load, NOT reacting to FPS — so
+// lowering this multiplier is the only way to stop it loading "all the highest
+// LOD" on a fanless GPU. maxStdDev trims fill-rate on top. Both are safe (they
+// render fewer / smaller, never cull a whole splat). The dangerous knob,
+// lodRenderScale, is intentionally NOT here (see header note) — it raises the
+// sub-pixel cull threshold and at 2.0 made entire splats vanish at distance.
+const SPLAT_LEVERS = {
+  // Half the per-frame LOD splat-count target (desktop 2.5M -> 1.25M). Read
+  // live each frame in driveLod; the single biggest splat lever.
+  lodSplatScale: { low: 0.5 },
+  // sqrt(4); default sqrt(8). Shrinks each splat quad -> ~halves fragment area.
+  maxStdDev: { low: 2.0 },
+  // paged-splat allocation ceiling; half the captured default (only bites at
+  // pager-creation time, so mainly helps when low-power is on before load).
+  maxPagedSplats: { low: (def) => Math.floor(def * 0.5) }
+};
+
+// Props surfaced in status() even when the toggle doesn't drive them, so you
+// can watch what console experiments are doing.
+const SPLAT_STATUS_PROPS = [
+  'maxStdDev',
+  'lodRenderScale',
+  'lodSplatScale',
+  'maxPagedSplats'
+];
+
+// --- Live accessors for the two sub-renderers (may not exist yet) ---
+
+// The Google 3D Tiles TilesRenderer lives on the auto-created #google3d child
+// of [street-geo], as `.tiles` on its google-maps-aerial component.
+function getTilesRenderer(sceneEl) {
+  const aerialEl = sceneEl.querySelector('#google3d');
+  return aerialEl?.components?.['google-maps-aerial']?.tiles || null;
+}
+
+// The shared SparkRenderer is lazily created by the splat system on first load.
+function getSparkRenderer(sceneEl) {
+  return sceneEl.systems?.splat?.sparkRenderer || null;
+}
+
 AFRAME.registerComponent('low-power-mode', {
   init: function () {
     this.applyState = this.applyState.bind(this);
     this.enabled = useStore.getState().lowPowerMode;
+
+    // Captured "full quality" SparkRenderer defaults, keyed by prop and filled
+    // the first time we touch each (before we modify it) so reset/restore is
+    // exact. The tiles and pixel-ratio defaults are known constants.
+    this._splatDefaults = {};
 
     // Renderer may not exist yet at scene-component init time.
     if (this.el.renderer) {
@@ -41,15 +105,23 @@ AFRAME.registerComponent('low-power-mode', {
         this.applyState();
       }
     });
+
+    this.exposeDebugHandle();
   },
 
   applyState: function () {
+    this.applyPixelRatio(this.enabled ? 1 : window.devicePixelRatio);
+    this.applyErrorTarget(
+      this.enabled ? LOW_POWER_ERROR_TARGET : DEFAULT_ERROR_TARGET
+    );
+    this.applySplatLevers(this.enabled);
+  },
+
+  // --- Lever 1: render pixel ratio (global) ---
+  applyPixelRatio: function (ratio) {
     const renderer = this.el.renderer;
     if (!renderer) return;
-
-    // --- Pixel ratio (global) ---
-    const targetRatio = this.enabled ? 1 : window.devicePixelRatio;
-    renderer.setPixelRatio(targetRatio);
+    renderer.setPixelRatio(ratio);
     // Force the drawing buffer to re-size at the new ratio. A-Frame's own
     // resize path (size()) preserves whatever pixelRatio is currently set, so
     // this sticks across window resizes. updateStyle=false keeps CSS layout.
@@ -59,17 +131,105 @@ AFRAME.registerComponent('low-power-mode', {
       canvas.clientHeight || canvas.height,
       false
     );
+  },
 
-    // --- Extension hook: Google 3D Tiles error target ---
-    // const tiles = this.el.querySelector('[street-geo]')?.components?.['street-geo'];
-    // if (tiles?.googleTiles) tiles.googleTiles.errorTarget = this.enabled ? 40 : 16;
+  // --- Lever 2: Google 3D Tiles errorTarget ---
+  applyErrorTarget: function (target) {
+    const tiles = getTilesRenderer(this.el);
+    if (tiles) tiles.errorTarget = target;
+  },
 
-    // --- Extension hook: splat paged budget ---
-    // (apply to the shared SparkRenderer once exposed)
+  // --- Lever 3: SparkRenderer cost knobs (see SPLAT_LEVERS) ---
+  // Capture a prop's full-quality default once, before we ever modify it.
+  captureSplatDefault: function (sr, prop) {
+    if (!(prop in this._splatDefaults)) {
+      this._splatDefaults[prop] = sr[prop];
+    }
+    return this._splatDefaults[prop];
+  },
+
+  applySplatLevers: function (enabled) {
+    const sr = getSparkRenderer(this.el);
+    if (!sr) return;
+    for (const [prop, lever] of Object.entries(SPLAT_LEVERS)) {
+      const def = this.captureSplatDefault(sr, prop);
+      sr[prop] = enabled
+        ? typeof lever.low === 'function'
+          ? lever.low(def)
+          : lever.low
+        : def;
+    }
+    sr.setDirty?.();
+  },
+
+  // Set a single SparkRenderer prop live (captures its default first so reset
+  // restores it). For console attribution testing.
+  setSplatProp: function (prop, value) {
+    const sr = getSparkRenderer(this.el);
+    if (!sr) return null;
+    this.captureSplatDefault(sr, prop);
+    sr[prop] = value;
+    sr.setDirty?.();
+    return sr[prop];
+  },
+
+  // Console handle for per-lever attribution testing.
+  exposeDebugHandle: function () {
+    const sceneEl = this.el;
+    window.STREET = window.STREET || {};
+    window.STREET.lowPower = {
+      pixelRatio: (n) => {
+        this.applyPixelRatio(n);
+        return n;
+      },
+      errorTarget: (n) => {
+        this.applyErrorTarget(n);
+        return n;
+      },
+      // Set any SparkRenderer prop live, e.g. splat('maxStdDev', 2).
+      splat: (prop, value) => this.setSplatProp(prop, value),
+      reset: () => {
+        this.applyPixelRatio(window.devicePixelRatio);
+        this.applyErrorTarget(DEFAULT_ERROR_TARGET);
+        // Restore every captured splat default.
+        const sr = getSparkRenderer(sceneEl);
+        if (sr) {
+          for (const [prop, def] of Object.entries(this._splatDefaults)) {
+            sr[prop] = def;
+          }
+          sr.setDirty?.();
+        }
+        return this.status();
+      },
+      status: () => {
+        const tiles = getTilesRenderer(sceneEl);
+        const sr = getSparkRenderer(sceneEl);
+        const snapshot = {
+          enabled: this.enabled,
+          pixelRatio: sceneEl.renderer?.getPixelRatio?.() ?? null,
+          devicePixelRatio: window.devicePixelRatio,
+          errorTarget: tiles ? tiles.errorTarget : '(no tiles loaded)'
+        };
+        if (sr) {
+          for (const prop of SPLAT_STATUS_PROPS) {
+            snapshot[prop] = sr[prop];
+            snapshot[`${prop} (default)`] =
+              prop in this._splatDefaults
+                ? this._splatDefaults[prop]
+                : '(untouched)';
+          }
+        } else {
+          snapshot.splat = '(no splat loaded)';
+        }
+        console.table(snapshot);
+        return snapshot;
+      }
+    };
   },
 
   remove: function () {
     if (this.unsubscribe) this.unsubscribe();
     this.el.removeEventListener('renderstart', this.applyState);
+    if (window.STREET) delete window.STREET.lowPower;
   }
 });

--- a/src/aframe-components/low-power-mode.js
+++ b/src/aframe-components/low-power-mode.js
@@ -1,0 +1,75 @@
+import useStore from '../store.js';
+
+/**
+ * low-power-mode
+ *
+ * A scene-level component that trades visual fidelity for frame rate. Intended
+ * for live demos, screen recording, and video calls on thermally-limited /
+ * fanless machines where a heavy scene (Google 3D Tiles + Gaussian splats +
+ * managed-street geometry) overwhelms the GPU when it also has to encode video
+ * and drive an external display.
+ *
+ * State lives in the Zustand store (`lowPowerMode`, persisted to localStorage)
+ * and is toggled from the View menu. This component is the single consumer.
+ *
+ * Current lever (the big one):
+ *  - Render pixel ratio is capped at 1. On a Retina display the default is 2,
+ *    which is 4x the fragments. Capping to 1 roughly quarters the per-frame
+ *    fragment workload and benefits EVERYTHING (tiles, splats, geometry) in one
+ *    shot. This alone is usually the difference between stutter and smooth.
+ *
+ * Extension hooks (see applyState) for the next layer of tuning:
+ *  - Google 3D Tiles: raise TilesRenderer.errorTarget (16 -> ~40) for coarser,
+ *    cheaper tiles.
+ *  - Gaussian splats: lower the SparkRenderer paged-splat budget.
+ */
+AFRAME.registerComponent('low-power-mode', {
+  init: function () {
+    this.applyState = this.applyState.bind(this);
+    this.enabled = useStore.getState().lowPowerMode;
+
+    // Renderer may not exist yet at scene-component init time.
+    if (this.el.renderer) {
+      this.applyState();
+    } else {
+      this.el.addEventListener('renderstart', this.applyState, { once: true });
+    }
+
+    this.unsubscribe = useStore.subscribe((state) => {
+      if (state.lowPowerMode !== this.enabled) {
+        this.enabled = state.lowPowerMode;
+        this.applyState();
+      }
+    });
+  },
+
+  applyState: function () {
+    const renderer = this.el.renderer;
+    if (!renderer) return;
+
+    // --- Pixel ratio (global) ---
+    const targetRatio = this.enabled ? 1 : window.devicePixelRatio;
+    renderer.setPixelRatio(targetRatio);
+    // Force the drawing buffer to re-size at the new ratio. A-Frame's own
+    // resize path (size()) preserves whatever pixelRatio is currently set, so
+    // this sticks across window resizes. updateStyle=false keeps CSS layout.
+    const canvas = renderer.domElement;
+    renderer.setSize(
+      canvas.clientWidth || canvas.width,
+      canvas.clientHeight || canvas.height,
+      false
+    );
+
+    // --- Extension hook: Google 3D Tiles error target ---
+    // const tiles = this.el.querySelector('[street-geo]')?.components?.['street-geo'];
+    // if (tiles?.googleTiles) tiles.googleTiles.errorTarget = this.enabled ? 40 : 16;
+
+    // --- Extension hook: splat paged budget ---
+    // (apply to the shared SparkRenderer once exposed)
+  },
+
+  remove: function () {
+    if (this.unsubscribe) this.unsubscribe();
+    this.el.removeEventListener('renderstart', this.applyState);
+  }
+});

--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -106,6 +106,8 @@ const AppMenu = ({ currentUser }) => {
     setModal,
     isGridVisible,
     setIsGridVisible,
+    lowPowerMode,
+    setLowPowerMode,
     saveScene,
     setGeojsonImportData,
     setRightPanelTab,
@@ -658,6 +660,16 @@ const AppMenu = ({ currentUser }) => {
               </Menubar.ItemIndicator>
               Show Grid
               <div className="RightSlot">G</div>
+            </Menubar.CheckboxItem>
+            <Menubar.CheckboxItem
+              className="MenubarCheckboxItem"
+              checked={lowPowerMode}
+              onCheckedChange={setLowPowerMode}
+            >
+              <Menubar.ItemIndicator className="MenubarItemIndicator">
+                <AwesomeIcon icon={faCheck} size={14} />
+              </Menubar.ItemIndicator>
+              Low Power Mode
             </Menubar.CheckboxItem>
             <Menubar.Separator className="MenubarSeparator" />
             {cameraOptions.map((option) => (

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ require('./aframe-components/street-ground.js');
 require('./aframe-components/street-label.js');
 require('./aframe-components/blending-opacity.js');
 require('./aframe-components/measure-line.js');
+require('./aframe-components/low-power-mode.js');
 require('./aframe-components/css2d-renderer.js');
 require('./aframe-components/google-maps-aerial.js');
 require('./aframe-components/viewer-mode.js');

--- a/src/store.js
+++ b/src/store.js
@@ -119,6 +119,15 @@ const useStore = create(
           localStorage.setItem('unitsPreference', newUnitsPreference);
           set({ unitsPreference: newUnitsPreference });
         },
+        // Low Power / Demo mode: trades visual fidelity for FPS so a heavy
+        // scene (3D Tiles + splats + geometry) stays smooth while also
+        // screensharing / recording / driving an external display. Consumed by
+        // the `low-power-mode` A-Frame component on the scene.
+        lowPowerMode: localStorage.getItem('lowPowerMode') === 'true',
+        setLowPowerMode: (newLowPowerMode) => {
+          localStorage.setItem('lowPowerMode', newLowPowerMode.toString());
+          set({ lowPowerMode: newLowPowerMode });
+        },
         modal: firstModal(),
         previousModal: null,
         setModal: (newModal, rememberPrevious = false) => {


### PR DESCRIPTION
## Why

On a MacBook Air M2, running a heavy 3DStreet scene (Google 3D Tiles + Gaussian splats + managed-street geometry) while simultaneously screensharing or recording and driving an external display pushes the machine past its GPU and thermal limit. The Air is fanless, so it thermally throttles within a couple minutes of a sustained demo, causing stutter and dropped frames.

The root cause is that A-Frame defaults to `devicePixelRatio` (2 on Retina), meaning the GPU renders **4x the fragments** vs. a non-Retina display. Since tiles, splats, and geometry all go through the same renderer, this is the highest-leverage single lever: capping pixel ratio to 1 roughly quarters per-frame fragment work and benefits everything at once.

This PR adds a **Low Power Mode** toggle in the View menu that applies that cap, wired to a persisted store preference so it survives reload.

## What's in this PR

- `src/store.js` — `lowPowerMode` boolean preference + setter, persisted to `localStorage`
- `src/aframe-components/low-power-mode.js` — new scene-level A-Frame component that reads the store, subscribes to changes, and applies/restores the pixel ratio cap via the Three.js renderer
- `src/index.js` — registers the component
- `index.html` — adds `low-power-mode` to `<a-scene>`
- `src/editor/components/scenegraph/AppMenu.jsx` — "Low Power Mode" checkbox under View menu (next to Show Grid)

## How to test

1. `npm start`, load a scene with 3D Tiles + a splat + street geometry
2. View → Low Power Mode (check it)
3. Canvas should look visibly softer/less sharp, FPS should jump noticeably in a heavy scene
4. Toggle off, quality returns
5. Reload — preference persists (localStorage)

## Known caveat to verify

The component attaches on `renderstart` if the renderer isn't ready at init time. Worth confirming the cap applies on first load (not just after toggling) in the master A-Frame build we use.

## What's next (not in this PR)

This PR is the minimal slice: one lever, globally applied. The next layer of tuning to add once this is validated:

### 1. Google 3D Tiles `errorTarget`
The `TilesRenderer` instance in `google-maps-aerial.js` has an `errorTarget` property (default: 16px screen-space error). Raising it to ~40 in low-power mode tells the tiles renderer to use coarser, cheaper LODs. This is the second-biggest lever for scenes with 3D Tiles coverage. The hook is already commented in `low-power-mode.js`:

```js
// --- Extension hook: Google 3D Tiles error target ---
// const tiles = this.el.querySelector('[street-geo]')?.components?.['street-geo'];
// if (tiles?.googleTiles) tiles.googleTiles.errorTarget = this.enabled ? 40 : 16;
```

Needs the `TilesRenderer` instance to be exposed on the `street-geo` or `google-maps-aerial` component (currently it's local to `init()`).

### 2. SparkRenderer splat budget
The Gaussian splat renderer (`SparkRenderer`) has a `maxPagedSplats` property for capping the in-memory splat budget for paged RAD files, and `lodSplatScale` for scaling splat density. Accessible via `STREET.splatDebug.snapshot()` today. Wiring these into low-power mode would meaningfully reduce splat render cost for scenes with large splat assets.

### 3. Shadow map resolution
`street-environment` hardcodes `shadowMapHeight: 2048` / `shadowMapWidth: 2048`. Halving to 1024 in low-power mode is cheap to add and reduces texture memory bandwidth.

### 4. Antialias
The `<a-scene renderer="antialias: true">` attribute is set at scene init and can't be toggled at runtime without a reload. Longer-term option: offer a "quality preset" that reloads with `antialias: false` baked in for low-power mode. Low priority — pixel ratio already does most of the work.

## Hardware context

This feature was motivated by the M2 Air's limits. The fix for that machine is this toggle. For reference on why hardware upgrade alone isn't the only answer: even a MacBook Pro M5 Pro (16-core GPU, active cooling) will benefit from this toggle during a max-load demo + simultaneous 4K screenshare + external display — thermal headroom is finite on any machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)