### PR TITLE
Add Layer Panel: simple primitives + native upload for media layers

### DIFF
--- a/src/aframe-components/splat.js
+++ b/src/aframe-components/splat.js
@@ -13,8 +13,7 @@ let SparkRenderer = null;
 let PagedSplats = null;
 // Spark's own extension→SplatFileType mapper. We use it for blob: previews
 // (which have no extension to sniff) so the hint we pass is a real SplatFileType
-// enum value, not the bare extension — these differ for some formats (notably
-// ".sog" → "pcsogszip"), which is why passing the raw extension broke .sog.
+// enum value rather than the bare extension, since the two can differ.
 let getSplatFileTypeFromPath = null;
 let sparkLoadPromise = null;
 
@@ -194,15 +193,15 @@ AFRAME.registerComponent('splat', {
       // Resolve the splat format. Spark identifies it from the URL extension or
       // magic bytes on its own, so for a URL that carries a recognizable
       // extension (cloud URLs) we pass NO fileType and let Spark map it —
-      // critically, its SplatFileType enum does NOT always equal the extension
-      // (".sog" → "pcsogszip"), so passing the bare extension as fileType breaks
-      // those formats. This mirrors the standalone splat-viewer.html, which
-      // never passes fileType for cloud URLs.
+      // critically, its SplatFileType enum does NOT always equal the extension,
+      // so passing the bare extension as fileType can break those formats. This
+      // mirrors the standalone splat-viewer.html, which never passes fileType
+      // for cloud URLs.
       //
       // A blob: preview is the only case Spark can't sniff: the URL has no
       // extension AND .splat is headerless. There we map the upload's `format`
-      // hint to a real SplatFileType via Spark's own getSplatFileTypeFromPath
-      // (so ".sog" → "pcsogszip" etc.), falling back to the raw hint.
+      // hint to a real SplatFileType via Spark's own getSplatFileTypeFromPath,
+      // falling back to the raw hint.
       const noQuery = src.split(/[?#]/)[0];
       const lastSeg = noQuery.slice(noQuery.lastIndexOf('/') + 1);
       const urlExt = lastSeg.includes('.')
@@ -282,13 +281,15 @@ AFRAME.registerComponent('splat', {
     } catch (error) {
       if (loadId !== this.loadId) return;
       console.error('[splat] Failed to load splat:', error);
-      // A blob: src is ALWAYS a transient local preview that uploadAndPlaceAsset
-      // swaps for the uploaded cloud URL on success. Some formats can't be
-      // previewed from a blob: URL (e.g. .sog → Spark's pcsogszip loader), but
-      // the very same file loads fine from its cloud URL (which carries a real
-      // extension). So for a blob failure, don't flash a scary error — keep the
-      // "Processing…" indicator up; the cloud reload that follows renders it.
-      // (On upload failure the blob stays, but that surfaces via the upload UI.)
+      // A blob: src is a transient local preview that uploadAndPlaceAsset swaps
+      // for the uploaded cloud URL on success. A blob preview can fail for a
+      // file that still loads fine from its cloud URL (which carries a real
+      // extension Spark can sniff), and that cloud reload may not start for many
+      // seconds on a large upload. So for a blob failure, don't flash a scary
+      // error — keep the "Processing…" indicator up; the cloud reload that
+      // follows renders it (or surfaces its own error via the non-blob path if
+      // the file is truly bad). On upload failure the blob stays, but that
+      // surfaces via the upload UI.
       if (/^blob:/i.test(src)) {
         this.el.emit('splat-error', { src, error, preview: true }, false);
         return;

--- a/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
@@ -16,6 +16,7 @@ import {
 } from '@/editor/lib/asset-upload/uploadAndPlaceAsset.js';
 import { customLayersData, streetLayersData } from './layersData.js';
 import { LayersOptions } from './LayersOptions.js';
+import Events from '../../../lib/Events.js';
 import useStore from '@/store.js';
 import { getGroupedMixinOptions } from '../../../lib/mixinUtils';
 
@@ -364,6 +365,9 @@ const AddLayerPanel = () => {
             canvas: AFRAME.scenes[0].canvas,
             camera: AFRAME.INSPECTOR.camera
           });
+          // Reveal the Assets panel so the user sees the upload begin and its
+          // progress, matching the Add Layer Panel upload cards.
+          Events.emit('openassetspanel');
           uploadAndPlaceAsset(file, position);
           if (e.dataTransfer.files.length > 1) {
             STREET.notify.warningMessage(

--- a/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
@@ -1,15 +1,20 @@
 import { createUniqueId } from '../../../lib/entity.js';
 import * as defaultStreetObjects from './defaultStreets.js';
 import { uploadAndPlaceAsset } from '../../../lib/asset-upload/uploadAndPlaceAsset.js';
+import {
+  GLB_EXTS,
+  IMAGE_EXTS,
+  SPLAT_EXTS
+} from '@shared/asset-upload/uploadAsset.js';
 import Events from '../../../lib/Events.js';
 
-// Per-kind file picker filters for the upload-backed custom layers. These mirror
-// the extension lists in src/shared/asset-upload/uploadAsset.js, scoped to a
-// single asset kind so each card only accepts the file type it represents.
+// Per-kind file picker filters for the upload-backed custom layers, derived from
+// the shared extension allowlists in src/shared/asset-upload/uploadAsset.js so
+// each card accepts exactly what the upload pipeline accepts for that kind.
 const ASSET_PICKER_ACCEPT = {
-  glb: '.glb,.gltf',
-  image: '.jpg,.jpeg,.png,.webp,.avif',
-  splat: '.splat,.ply,.spz,.rad'
+  glb: GLB_EXTS.join(','),
+  image: IMAGE_EXTS.join(','),
+  splat: SPLAT_EXTS.join(',')
 };
 
 // Opens the native file-select dialog (same flow as the File ▸ Import menu and

--- a/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
@@ -312,6 +312,23 @@ export function createGrassBox(position) {
   AFRAME.INSPECTOR.execute('entitycreate', definition);
 }
 
+export function createConcreteCylinder(position) {
+  // A gray concrete cylinder roughly the size of an interstate highway support
+  // pillar (~1.2m diameter, ~8m tall), sitting on the ground. A quick placeholder
+  // for elevated-roadway columns.
+  const height = 8;
+  const definition = {
+    components: {
+      position: groundedPositionString(position, height / 2),
+      geometry: `primitive: cylinder; radius: 0.6; height: ${height};`,
+      material: 'color: #9e9e9e; roughness: 0.9;',
+      'data-layer-name': 'Concrete Cylinder • Highway Pillar',
+      shadow: 'receive: true; cast: true;'
+    }
+  };
+  AFRAME.INSPECTOR.execute('entitycreate', definition);
+}
+
 export function createHighlightRing(position) {
   // A bright red ring laid flat on the ground, large enough to circle and
   // highlight a real-world street element (vehicle, tree, lane area, etc.).

--- a/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
@@ -1,5 +1,46 @@
 import { createUniqueId } from '../../../lib/entity.js';
 import * as defaultStreetObjects from './defaultStreets.js';
+import { uploadAndPlaceAsset } from '../../../lib/asset-upload/uploadAndPlaceAsset.js';
+import Events from '../../../lib/Events.js';
+
+// Per-kind file picker filters for the upload-backed custom layers. These mirror
+// the extension lists in src/shared/asset-upload/uploadAsset.js, scoped to a
+// single asset kind so each card only accepts the file type it represents.
+const ASSET_PICKER_ACCEPT = {
+  glb: '.glb,.gltf',
+  image: '.jpg,.jpeg,.png,.webp,.avif',
+  splat: '.splat,.ply,.spz,.rad'
+};
+
+// Opens the native file-select dialog (same flow as the File ▸ Import menu and
+// drag-and-drop), then hands the chosen file to the asset upload pipeline. The
+// pipeline renders a local placeholder immediately and uploads to the user's
+// asset library in the background (auth + quota are enforced there).
+function openAssetUploadPicker(position, kind) {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = ASSET_PICKER_ACCEPT[kind];
+  input.onchange = async (event) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      // Reveal the Assets panel so the user sees the upload begin and its
+      // progress, even if the left panel was showing Layers or Geospatial.
+      Events.emit('openassetspanel');
+      await uploadAndPlaceAsset(file, position);
+    }
+  };
+  input.click();
+}
+
+// Builds a position string that keeps an entity's base on the ground. `position`
+// is a THREE.Vector3 when dropped onto the scene, or undefined when the card is
+// clicked (entity is centered at the origin).
+function groundedPositionString(position, yOffset) {
+  if (position && typeof position.x === 'number') {
+    return `${position.x} ${position.y + yOffset} ${position.z}`;
+  }
+  return `0 ${yOffset} 0`;
+}
 
 export function createSvgExtrudedEntity(position) {
   // This component accepts a svgString and creates a new entity with geometry extruded
@@ -231,24 +272,60 @@ export function create150ftRightOfWay(position) {
 }
 
 export function createCustomModel(position) {
-  // accepts a path for a glTF (or glb) file hosted on any publicly accessible HTTP server.
-  // Then create entity with model from that path by using gltf-model component
-  const modelUrl = prompt(
-    'Please enter a URL to custom glTF/GLB model',
-    'https://cdn.glitch.global/690c7ea3-3f1c-434b-8b8d-3907b16de83c/Mission_Bay_school_low_poly_model_v03_draco.glb'
-  );
-  if (modelUrl && modelUrl !== '') {
-    const definition = {
-      class: 'custom-model',
-      components: {
-        position: position ?? '0 0 0',
-        'gltf-model': `url(${modelUrl})`,
-        'data-layer-name': 'glTF Model • My Custom Object',
-        shadow: 'receive: true; cast: true;'
-      }
-    };
-    AFRAME.INSPECTOR.execute('entitycreate', definition);
-  }
+  // Upload a glTF/GLB model from the user's device. The chosen file is rendered
+  // locally and stored in the user's asset library via the upload pipeline.
+  openAssetUploadPicker(position, 'glb');
+}
+
+export function createBuildingBox(position) {
+  // A simple massing block roughly the size of a 3-story building (~10m tall),
+  // sitting on the ground in a bright primary blue. Meant as an easy placeholder
+  // for non-technical users to block out buildings.
+  const height = 10; // ~3 stories
+  const definition = {
+    components: {
+      position: groundedPositionString(position, height / 2),
+      geometry: `primitive: box; width: 10; height: ${height}; depth: 10;`,
+      material: 'color: #2962ff; roughness: 0.8;',
+      'data-layer-name': 'Building Box • 3 Stories',
+      shadow: 'receive: true; cast: true;'
+    }
+  };
+  AFRAME.INSPECTOR.execute('entitycreate', definition);
+}
+
+export function createGrassBox(position) {
+  // A large, thin green slab (4x the building box footprint, 0.5m thick) to act
+  // as a ground/lawn for non-street scenes that don't already have terrain.
+  // Offset down by half its thickness so its top surface sits exactly at y=0 and
+  // objects placed on the ground rest flush on top of it.
+  const thickness = 0.5;
+  const definition = {
+    components: {
+      position: groundedPositionString(position, -thickness / 2),
+      geometry: `primitive: box; width: 40; height: ${thickness}; depth: 40;`,
+      material: 'color: #4c9a2a; roughness: 1;',
+      'data-layer-name': 'Grass Box • Ground',
+      shadow: 'receive: true;'
+    }
+  };
+  AFRAME.INSPECTOR.execute('entitycreate', definition);
+}
+
+export function createHighlightRing(position) {
+  // A bright red ring laid flat on the ground, large enough to circle and
+  // highlight a real-world street element (vehicle, tree, lane area, etc.).
+  // Uses the flat shader so it stays vivid regardless of scene lighting.
+  const definition = {
+    components: {
+      position: groundedPositionString(position, 0.1),
+      rotation: '-90 0 0',
+      geometry: 'primitive: torus; radius: 3; radiusTubular: 0.15;',
+      material: 'shader: flat; color: #ff0000; side: double;',
+      'data-layer-name': 'Highlight Ring • Red'
+    }
+  };
+  AFRAME.INSPECTOR.execute('entitycreate', definition);
 }
 
 export function createPrimitiveGeometry(position) {
@@ -266,24 +343,10 @@ export function createPrimitiveGeometry(position) {
 }
 
 export function createImageEntity(position) {
-  // This component accepts a svgString and creates a new entity with geometry extruded
-  // from the svg and applies the default mixin material grass.
-  const imagePath = prompt(
-    'Please enter an image path that is publicly accessible on the web and starts with https://',
-    `https://assets.3dstreet.app/images/signs/Sign-Speed-30kph-Kiritimati.png`
-  );
-  if (imagePath && imagePath !== '') {
-    const definition = {
-      element: 'a-entity',
-      components: {
-        position: position ?? '0 0 0', // TODO: How to override only the height (y) value? We don't want the sign in the ground
-        geometry: 'primitive: plane; height: 1.5; width: 1;',
-        material: `src: url(${imagePath})`,
-        'data-layer-name': 'Image • User Specified Path'
-      }
-    };
-    AFRAME.INSPECTOR.execute('entitycreate', definition);
-  }
+  // Upload an image (sign, reference photo, custom map, etc.) from the user's
+  // device. The upload pipeline sizes the image plane and stores it in the
+  // user's asset library.
+  openAssetUploadPicker(position, 'image');
 }
 
 export function createIntersection(position) {
@@ -299,25 +362,10 @@ export function createIntersection(position) {
 }
 
 export function createSplatObject(position) {
-  // accepts a path for a .splat, .ply, or .spz file hosted on a CORS-enabled HTTP server.
-  // Then create entity with model from that path by using splat component (Spark library)
-  // Note: GitHub raw URLs don't work due to CORS. Use a CDN or CORS-enabled server.
-  const modelUrl = prompt(
-    "Enter URL to a Gaussian Splat (.splat, .ply, .spz)\n\nNote: Host must allow CORS. GitHub raw URLs won't work.",
-    'https://sparkjs.dev/assets/splats/butterfly.spz'
-  );
-
-  if (modelUrl && modelUrl !== '') {
-    const definition = {
-      class: 'splat-model',
-      'data-layer-name': 'Splat Model • My Custom Object',
-      components: {
-        position: position ?? '0 0 0',
-        splat: `src: ${modelUrl}`
-      }
-    };
-    AFRAME.INSPECTOR.execute('entitycreate', definition);
-  }
+  // Upload a Gaussian Splat (.splat, .ply, .spz, .rad) from the user's device.
+  // The upload pipeline renders it locally and stores it in the user's asset
+  // library (and queues RAD/LOD conversion where applicable).
+  openAssetUploadPicker(position, 'splat');
 }
 
 export function createPanoramaSphere() {

--- a/src/editor/components/elements/AddLayerPanel/layersData.js
+++ b/src/editor/components/elements/AddLayerPanel/layersData.js
@@ -116,6 +116,15 @@ export const customLayersData = [
     handlerFunction: createFunctions.createGrassBox
   },
   {
+    name: 'Concrete Cylinder',
+    img: '',
+    icon: '',
+    requiresPro: false,
+    description:
+      'Add a gray concrete cylinder roughly the size of an interstate highway support pillar. A quick placeholder for elevated-roadway columns.',
+    handlerFunction: createFunctions.createConcreteCylinder
+  },
+  {
     name: 'Upload Image',
     img: '',
     requiresPro: false,

--- a/src/editor/components/elements/AddLayerPanel/layersData.js
+++ b/src/editor/components/elements/AddLayerPanel/layersData.js
@@ -80,40 +80,67 @@ export const streetLayersData = [
 
 export const customLayersData = [
   {
-    name: 'Entity from extruded SVG',
+    name: 'Building Box',
     img: '',
     icon: '',
-    requiresPro: true,
+    requiresPro: false,
     description:
-      'Create entity with svg-extruder component, that accepts a svgString and creates a new entity with geometry extruded from the svg and applies the default mixin material grass.',
-    handlerFunction: createFunctions.createSvgExtrudedEntity
+      'Add a simple box roughly the size of a 3-story building, sitting on the ground in a bright blue. A quick placeholder for blocking out buildings.',
+    handlerFunction: createFunctions.createBuildingBox
   },
   {
-    name: 'glTF model from URL',
+    name: 'Highlight Ring',
     img: '',
-    requiresPro: true,
     icon: '',
+    requiresPro: false,
     description:
-      'Create entity with model from path for a glTF (or Glb) file hosted on any publicly accessible HTTP server.',
-    handlerFunction: createFunctions.createCustomModel
+      'Add a bright red ring on the ground, big enough to circle and highlight a real-world element like a vehicle, tree, or part of a lane.',
+    handlerFunction: createFunctions.createHighlightRing
   },
   {
-    name: 'Create primitive geometry',
+    name: 'Asphalt Circle',
     img: '',
-    requiresPro: true,
     icon: '',
+    requiresPro: false,
     description:
-      'Create entity with A-Frame primitive geometry. Geometry type could be changed in properties panel.',
+      'Add a large flat asphalt circle on the ground. Geometry and material can be changed in the properties panel.',
     handlerFunction: createFunctions.createPrimitiveGeometry
   },
   {
-    name: 'Place New Image Entity',
+    name: 'Grass Box',
     img: '',
-    requiresPro: true,
+    icon: '',
+    requiresPro: false,
+    description:
+      'Add a large, thin green ground slab to act as a lawn for scenes that do not already have terrain.',
+    handlerFunction: createFunctions.createGrassBox
+  },
+  {
+    name: 'Upload Image',
+    img: '',
+    requiresPro: false,
     icon: 'ui_assets/cards/icons/gallery24.png',
     description:
-      'Place an image such as a sign, reference photo, custom map, etc.',
+      'Upload an image (sign, reference photo, custom map, etc.) from your device and place it in the scene.',
     handlerFunction: createFunctions.createImageEntity
+  },
+  {
+    name: 'Upload 3D Model',
+    img: '',
+    requiresPro: false,
+    icon: '',
+    description:
+      'Upload a glTF or GLB model from your device. It is rendered immediately and saved to your asset library.',
+    handlerFunction: createFunctions.createCustomModel
+  },
+  {
+    name: 'Upload Gaussian Splat',
+    img: '',
+    requiresPro: false,
+    icon: '',
+    description:
+      'Upload a Gaussian Splat (.splat, .ply, .spz, .rad) from your device and place it in the scene.',
+    handlerFunction: createFunctions.createSplatObject
   },
   {
     name: '360° Panorama Sphere',
@@ -125,12 +152,12 @@ export const customLayersData = [
     handlerFunction: createFunctions.createPanoramaSphere
   },
   {
-    name: 'Gaussian Splat from URL',
+    name: 'Entity from extruded SVG',
     img: '',
-    requiresPro: true,
     icon: '',
+    requiresPro: false,
     description:
-      'Create entity with Gaussian Splat model from a URL. Supports .splat, .ply, and .spz file formats.',
-    handlerFunction: createFunctions.createSplatObject
+      'Create entity with svg-extruder component, that accepts a svgString and creates a new entity with geometry extruded from the svg and applies the default mixin material grass.',
+    handlerFunction: createFunctions.createSvgExtrudedEntity
   }
 ].map((layer, index) => ({ ...layer, id: index + 1 }));

--- a/src/editor/components/elements/useAssetUploadStatus.js
+++ b/src/editor/components/elements/useAssetUploadStatus.js
@@ -7,8 +7,8 @@ export const STATUS_LABELS = {
   uploading: { color: '#f4a01a', text: 'Uploading' },
   uploaded: { color: '#2bb673', text: 'Cloud asset' },
   failed: { color: '#e0473d', text: 'Upload failed' },
-  local: { color: '#7f7f7f', text: 'Saved locally only' },
-  local_error: { color: '#e0473d', text: "Local only — won't sync" },
+  local: { color: '#7f7f7f', text: 'Temporary local preview' },
+  local_error: { color: '#e0473d', text: "Local only: won't sync" },
   cloud_missing: { color: '#e0473d', text: 'Cloud asset unavailable' },
   waiting: { color: '#f4a01a', text: 'Waiting for connection…' }
 };
@@ -20,15 +20,15 @@ export const REASON_TEXT = {
   too_large: 'Exceeds the cloud upload size limit. Preview only.',
   optimized_too_large:
     'Even after optimization the file is over the upload limit. Preview only.',
-  over_quota: 'Storage full — delete assets or upgrade to sync this model.',
+  over_quota: 'Storage full: delete assets or upgrade to sync this model.',
   file_too_large:
-    "Larger than your plan's per-file limit — upgrade to sync this model.",
+    "Larger than your plan's per-file limit: upgrade to sync this model.",
   not_signed_in: 'Sign in to save this model to your cloud.',
   upload_blocked: 'Cloud upload was blocked.',
   asset_deleted:
-    'Marked for deletion — will be permanently purged on the next cleanup pass.',
+    'Marked for deletion: will be permanently purged on the next cleanup pass.',
   asset_not_found:
-    'Not found on the server — it may never have existed, or it was already purged.'
+    'Not found on the server: it may never have existed, or it was already purged.'
 };
 
 const PERSISTENT_ATTRS = ['data-asset-id', 'data-asset-owner-uid'];

--- a/src/editor/components/scenegraph/SceneGraph.jsx
+++ b/src/editor/components/scenegraph/SceneGraph.jsx
@@ -73,6 +73,7 @@ export default class SceneGraph extends React.Component {
   componentDidMount() {
     this.rebuildEntityOptions();
     Events.on('entityupdate', this.onEntityUpdate);
+    Events.on('openassetspanel', this.showAssetsPanel);
     document.addEventListener('child-attached', this.onChildAttachedDetached);
     document.addEventListener('child-detached', this.onChildAttachedDetached);
     this.unsubscribePanels = useStore.subscribe(
@@ -83,6 +84,7 @@ export default class SceneGraph extends React.Component {
 
   componentWillUnmount() {
     Events.off('entityupdate', this.onEntityUpdate);
+    Events.off('openassetspanel', this.showAssetsPanel);
     document.removeEventListener(
       'child-attached',
       this.onChildAttachedDetached
@@ -390,6 +392,12 @@ export default class SceneGraph extends React.Component {
 
   setActiveTab = (tab) => {
     this.setState({ activeTab: tab });
+  };
+
+  // Reveal the Assets tab when an asset upload starts elsewhere (e.g. the Add
+  // Layer Panel's upload cards) so the user sees their upload progress.
+  showAssetsPanel = () => {
+    this.setActiveTab('assets');
   };
 
   openAddLayer = () => {

--- a/src/shared/asset-upload/uploadAsset.js
+++ b/src/shared/asset-upload/uploadAsset.js
@@ -31,13 +31,13 @@ import { optimizeGlb } from './optimizeGlb.js';
 // ceiling in public/storage.rules.
 export const MAX_FILE_BYTES = 5 * 1000 * 1000 * 1000;
 
-const GLB_EXTS = ['.glb', '.gltf'];
-const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.webp', '.avif'];
+export const GLB_EXTS = ['.glb', '.gltf'];
+export const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.webp', '.avif'];
 // Gaussian Splat formats supported by the `splat` A-Frame component (Spark)
 // and the RAD converter (build-lod content-sniffs all of these). `.rad` is the
 // pre-optimized, byte-range-streamable form: uploading one skips conversion
 // (see onSplatAssetCreated). Sourced from the shared SPLAT_EXTENSIONS constant.
-const SPLAT_EXTS = SPLAT_EXTENSIONS.map((ext) => `.${ext}`);
+export const SPLAT_EXTS = SPLAT_EXTENSIONS.map((ext) => `.${ext}`);
 const ACCEPTED_EXTS = [...GLB_EXTS, ...IMAGE_EXTS, ...SPLAT_EXTS];
 
 export const FILE_PICKER_ACCEPT = ACCEPTED_EXTS.join(',');

--- a/src/shared/assets/components/MeshDetailsModal.jsx
+++ b/src/shared/assets/components/MeshDetailsModal.jsx
@@ -479,8 +479,6 @@ const MeshDetailsModal = ({
     splat: 'SPLAT',
     spz: 'SPZ',
     rad: 'RAD Streaming Level-of-Detail',
-    ksplat: 'KSPLAT',
-    sog: 'SOG',
     glb: 'GLB',
     gltf: 'glTF'
   };

--- a/src/shared/assets/constants.js
+++ b/src/shared/assets/constants.js
@@ -35,7 +35,7 @@ export const ASSET_TYPES = {
  * @readonly
  * @type {string[]}
  */
-export const SPLAT_EXTENSIONS = ['ply', 'splat', 'spz', 'rad', 'ksplat', 'sog'];
+export const SPLAT_EXTENSIONS = ['ply', 'splat', 'spz', 'rad'];
 
 /**
  * Valid asset categories for gallery items


### PR DESCRIPTION
## Summary

Reworks the **Custom Layers** tab of the Add Layer Panel to be more useful for non-technical users and to use the modern asset upload pipeline instead of legacy URL prompts.

### New simple primitive shapes (free)
- **Building Box** — a ~3-story (10×10×10m) bright-blue massing block sitting on the ground; a quick placeholder for blocking out buildings.
- **Highlight Ring** — a flat, bright-red ring (flat shader) big enough to circle and highlight a real-world element (vehicle, tree, lane area).
- **Grass Box** — a large, thin (40×40×0.5m) green ground slab for scenes without terrain. Offset to `y = -0.25` so its top surface sits exactly at `y = 0`, letting objects placed on the ground rest flush on top.
- **Asphalt Circle** — renamed from "Create primitive geometry" (same handler/geometry).

### Media layers now upload instead of prompting for a URL
- **Upload Image**, **Upload 3D Model**, and **Upload Gaussian Splat** now open the native file-select dialog and route the chosen file through the existing asset upload pipeline (`uploadAndPlaceAsset`) — local placeholder rendered immediately, then saved to the user's asset library. Auth and quota are enforced by the pipeline.

### Other
- Removed Pro gating from all custom layers (uploads are already gated by quota/auth).
- Reordered so the least-supported layers (360° Panorama Sphere, Entity from extruded SVG) come last.
- The **Assets** panel now auto-opens when an upload starts (both from the upload cards and from drag-and-drop onto the scene), via a new `openassetspanel` event listened to by `SceneGraph`.

## Test plan
- [x] Each primitive card (Building Box, Highlight Ring, Asphalt Circle, Grass Box) places the expected shape on click and on drag-drop to a ground point.
- [x] Objects placed on the ground rest flush on top of a Grass Box.
- [x] Upload Image / 3D Model / Gaussian Splat open a file dialog scoped to the right extensions; selecting a file places a placeholder and uploads.
- [x] Choosing a file (card or drag-drop) flips the left panel to the Assets tab if it was on Layers/Geospatial.
- [x] Behavior is sane when signed out (upload pipeline's existing auth handling).