### PR TITLE
don't remove entity without parent

### DIFF
--- a/src/aframe-components/street-generated-clones.js
+++ b/src/aframe-components/street-generated-clones.js
@@ -66,7 +66,13 @@ AFRAME.registerComponent('street-generated-clones', {
   },
 
   clearEntities: function () {
-    this.createdEntities.forEach((entity) => entity.remove());
+    // Only detach entities still connected to the DOM. An entity may already
+    // be detached (parentNode === null) during event-driven re-renders; calling
+    // remove() on it throws in AEntity.remove and aborts this loop, which both
+    // crashes and leaves later entities ghost-retained until reload. See #1493.
+    this.createdEntities.forEach((entity) => {
+      if (entity.parentNode) entity.remove();
+    });
     this.createdEntities.length = 0;
   },
 

--- a/src/aframe-components/street-generated-pedestrians.js
+++ b/src/aframe-components/street-generated-pedestrians.js
@@ -37,7 +37,10 @@ AFRAME.registerComponent('street-generated-pedestrians', {
   },
 
   clearEntities: function () {
-    this.createdEntities.forEach((entity) => entity.remove());
+    // Only detach entities still connected to the DOM (see #1493).
+    this.createdEntities.forEach((entity) => {
+      if (entity.parentNode) entity.remove();
+    });
     this.createdEntities.length = 0;
   },
   remove: function () {

--- a/src/aframe-components/street-generated-rail.js
+++ b/src/aframe-components/street-generated-rail.js
@@ -19,7 +19,10 @@ AFRAME.registerComponent('street-generated-rail', {
     this.el.addEventListener('segment-changed', this.onSegmentChanged);
   },
   clearEntities: function () {
-    this.createdEntities.forEach((entity) => entity.remove());
+    // Only detach entities still connected to the DOM (see #1493).
+    this.createdEntities.forEach((entity) => {
+      if (entity.parentNode) entity.remove();
+    });
     this.createdEntities.length = 0;
   },
   remove: function () {

--- a/src/aframe-components/street-generated-stencil.js
+++ b/src/aframe-components/street-generated-stencil.js
@@ -83,7 +83,10 @@ AFRAME.registerComponent('street-generated-stencil', {
     this.el.addEventListener('segment-changed', this.onSegmentChanged);
   },
   clearEntities: function () {
-    this.createdEntities.forEach((entity) => entity.remove());
+    // Only detach entities still connected to the DOM (see #1493).
+    this.createdEntities.forEach((entity) => {
+      if (entity.parentNode) entity.remove();
+    });
     this.createdEntities.length = 0;
   },
   remove: function () {

--- a/src/aframe-components/street-generated-striping.js
+++ b/src/aframe-components/street-generated-striping.js
@@ -40,7 +40,10 @@ AFRAME.registerComponent('street-generated-striping', {
     this.el.addEventListener('segment-changed', this.onSegmentChanged);
   },
   clearEntities: function () {
-    this.createdEntities.forEach((entity) => entity.remove());
+    // Only detach entities still connected to the DOM (see #1493).
+    this.createdEntities.forEach((entity) => {
+      if (entity.parentNode) entity.remove();
+    });
     this.createdEntities.length = 0;
   },
   remove: function () {


### PR DESCRIPTION
The number 1 error in Sentry right now. Fixes #1493 (epic #1720 → "Editing robustness").

## Root cause

All five `street-generated-*` components tear down their entities with the same unguarded idiom:

```js
clearEntities: function () {
  this.createdEntities.forEach((entity) => entity.remove());
  this.createdEntities.length = 0;
}
```

`AEntity.remove()` calls `this.parentNode.removeChild(this)`. During an event-driven re-render (lane-type / segment change), a component `remove`, or a `detach`, an entity in `createdEntities` can already be detached (`parentNode === null`), so `removeChild` throws a `TypeError`.

Because `forEach` does not swallow exceptions, the throw **aborts the loop**: later entities are never removed (they linger as "ghost" clones until reload), `createdEntities.length = 0` never runs, and the regeneration that follows `clearEntities()` is skipped. So the crash and the long-reported "changing lane type didn't remove clones until reloading" are the same bug with two faces.

## Fix

Guard the teardown so only still-connected entities are detached, across all five components:

```js
this.createdEntities.forEach((entity) => {
  if (entity.parentNode) entity.remove();
});
```

Matches the guard idiom already used in `street-label.js` and `managed-street.js`. With the guard, the already-detached entity is skipped (its `object3D` was already removed by A-Frame's detach lifecycle), the loop completes, the array clears, and regeneration proceeds.

- `src/aframe-components/street-generated-clones.js`
- `src/aframe-components/street-generated-stencil.js`
- `src/aframe-components/street-generated-pedestrians.js`
- `src/aframe-components/street-generated-rail.js`
- `src/aframe-components/street-generated-striping.js`

## Closes these Sentry issues (all same root cause)

| Sentry | Events | Entry point |
|--------|-------:|-------------|
| [6921618759](https://3dstreet.sentry.io/issues/6921618759/) | 63 | clones `clearEntities` ← `street-segment.update` (`segment-changed`) |
| [7468727609](https://3dstreet.sentry.io/issues/7468727609/) | 34 | clones `update` → `clearEntities` (via `updateComponent`) |
| [7402838043](https://3dstreet.sentry.io/issues/7402838043/) | 13 | clones `remove` → `clearEntities` (via `ComponentRemoveCommand`) |
| [7565126957](https://3dstreet.sentry.io/issues/7565126957/) | 1 | stencil `detach` → `remove` |

## Verification — deterministic repro

Forces the exact null-`parentNode` condition, so it crashes on `main` and is clean on this branch every time.

1. Open a scene with a segment that has generated clones (e.g. a sidewalk with trees or a parking lane with cars).
2. In the browser console:

```js
const seg = [...document.querySelectorAll('[street-segment]')]
  .find(s => Object.keys(s.components).some(n => n.startsWith('street-generated-clones')));
const name = Object.keys(seg.components).find(n => n.startsWith('street-generated-clones'));
const comp = seg.components[name];

// Orphan the first created entity the way an event-driven re-render does:
const ghost = comp.createdEntities[0];
ghost.parentNode.removeChild(ghost); // ghost.parentNode is now null

comp.clearEntities();
```

- **Before (main):** throws `TypeError: Cannot read properties of null (reading 'removeChild')`; `comp.createdEntities` is not cleared and the remaining clones stay visible (ghost retention).
- **After (this branch):** returns cleanly, orphan skipped, the rest removed, `comp.createdEntities.length === 0`.

## UI repro (matches original report)

With a segment that has generated content, change its lane/segment type or drag its width, remove a `street-generated-*` component, or Detach a generated stencil. On `main` the old entities intermittently linger until reload and Sentry logs the `removeChild`-of-null `TypeError`; on this branch they swap cleanly with no console error.

## Acceptance

- [x] No `removeChild`-on-null when changing lane/segment type with generated clones, stencils, striping, rail, or pedestrians present
- [x] Detach-from-clone and component-remove paths don't throw
- [ ] The 4 Sentry issues stop recurring after deploy