### PR TITLE
Fix angled parking stripes flipped vs parked cars

### DIFF
--- a/src/aframe-components/managed-street.js
+++ b/src/aframe-components/managed-street.js
@@ -1346,7 +1346,7 @@ function parseStreetmixSegments(segments, length) {
       // an absolute, side-only facing and opts out of direction-based rotation;
       // otherwise both sides land at the same rotationY and the stem points the
       // wrong way on one side. Sideways/angled derive facing from the (possibly
-      // mirrored) markings rotation and still follow travel direction.
+      // mirrored) markings rotation with an absolute facing (direction: none).
       let stencilFacing;
       let stencilDirection;
       if (isParallel) {
@@ -1354,8 +1354,13 @@ function parseStreetmixSegments(segments, length) {
         stencilFacing = parkingSide === 'right' ? 0 : 180;
         stencilDirection = 'none';
       } else {
+        // Sideways/angled stripes use an absolute facing, exactly like the
+        // parked cars (carDirection: 'none'). Routing them through
+        // direction-based rotation instead makes street-generated-stencil
+        // negate the angle for outbound segments (rotationY = 0 - facing),
+        // which flips the stripe to the opposite angle from the car it borders.
         stencilFacing = markingsRotZ + 90;
-        stencilDirection = direction;
+        stencilDirection = 'none';
       }
       segmentParentEl.setAttribute(
         'street-generated-clones',


### PR DESCRIPTION
Sideways/angled parking stripes used stencilDirection = direction, which is 'outbound' for angled lanes. street-generated-stencil negates the angle for outbound (rotationY = 0 - facing), flipping the stripe to the opposite angle from the car beside it. Use stencilDirection = 'none' with an absolute facing, matching the parked cars (carDirection: 'none'), so the stripe stays parallel to the car. Verified against the marina-parking-street parity fixture.