### PR TITLE
First-class geometry/material sidebar + animated grass generator

### DIFF
--- a/docs/host-generator-pattern.md
+++ b/docs/host-generator-pattern.md
@@ -1,0 +1,80 @@
+# Host primitive + generator pattern
+
+This pattern lets a plain editable primitive (a "host") carry an optional managed
+"generator" component that procedurally decorates it, with **both** the host's
+geometry/material **and** the generator's options surfaced as first-class controls
+in the properties sidebar.
+
+The first example is the **Grass Box**: a plain green ground box
+(`geometry` + `material`) plus an optional `street-generated-grass` generator that
+spawns an instanced, wind-animated field of grass blades on top. We expect other
+combinations in the future (other surfaces, other procedural decorations).
+
+## The two parts
+
+### 1. First-class geometry / material in the sidebar
+
+The properties sidebar promotes selected components to an expanded **featured**
+section above the collapsed "Advanced Components" toggle. This is driven by a
+generalized allow-list, not a per-shape sidebar:
+
+- `src/editor/lib/featuredComponents.js` — `FEATURED_COMPONENT_PREFIXES`
+  (`geometry`, `material`, `street-generated-`) and helpers. This generalizes a
+  mechanism that previously lived only in `StreetSegmentSidebar`.
+- `FeaturedComponents.jsx` — renders the featured components for any entity.
+  `geometry` and generators reuse the generic schema-driven `Component` widget;
+  `material` gets a curated panel.
+- `MaterialControls.jsx` — curated material editing (color, texture with a
+  one-click **Make Solid** to drop the texture, a real **opacity slider** with
+  live preview that also toggles `transparent`, and roughness).
+- `AdvancedComponents.jsx` excludes featured components so nothing is shown twice.
+
+Any primitive — Building Box, Asphalt Circle, Grass Box, image planes — gets its
+key dimensions and material color/texture as first-class controls for free.
+
+### 2. The generator component
+
+Generators follow the canonical `street-generated-*` managed-children pattern
+(see `src/aframe-components/street-generated-clones.js`). Using
+`street-generated-grass.js` as the reference:
+
+- Track spawned entities in `this.createdEntities`; `clearEntities()` on
+  `update()`/`remove()`.
+- Tag spawned entities `class: autocreated`, `data-no-transform`,
+  `data-layer-name`, and `data-parent-component` so the SceneGraph treats them as
+  managed (the sidebar's "Edit Settings / Detach" flow works automatically).
+- Wrap heavy GPU objects (e.g. a `THREE.InstancedMesh`) under an `autocreated`
+  child entity via `setObject3D`, so the SceneGraph behaves and the mesh is
+  regenerated rather than saved.
+- **Serialization is automatic.** The serializer skips `autocreated` children
+  (`src/json-utils_1.1.js`), so the scene saves only the generator's config
+  (e.g. `{ density, grassHeight, ... }`) on the host entity and regenerates the
+  decoration on load — never thousands of entities.
+- Size the decoration off the host's geometry when relevant and listen for
+  `componentchanged` on the host so editing the host's first-class geometry
+  rebuilds the decoration live.
+
+### Generator implementation checklist (learned from the grass prototype)
+
+- Animate from A-Frame's `tick(time, delta)`, **not** `window.requestAnimationFrame`
+  — so it pauses with the scene, drives correctly under WebXR, and never spawns
+  competing loops.
+- Dispose GPU resources in `clearEntities()` (`geometry.dispose()` /
+  `material.dispose()`) to avoid leaks on repeated add/remove.
+- Scale work with area and apply a quality cap (grass caps blades at
+  `MAX_BLADES`) so large hosts / mobile GPUs stay healthy.
+- Seed any RNG (via `src/lib/rng.js`) so the layout is stable across reloads,
+  since children regenerate from config. Default `seed: 0` → pick one and persist
+  it via `setAttribute`.
+- Rebuild on every relevant schema change (the grass `update()` rebuilds on
+  density/blade size and recolors in place on color-only changes).
+
+## Adding a new host + generator combination
+
+1. Add an Add-Layer card / `createLayerFunctions.js` factory that creates the
+   host primitive (geometry + material) and attaches your generator component.
+2. Implement the generator as a `street-generated-*` component following the
+   checklist above, and register it in `src/index.js`.
+3. Nothing else is required for the sidebar: geometry, material, and the
+   `street-generated-*` generator options are surfaced as first-class controls
+   automatically.

--- a/docs/host-generator-pattern.md
+++ b/docs/host-generator-pattern.md
@@ -18,9 +18,12 @@ The properties sidebar promotes selected components to an expanded **featured**
 section above the collapsed "Advanced Components" toggle. This is driven by a
 generalized allow-list, not a per-shape sidebar:
 
-- `src/editor/lib/featuredComponents.js` — `FEATURED_COMPONENT_PREFIXES`
-  (`geometry`, `material`, `street-generated-`) and helpers. This generalizes a
-  mechanism that previously lived only in `StreetSegmentSidebar`.
+- `src/editor/lib/featuredComponents.js` — `FEATURED_COMPONENT_NAMES`
+  (exact-matched `geometry`, `material`) plus `GENERATOR_COMPONENT_PREFIXES`
+  (prefix-matched `street-generated-`) and helpers. This generalizes a mechanism
+  that previously lived only in `StreetSegmentSidebar`. Builtins are exact-matched
+  so future components like the A-Frame community `geometry-merger` aren't
+  over-promoted.
 - `FeaturedComponents.jsx` — renders the featured components for any entity.
   `geometry` and generators reuse the generic schema-driven `Component` widget;
   `material` gets a curated panel.

--- a/src/aframe-components/street-generated-grass.js
+++ b/src/aframe-components/street-generated-grass.js
@@ -193,6 +193,10 @@ AFRAME.registerComponent('street-generated-grass', {
     const grassEntity = document.createElement('a-entity');
     grassEntity.classList.add('autocreated');
     grassEntity.setAttribute('data-no-transform', '');
+    // The grass is not independently selectable: clicks fall through to the host
+    // primitive (the box), whose sidebar carries the grass settings. Mirrors
+    // street-generated-rail / street-ground.
+    grassEntity.setAttribute('data-ignore-raycaster', '');
     grassEntity.setAttribute('data-layer-name', 'Animated Grass');
     grassEntity.setAttribute('data-parent-component', this.attrName);
     grassEntity.setObject3D('grass', instancedMesh);

--- a/src/aframe-components/street-generated-grass.js
+++ b/src/aframe-components/street-generated-grass.js
@@ -1,4 +1,5 @@
 /* global AFRAME, THREE */
+import { MeshSurfaceSampler } from 'three/examples/jsm/math/MeshSurfaceSampler';
 import { createRNG } from '../lib/rng';
 
 // Maximum number of blades regardless of area/density — a quality cap so large
@@ -32,16 +33,19 @@ const SIMPLE_NOISE = `
 /**
  * street-generated-grass
  *
- * An instanced, wind-animated field of grass blades layered on top of a host
- * primitive (the Grass Box). It follows the canonical street-generated-* managed
- * children pattern (see street-generated-clones.js): the blades live on an
- * `autocreated` child entity that the serializer skips, so only this component's
- * config (`{ density, grassHeight, ... }`) is saved and the field is regenerated
+ * An instanced, wind-animated field of grass blades scattered over the surface
+ * of a host A-Frame geometry primitive (box, circle, cylinder, plane, sphere,
+ * etc.). It follows the canonical street-generated-* managed children pattern
+ * (see street-generated-clones.js): the blades live on an `autocreated` child
+ * entity that the serializer skips, so only this component's config
+ * (`{ density, grassHeight, ... }`) is saved and the field is regenerated
  * deterministically on load — never 25k entities.
  *
- * The field sizes itself to the host's box geometry (width/depth/height) and
- * rebuilds when that geometry changes, so editing the box's first-class geometry
- * controls keeps the lawn matched to the slab.
+ * Placement uses Three's MeshSurfaceSampler over the host's real mesh, so blades
+ * cover any primitive uniformly and each blade aligns its local +Y to the sampled
+ * surface normal (straight up on flat tops, radial on a cylinder, fur on a sphere).
+ * It rebuilds when the host geometry changes, so editing the primitive or its
+ * dimensions in the first-class geometry controls keeps the lawn matched.
  *
  * See docs/host-generator-pattern.md for the host + generator pattern.
  */
@@ -105,13 +109,26 @@ AFRAME.registerComponent('street-generated-grass', {
   generateGrass: function () {
     const data = this.data;
 
-    // Size the field to the host box geometry so grass covers the slab top.
-    const geometry = this.el.getAttribute('geometry') || {};
-    const width = geometry.width || 40;
-    const depth = geometry.depth || 40;
-    const topY = (geometry.height || 0) / 2; // local top surface of the box
+    // Scatter over the host primitive's real mesh. getObject3D('mesh') is the
+    // THREE.Mesh the A-Frame geometry component builds; it may not exist yet on
+    // an early call, in which case the componentchanged listener rebuilds once
+    // the geometry is ready, so no-op cleanly here.
+    const hostMesh = this.el.getObject3D('mesh');
+    if (!hostMesh || !hostMesh.geometry) return;
 
-    const area = width * depth;
+    // Seeded layout so reloads regenerate identical placement from config. The
+    // sampler consumes this rng too (setRandomGenerator), so the whole scatter —
+    // face choice, barycentric point, scale, spin — is deterministic per seed.
+    const rng = createRNG(data.seed);
+
+    const sampler = new MeshSurfaceSampler(hostMesh)
+      .setRandomGenerator(rng)
+      .build();
+
+    // The sampler's cumulative-area distribution ends at the mesh's total surface
+    // area, so density (blades per m²) stays meaningful across every primitive.
+    const distribution = sampler.distribution;
+    const area = distribution[distribution.length - 1] || 0;
     const count = Math.max(
       1,
       Math.min(MAX_BLADES, Math.round(data.density * area))
@@ -173,13 +190,19 @@ AFRAME.registerComponent('street-generated-grass', {
       count
     );
 
-    // Seeded layout so reloads regenerate identical placement from config.
-    const rng = createRNG(data.seed);
     const dummy = new THREE.Object3D();
+    const samplePos = new THREE.Vector3();
+    const sampleNormal = new THREE.Vector3();
+    const up = new THREE.Vector3(0, 1, 0);
     for (let i = 0; i < count; i++) {
-      dummy.position.set((rng() - 0.5) * width, topY, (rng() - 0.5) * depth);
+      sampler.sample(samplePos, sampleNormal);
+      dummy.position.copy(samplePos);
+      // Align blade local +Y to the surface normal so blades stand off the
+      // surface (straight up on flat faces, radial on curved ones), then add a
+      // random spin about that normal so they don't all face the same way.
+      dummy.quaternion.setFromUnitVectors(up, sampleNormal);
+      dummy.rotateY(rng() * Math.PI * 2);
       dummy.scale.setScalar(0.5 + rng() * 0.5);
-      dummy.rotation.y = rng() * Math.PI;
       dummy.updateMatrix();
       instancedMesh.setMatrixAt(i, dummy.matrix);
     }

--- a/src/aframe-components/street-generated-grass.js
+++ b/src/aframe-components/street-generated-grass.js
@@ -48,14 +48,14 @@ const SIMPLE_NOISE = `
 AFRAME.registerComponent('street-generated-grass', {
   schema: {
     // Blades per square meter of host area; the actual count is area-scaled and
-    // capped at MAX_BLADES.
-    density: { default: 10, type: 'number' },
-    grassHeight: { default: 1.0, type: 'number' },
-    grassWidth: { default: 0.1, type: 'number' },
+    // capped at MAX_BLADES. min: 0 keeps all numeric inputs non-negative.
+    density: { default: 10, type: 'number', min: 0 },
+    grassHeight: { default: 1.0, type: 'number', min: 0 },
+    grassWidth: { default: 0.1, type: 'number', min: 0 },
     color: { default: '#6aa84f', type: 'color' },
     // Random seed for blade layout. 0 means "pick one and persist it" so the
     // layout is stable across reloads even though blades regenerate from config.
-    seed: { default: 0, type: 'int' }
+    seed: { default: 0, type: 'int', min: 0 }
   },
 
   init: function () {

--- a/src/aframe-components/street-generated-grass.js
+++ b/src/aframe-components/street-generated-grass.js
@@ -1,0 +1,240 @@
+/* global AFRAME, THREE */
+import { createRNG } from '../lib/rng';
+
+// Maximum number of blades regardless of area/density — a quality cap so large
+// slabs or high density don't tank mobile / integrated GPUs.
+const MAX_BLADES = 25000;
+
+// Shared GLSL value-noise helper used by the wind vertex shader.
+const SIMPLE_NOISE = `
+  float N (vec2 st) {
+      return fract( sin( dot( st.xy, vec2(12.9898,78.233 ) ) ) *  43758.5453123);
+  }
+
+  float smoothNoise( vec2 ip ){
+      vec2 lv = fract( ip );
+      vec2 id = floor( ip );
+
+      lv = lv * lv * ( 3. - 2. * lv );
+
+      float bl = N( id );
+      float br = N( id + vec2( 1, 0 ));
+      float b = mix( bl, br, lv.x );
+
+      float tl = N( id + vec2( 0, 1 ));
+      float tr = N( id + vec2( 1, 1 ));
+      float t = mix( tl, tr, lv.x );
+
+      return mix( b, t, lv.y );
+  }
+`;
+
+/**
+ * street-generated-grass
+ *
+ * An instanced, wind-animated field of grass blades layered on top of a host
+ * primitive (the Grass Box). It follows the canonical street-generated-* managed
+ * children pattern (see street-generated-clones.js): the blades live on an
+ * `autocreated` child entity that the serializer skips, so only this component's
+ * config (`{ density, grassHeight, ... }`) is saved and the field is regenerated
+ * deterministically on load — never 25k entities.
+ *
+ * The field sizes itself to the host's box geometry (width/depth/height) and
+ * rebuilds when that geometry changes, so editing the box's first-class geometry
+ * controls keeps the lawn matched to the slab.
+ *
+ * See docs/host-generator-pattern.md for the host + generator pattern.
+ */
+AFRAME.registerComponent('street-generated-grass', {
+  schema: {
+    // Blades per square meter of host area; the actual count is area-scaled and
+    // capped at MAX_BLADES.
+    density: { default: 10, type: 'number' },
+    grassHeight: { default: 1.0, type: 'number' },
+    grassWidth: { default: 0.1, type: 'number' },
+    color: { default: '#6aa84f', type: 'color' },
+    // Random seed for blade layout. 0 means "pick one and persist it" so the
+    // layout is stable across reloads even though blades regenerate from config.
+    seed: { default: 0, type: 'int' }
+  },
+
+  init: function () {
+    this.createdEntities = [];
+    this.instancedMesh = null;
+    this.uniforms = null;
+    // Rebuild when the host box geometry changes (e.g. the user edits
+    // width/depth/height in the first-class geometry controls).
+    this.onComponentChanged = (e) => {
+      if (e.detail.name === 'geometry') {
+        this.update();
+      }
+    };
+    this.el.addEventListener('componentchanged', this.onComponentChanged);
+  },
+
+  update: function (oldData) {
+    // Seed handling mirrors street-generated-clones: if unseeded, pick a stable
+    // seed and persist it (setAttribute re-triggers update), so the layout is
+    // identical across reloads.
+    if (this.data.seed === 0) {
+      const newSeed = Math.floor(Math.random() * 1000000) + 1;
+      this.el.setAttribute(this.attrName, 'seed', newSeed);
+      return;
+    }
+
+    // Cheap path: only the color changed → recolor in place instead of rebuilding
+    // the whole instanced mesh. oldData is undefined when we call update()
+    // manually (geometry change), which correctly forces a full rebuild.
+    if (
+      this.instancedMesh &&
+      oldData &&
+      oldData.color !== this.data.color &&
+      oldData.density === this.data.density &&
+      oldData.grassHeight === this.data.grassHeight &&
+      oldData.grassWidth === this.data.grassWidth &&
+      oldData.seed === this.data.seed
+    ) {
+      this.instancedMesh.material.color.set(this.data.color);
+      return;
+    }
+
+    this.clearEntities();
+    this.generateGrass();
+  },
+
+  generateGrass: function () {
+    const data = this.data;
+
+    // Size the field to the host box geometry so grass covers the slab top.
+    const geometry = this.el.getAttribute('geometry') || {};
+    const width = geometry.width || 40;
+    const depth = geometry.depth || 40;
+    const topY = (geometry.height || 0) / 2; // local top surface of the box
+
+    const area = width * depth;
+    const count = Math.max(
+      1,
+      Math.min(MAX_BLADES, Math.round(data.density * area))
+    );
+
+    const uniforms = {
+      time: { value: 0 },
+      grassHeight: { value: data.grassHeight }
+    };
+
+    const leavesMaterial = new THREE.MeshLambertMaterial({
+      color: new THREE.Color(data.color),
+      side: THREE.DoubleSide
+    });
+
+    // Inject a wind animation into the vertex shader. Blades sway more toward the
+    // tip (uv.y) and each blade gets a unique phase from its instance position.
+    leavesMaterial.onBeforeCompile = function (shader) {
+      shader.uniforms.time = uniforms.time;
+      shader.uniforms.grassHeight = uniforms.grassHeight;
+
+      shader.vertexShader = shader.vertexShader.replace(
+        '#include <common>',
+        `#include <common>
+        uniform float time;
+        uniform float grassHeight;
+
+        ${SIMPLE_NOISE}`
+      );
+
+      shader.vertexShader = shader.vertexShader.replace(
+        '#include <begin_vertex>',
+        `#include <begin_vertex>
+
+        vec4 instancePosition = instanceMatrix * vec4(0.0, 0.0, 0.0, 1.0);
+
+        float t = time * 2.;
+        vec2 noiseCoord = instancePosition.xz * 0.1 + transformed.xz * 0.5 + vec2(0., t);
+        float noise = smoothNoise(noiseCoord);
+        noise = pow(noise * 0.5 + 0.5, 2.) * 2.;
+
+        float dispPower = 1. - cos( uv.y * 3.1416 * 0.5 );
+        float displacement = noise * ( 0.3 * dispPower * grassHeight );
+        transformed.z -= displacement;`
+      );
+    };
+
+    const geometryBlade = new THREE.PlaneGeometry(
+      data.grassWidth,
+      data.grassHeight,
+      1,
+      4
+    );
+    geometryBlade.translate(0, data.grassHeight / 2, 0);
+
+    const instancedMesh = new THREE.InstancedMesh(
+      geometryBlade,
+      leavesMaterial,
+      count
+    );
+
+    // Seeded layout so reloads regenerate identical placement from config.
+    const rng = createRNG(data.seed);
+    const dummy = new THREE.Object3D();
+    for (let i = 0; i < count; i++) {
+      dummy.position.set((rng() - 0.5) * width, topY, (rng() - 0.5) * depth);
+      dummy.scale.setScalar(0.5 + rng() * 0.5);
+      dummy.rotation.y = rng() * Math.PI;
+      dummy.updateMatrix();
+      instancedMesh.setMatrixAt(i, dummy.matrix);
+    }
+    instancedMesh.instanceMatrix.needsUpdate = true;
+
+    // Wrap the mesh in an autocreated child entity so the SceneGraph shows it as
+    // managed and the serializer skips it (regenerated rather than saved).
+    const grassEntity = document.createElement('a-entity');
+    grassEntity.classList.add('autocreated');
+    grassEntity.setAttribute('data-no-transform', '');
+    grassEntity.setAttribute('data-layer-name', 'Animated Grass');
+    grassEntity.setAttribute('data-parent-component', this.attrName);
+    grassEntity.setObject3D('grass', instancedMesh);
+
+    this.el.appendChild(grassEntity);
+    this.createdEntities.push(grassEntity);
+    this.instancedMesh = instancedMesh;
+    this.uniforms = uniforms;
+  },
+
+  // Drive the wind from A-Frame's tick (not window.requestAnimationFrame) so the
+  // animation pauses with the scene, drives correctly under WebXR, and never runs
+  // multiple competing loops.
+  tick: function (time) {
+    if (this.uniforms) {
+      this.uniforms.time.value = time / 1000;
+    }
+  },
+
+  clearEntities: function () {
+    // Dispose GPU resources before detaching so repeated add/remove doesn't leak.
+    if (this.instancedMesh) {
+      this.instancedMesh.geometry.dispose();
+      this.instancedMesh.material.dispose();
+      this.instancedMesh = null;
+    }
+    this.uniforms = null;
+    this.createdEntities.forEach((entity) => {
+      if (entity.parentNode) entity.remove();
+    });
+    this.createdEntities.length = 0;
+  },
+
+  // "Detach" from the autocreated-child sidebar simply stops managing the field
+  // by removing this component (the instanced mesh is procedural and has no
+  // independent serializable form, unlike cloned model entities).
+  detach: function () {
+    AFRAME.INSPECTOR.execute('componentremove', {
+      entity: this.el,
+      component: this.attrName
+    });
+  },
+
+  remove: function () {
+    this.el.removeEventListener('componentchanged', this.onComponentChanged);
+    this.clearEntities();
+  }
+});

--- a/src/aframe-components/street-generated-grass.js
+++ b/src/aframe-components/street-generated-grass.js
@@ -184,6 +184,9 @@ AFRAME.registerComponent('street-generated-grass', {
       instancedMesh.setMatrixAt(i, dummy.matrix);
     }
     instancedMesh.instanceMatrix.needsUpdate = true;
+    // InstancedMesh defaults to a unit bounding sphere; recompute it so frustum
+    // culling uses the real grass-field extent and doesn't cull the whole field.
+    instancedMesh.computeBoundingSphere();
 
     // Wrap the mesh in an autocreated child entity so the SceneGraph shows it as
     // managed and the serializer skips it (regenerated rather than saved).

--- a/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
@@ -14,7 +14,11 @@ import {
   isAcceptedAssetFile,
   placeCloudAsset
 } from '@/editor/lib/asset-upload/uploadAndPlaceAsset.js';
-import { customLayersData, streetLayersData } from './layersData.js';
+import {
+  customLayersData,
+  shapeLayersData,
+  streetLayersData
+} from './layersData.js';
 import { LayersOptions } from './LayersOptions.js';
 import Events from '../../../lib/Events.js';
 import useStore from '@/store.js';
@@ -435,6 +439,8 @@ const AddLayerPanel = () => {
     switch (selectedOption) {
       case 'Custom Layers':
         return customLayersData;
+      case 'Shapes':
+        return shapeLayersData;
       case 'Streets and Intersections':
         return streetLayersData;
       default:

--- a/src/editor/components/elements/AddLayerPanel/LayersOptions.js
+++ b/src/editor/components/elements/AddLayerPanel/LayersOptions.js
@@ -1,12 +1,12 @@
 const LayersOptions = [
   {
     value: 'Streets and Intersections',
-    label: '🚦 Streets & Intersections',
+    label: '🚦 Streets',
     onClick: () => {}
   },
   {
     value: 'Traffic Control',
-    label: '🚧 Traffic Control',
+    label: '🚧 Control',
     mixinGroups: ['dividers', 'traffic-control'],
     onClick: () => {}
   },
@@ -53,8 +53,13 @@ const LayersOptions = [
     onClick: () => {}
   },
   {
+    value: 'Shapes',
+    label: '🔵 Shapes',
+    onClick: () => {}
+  },
+  {
     value: 'Custom Layers',
-    label: '⚙️ Custom Layers',
+    label: '⚙️ Custom',
     onClick: () => {}
   }
 ];

--- a/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
@@ -342,6 +342,23 @@ export function createConcreteCylinder(position) {
   AFRAME.INSPECTOR.execute('entitycreate', definition);
 }
 
+export function createTorusKnot(position) {
+  // A polished metallic torus knot — a decorative primitive that shows off the
+  // geometry + material featured controls (metalness/roughness). Lifted off the
+  // ground so the full knot is visible. Geometry and material are editable in
+  // the properties panel.
+  const definition = {
+    components: {
+      position: groundedPositionString(position, 3),
+      geometry: 'primitive: torusKnot; radius: 2.33; radiusTubular: 0.43;',
+      material: 'color: #a6a6a6; metalness: 0.75; roughness: 0.23;',
+      'data-layer-name': 'Torus Knot',
+      shadow: 'receive: true; cast: true;'
+    }
+  };
+  AFRAME.INSPECTOR.execute('entitycreate', definition);
+}
+
 export function createHighlightRing(position) {
   // A bright red ring laid flat on the ground, large enough to circle and
   // highlight a real-world street element (vehicle, tree, lane area, etc.).
@@ -349,7 +366,7 @@ export function createHighlightRing(position) {
   const definition = {
     components: {
       position: groundedPositionString(position, 0.1),
-      rotation: '-90 0 0',
+      rotation: '0 0 0',
       geometry: 'primitive: torus; radius: 3; radiusTubular: 0.15;',
       material: 'shader: flat; color: #ff0000; side: double;',
       'data-layer-name': 'Highlight Ring • Red'

--- a/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
@@ -304,12 +304,20 @@ export function createGrassBox(position) {
   // as a ground/lawn for non-street scenes that don't already have terrain.
   // Offset down by half its thickness so its top surface sits exactly at y=0 and
   // objects placed on the ground rest flush on top of it.
+  //
+  // The box ships with the street-generated-grass generator attached as a live
+  // demo of the host-primitive + generator pattern: the box's geometry/material
+  // and the grass options (density, blade height, …) all surface as first-class
+  // controls in the properties sidebar. The animated blades are autocreated
+  // children regenerated from config, so saving the scene stores only the box +
+  // the grass config, not the blades. See docs/host-generator-pattern.md.
   const thickness = 0.5;
   const definition = {
     components: {
       position: groundedPositionString(position, -thickness / 2),
       geometry: `primitive: box; width: 40; height: ${thickness}; depth: 40;`,
       material: 'color: #4c9a2a; roughness: 1;',
+      'street-generated-grass': '',
       'data-layer-name': 'Grass Box • Ground',
       shadow: 'receive: true;'
     }

--- a/src/editor/components/elements/AddLayerPanel/layersData.js
+++ b/src/editor/components/elements/AddLayerPanel/layersData.js
@@ -78,7 +78,9 @@ export const streetLayersData = [
   }
 ].map((layer, index) => ({ ...layer, id: index + 1 }));
 
-export const customLayersData = [
+// A-Frame geometry primitives — host shapes that surface first-class geometry +
+// material controls in the properties sidebar (the host-primitive pattern).
+export const shapeLayersData = [
   {
     name: 'Building Box',
     img: '',
@@ -87,15 +89,6 @@ export const customLayersData = [
     description:
       'Add a simple box roughly the size of a 3-story building, sitting on the ground in a bright blue. A quick placeholder for blocking out buildings.',
     handlerFunction: createFunctions.createBuildingBox
-  },
-  {
-    name: 'Highlight Ring',
-    img: '',
-    icon: '',
-    requiresPro: false,
-    description:
-      'Add a bright red ring on the ground, big enough to circle and highlight a real-world element like a vehicle, tree, or part of a lane.',
-    handlerFunction: createFunctions.createHighlightRing
   },
   {
     name: 'Asphalt Circle',
@@ -124,6 +117,27 @@ export const customLayersData = [
       'Add a gray concrete cylinder roughly the size of an interstate highway support pillar. A quick placeholder for elevated-roadway columns.',
     handlerFunction: createFunctions.createConcreteCylinder
   },
+  {
+    name: 'Torus Knot',
+    img: '',
+    icon: '',
+    requiresPro: false,
+    description:
+      'Add a polished metallic torus knot. A decorative primitive that shows off the geometry and material (metalness/roughness) controls in the properties panel.',
+    handlerFunction: createFunctions.createTorusKnot
+  },
+  {
+    name: 'Highlight Ring',
+    img: '',
+    icon: '',
+    requiresPro: false,
+    description:
+      'Add a bright red ring, big enough to circle and highlight a real-world element like a vehicle, tree, or part of a lane.',
+    handlerFunction: createFunctions.createHighlightRing
+  }
+].map((layer, index) => ({ ...layer, id: index + 1 }));
+
+export const customLayersData = [
   {
     name: 'Upload Image',
     img: '',

--- a/src/editor/components/elements/AddLayerPanel/layersData.js
+++ b/src/editor/components/elements/AddLayerPanel/layersData.js
@@ -112,7 +112,7 @@ export const customLayersData = [
     icon: '',
     requiresPro: false,
     description:
-      'Add a large, thin green ground slab to act as a lawn for scenes that do not already have terrain.',
+      'Add a large green ground slab with animated instanced grass. The box dimensions, color, and grass options (density, blade height) are all editable in the properties panel.',
     handlerFunction: createFunctions.createGrassBox
   },
   {

--- a/src/editor/components/elements/AdvancedComponents.jsx
+++ b/src/editor/components/elements/AdvancedComponents.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Component from './Component';
 import DEFAULT_COMPONENTS from './DefaultComponents';
+import { isFeaturedComponent } from '../../lib/featuredComponents';
 import { Button } from '../elements';
 import posthog from 'posthog-js';
 const AdvancedComponents = ({ entity }) => {
@@ -9,7 +10,10 @@ const AdvancedComponents = ({ entity }) => {
 
   const components = entity ? entity.components : {};
   const definedComponents = Object.keys(components).filter((key) => {
-    return DEFAULT_COMPONENTS.indexOf(key) === -1;
+    // Skip default transform components and anything already promoted to the
+    // first-class "featured" section above, so geometry/material/generators
+    // aren't shown twice.
+    return DEFAULT_COMPONENTS.indexOf(key) === -1 && !isFeaturedComponent(key);
   });
 
   const toggleAdvanced = () => {

--- a/src/editor/components/elements/AdvancedComponents.jsx
+++ b/src/editor/components/elements/AdvancedComponents.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Component from './Component';
 import DEFAULT_COMPONENTS from './DefaultComponents';
-import { isFeaturedComponent } from '../../lib/featuredComponents';
+import { isGeneratorComponent } from '../../lib/featuredComponents';
 import { Button } from '../elements';
 import posthog from 'posthog-js';
 const AdvancedComponents = ({ entity }) => {
@@ -10,10 +10,11 @@ const AdvancedComponents = ({ entity }) => {
 
   const components = entity ? entity.components : {};
   const definedComponents = Object.keys(components).filter((key) => {
-    // Skip default transform components and anything already promoted to the
-    // first-class "featured" section above, so geometry/material/generators
-    // aren't shown twice.
-    return DEFAULT_COMPONENTS.indexOf(key) === -1 && !isFeaturedComponent(key);
+    // Skip default transform components and generator components (fully shown in
+    // the featured section). geometry/material are intentionally kept here too,
+    // so a technical user editing their first-class controls can still reach the
+    // full set of advanced geometry/material settings.
+    return DEFAULT_COMPONENTS.indexOf(key) === -1 && !isGeneratorComponent(key);
   });
 
   const toggleAdvanced = () => {

--- a/src/editor/components/elements/Component.jsx
+++ b/src/editor/components/elements/Component.jsx
@@ -98,26 +98,34 @@ export default class Component extends React.Component {
     }
 
     const hideProperties = this.props.hideProperties || [];
-    return Object.keys(componentData.schema)
-      .sort()
-      .filter((propertyName) => {
-        return (
-          !hideProperties.includes(propertyName) &&
-          shouldShowProperty(propertyName, componentData)
-        );
-      })
-      .map((propertyName) => (
-        <div className="detailed" key={propertyName}>
-          <PropertyRow
-            name={propertyName}
-            schema={componentData.schema[propertyName]}
-            data={componentData.data[propertyName]}
-            componentname={this.props.name}
-            isSingle={false}
-            entity={this.props.entity}
-          />
-        </div>
-      ));
+    return (
+      Object.keys(componentData.schema)
+        // `primitive` is the discriminator that decides which other fields apply
+        // (e.g. box -> width/depth/height), so surface it first; rest alphabetical.
+        .sort((a, b) => {
+          if (a === 'primitive') return -1;
+          if (b === 'primitive') return 1;
+          return a < b ? -1 : a > b ? 1 : 0;
+        })
+        .filter((propertyName) => {
+          return (
+            !hideProperties.includes(propertyName) &&
+            shouldShowProperty(propertyName, componentData)
+          );
+        })
+        .map((propertyName) => (
+          <div className="detailed" key={propertyName}>
+            <PropertyRow
+              name={propertyName}
+              schema={componentData.schema[propertyName]}
+              data={componentData.data[propertyName]}
+              componentname={this.props.name}
+              isSingle={false}
+              entity={this.props.entity}
+            />
+          </div>
+        ))
+    );
   };
 
   render() {

--- a/src/editor/components/elements/Component.jsx
+++ b/src/editor/components/elements/Component.jsx
@@ -16,7 +16,11 @@ export default class Component extends React.Component {
     component: PropTypes.any,
     entity: PropTypes.object,
     isCollapsed: PropTypes.bool,
-    name: PropTypes.string
+    name: PropTypes.string,
+    // Property names to omit from the rendered rows (e.g. advanced geometry
+    // props promoted into the featured section but too low-level to surface
+    // there — they remain available under Advanced Components).
+    hideProperties: PropTypes.array
   };
 
   constructor(props) {
@@ -93,10 +97,14 @@ export default class Component extends React.Component {
       );
     }
 
+    const hideProperties = this.props.hideProperties || [];
     return Object.keys(componentData.schema)
       .sort()
       .filter((propertyName) => {
-        return shouldShowProperty(propertyName, componentData);
+        return (
+          !hideProperties.includes(propertyName) &&
+          shouldShowProperty(propertyName, componentData)
+        );
       })
       .map((propertyName) => (
         <div className="detailed" key={propertyName}>

--- a/src/editor/components/elements/ComponentsContainer.jsx
+++ b/src/editor/components/elements/ComponentsContainer.jsx
@@ -1,5 +1,6 @@
 import CommonComponents from './CommonComponents';
 import AdvancedComponents from './AdvancedComponents';
+import FeaturedComponents from './FeaturedComponents';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Events from '../../lib/Events';
@@ -70,6 +71,7 @@ export default class ComponentsContainer extends React.Component {
             </div>
           </div>
         )}
+        <FeaturedComponents entity={entity} />
         <div className="advancedComponentsContainer">
           <AdvancedComponents entity={entity} />
         </div>

--- a/src/editor/components/elements/FeaturedComponents.jsx
+++ b/src/editor/components/elements/FeaturedComponents.jsx
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import Component from './Component';
+import MaterialControls from './MaterialControls';
+import { getFeaturedComponentNames } from '../../lib/featuredComponents';
+
+// Renders the first-class "featured" controls (geometry, material, and any
+// street-generated-* generator) expanded at the top of the properties sidebar,
+// above Advanced Components. Geometry and generators reuse the generic
+// schema-driven Component widget; material gets a curated panel (MaterialControls).
+const FeaturedComponents = ({ entity }) => {
+  const components = entity ? entity.components : {};
+  const featured = getFeaturedComponentNames(entity);
+
+  if (featured.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="featured-components">
+      {featured.map((name) => {
+        if (name === 'material') {
+          return <MaterialControls key={name} entity={entity} />;
+        }
+        return (
+          <div key={name} className="details">
+            <Component
+              isCollapsed={false}
+              component={components[name]}
+              entity={entity}
+              name={name}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+FeaturedComponents.propTypes = {
+  entity: PropTypes.object.isRequired
+};
+
+export default FeaturedComponents;

--- a/src/editor/components/elements/FeaturedComponents.jsx
+++ b/src/editor/components/elements/FeaturedComponents.jsx
@@ -55,7 +55,8 @@ const FeaturedComponents = ({ entity }) => {
 };
 
 FeaturedComponents.propTypes = {
-  entity: PropTypes.object.isRequired
+  // entity can be null (e.g. no selection) — the component renders nothing.
+  entity: PropTypes.object
 };
 
 export default FeaturedComponents;

--- a/src/editor/components/elements/FeaturedComponents.jsx
+++ b/src/editor/components/elements/FeaturedComponents.jsx
@@ -3,6 +3,19 @@ import Component from './Component';
 import MaterialControls from './MaterialControls';
 import { getFeaturedComponentNames } from '../../lib/featuredComponents';
 
+// Low-level geometry props that are too advanced for the first-class section.
+// They stay reachable under Advanced Components. `segments*` (tessellation) props
+// are also hidden via the prefix check below.
+const HIDDEN_GEOMETRY_PROPS = ['buffer', 'skipCache'];
+
+function getHiddenGeometryProps(component) {
+  const schema = component?.schema || {};
+  return Object.keys(schema).filter(
+    (name) =>
+      HIDDEN_GEOMETRY_PROPS.includes(name) || name.startsWith('segments')
+  );
+}
+
 // Renders the first-class "featured" controls (geometry, material, and any
 // street-generated-* generator) expanded at the top of the properties sidebar,
 // above Advanced Components. Geometry and generators reuse the generic
@@ -28,6 +41,11 @@ const FeaturedComponents = ({ entity }) => {
               component={components[name]}
               entity={entity}
               name={name}
+              hideProperties={
+                name === 'geometry'
+                  ? getHiddenGeometryProps(components[name])
+                  : undefined
+              }
             />
           </div>
         );

--- a/src/editor/components/elements/MaterialControls.jsx
+++ b/src/editor/components/elements/MaterialControls.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
+import Collapsible from '../Collapsible';
 import PropertyRow from './PropertyRow';
 import Events from '../../lib/Events';
 import { Button } from '../elements';
@@ -88,83 +89,87 @@ const MaterialControls = ({ entity }) => {
 
   return (
     <div className="details material-controls">
-      <div className="componentHeader collapsible-header">
-        <span className="componentTitle" title="Material">
-          <span>Material</span>
-        </span>
-      </div>
-      <div className="collapsible-content">
-        {/* The material schema is dynamic per shader (e.g. shader:flat has no
-            roughness), so each optional row is guarded by schema presence. */}
-        {schema.color && (
-          <PropertyRow
-            name="color"
-            label="Color"
-            schema={schema.color}
-            data={data.color}
-            componentname="material"
-            entity={entity}
-          />
-        )}
-        {schema.src && (
-          <PropertyRow
-            name="src"
-            label="Texture"
-            schema={schema.src}
-            data={data.src ?? ''}
-            componentname="material"
-            entity={entity}
-            rightElement={
-              hasTexture ? (
-                <Button variant="ghost" onClick={makeSolidColor}>
-                  Make Solid
-                </Button>
-              ) : null
-            }
-          />
-        )}
-        {hasTexture && schema.repeat && (
-          <PropertyRow
-            name="repeat"
-            label="Texture Repeat"
-            schema={schema.repeat}
-            data={data.repeat}
-            componentname="material"
-            entity={entity}
-          />
-        )}
-        <div className="propertyRow opacity-row">
-          <label
-            className="text"
-            htmlFor="material-opacity"
-            style={{ textTransform: 'none' }}
-          >
-            Opacity
-          </label>
-          <div className="opacity-slider">
-            <input
-              id="material-opacity"
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              value={opacity}
-              onChange={(e) => setOpacity(parseFloat(e.target.value))}
-            />
-            <span className="opacity-value">{Math.round(opacity * 100)}%</span>
-          </div>
+      <Collapsible>
+        <div className="componentHeader collapsible-header">
+          <span className="componentTitle" title="material">
+            <span>material</span>
+          </span>
         </div>
-        {schema.roughness && (
-          <PropertyRow
-            name="roughness"
-            label="Roughness"
-            schema={schema.roughness}
-            data={data.roughness}
-            componentname="material"
-            entity={entity}
-          />
-        )}
-      </div>
+        <div className="collapsible-content">
+          {/* The material schema is dynamic per shader (e.g. shader:flat has no
+            roughness), so each optional row is guarded by schema presence. */}
+          {schema.color && (
+            <PropertyRow
+              name="color"
+              label="Color"
+              schema={schema.color}
+              data={data.color}
+              componentname="material"
+              entity={entity}
+            />
+          )}
+          {schema.src && (
+            <PropertyRow
+              name="src"
+              label="Texture"
+              schema={schema.src}
+              data={data.src ?? ''}
+              componentname="material"
+              entity={entity}
+              rightElement={
+                hasTexture ? (
+                  <Button variant="ghost" onClick={makeSolidColor}>
+                    Make Solid
+                  </Button>
+                ) : null
+              }
+            />
+          )}
+          {hasTexture && schema.repeat && (
+            <PropertyRow
+              name="repeat"
+              label="Texture Repeat"
+              schema={schema.repeat}
+              data={data.repeat}
+              componentname="material"
+              entity={entity}
+            />
+          )}
+          <div className="propertyRow opacity-row">
+            <label
+              className="text"
+              htmlFor="material-opacity"
+              style={{ textTransform: 'none' }}
+            >
+              Opacity
+            </label>
+            <div className="opacity-slider">
+              <input
+                id="material-opacity"
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={opacity}
+                onChange={(e) => setOpacity(parseFloat(e.target.value))}
+              />
+              <span className="opacity-value">
+                {Math.round(opacity * 100)}%
+              </span>
+            </div>
+          </div>
+          {schema.roughness && (
+            <PropertyRow
+              name="roughness"
+              label="Roughness"
+              schema={schema.roughness}
+              data={data.roughness}
+              componentname="material"
+              entity={entity}
+            />
+          )}
+        </div>
+      </Collapsible>
     </div>
   );
 };

--- a/src/editor/components/elements/MaterialControls.jsx
+++ b/src/editor/components/elements/MaterialControls.jsx
@@ -1,0 +1,176 @@
+import { useEffect, useReducer } from 'react';
+import PropTypes from 'prop-types';
+import PropertyRow from './PropertyRow';
+import Events from '../../lib/Events';
+import { Button } from '../elements';
+
+// First-class material editing surfaced at the top of the properties sidebar.
+//
+// Curated rather than schema-dumped because the material component has ~30 props;
+// this exposes only the ones non-technical users reach for (color, texture,
+// opacity, roughness) plus two UX shortcuts called out in #1741:
+//   - "Make Solid" drops the texture/SRC in one click so the flat color shows
+//     through (the common case for AI mask boxes and massing blocks).
+//   - A real opacity slider with live preview that also toggles `transparent`
+//     so partial opacity actually renders.
+const MaterialControls = ({ entity }) => {
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  // Re-render when the material changes (incl. our own edits and external ones).
+  useEffect(() => {
+    const onEntityUpdate = (detail) => {
+      if (detail.entity === entity && detail.component === 'material') {
+        forceUpdate();
+      }
+    };
+    Events.on('entityupdate', onEntityUpdate);
+    return () => Events.off('entityupdate', onEntityUpdate);
+  }, [entity]);
+
+  const component = entity?.components?.material;
+  if (!component || !component.schema || !component.data) {
+    return null;
+  }
+  const schema = component.schema;
+  const data = component.data;
+  const hasTexture = !!data.src;
+  const opacity = typeof data.opacity === 'number' ? data.opacity : 1;
+
+  const makeSolidColor = () => {
+    AFRAME.INSPECTOR.execute('entityupdate', {
+      entity,
+      component: 'material',
+      property: 'src',
+      value: '',
+      noSelectEntity: true
+    });
+  };
+
+  const setOpacity = (value) => {
+    // A material only honors opacity < 1 when `transparent` is enabled, so keep
+    // the two in sync. When transparent doesn't need to change we use a single
+    // (updatable) entityupdate so dragging the slider collapses into one undo
+    // step, matching NumberWidget behavior.
+    const needTransparent = value < 1;
+    if (!!data.transparent === needTransparent) {
+      AFRAME.INSPECTOR.execute('entityupdate', {
+        entity,
+        component: 'material',
+        property: 'opacity',
+        value,
+        noSelectEntity: true
+      });
+    } else {
+      AFRAME.INSPECTOR.execute('multi', [
+        [
+          'entityupdate',
+          {
+            entity,
+            component: 'material',
+            property: 'opacity',
+            value,
+            noSelectEntity: true
+          }
+        ],
+        [
+          'entityupdate',
+          {
+            entity,
+            component: 'material',
+            property: 'transparent',
+            value: needTransparent,
+            noSelectEntity: true
+          }
+        ]
+      ]);
+    }
+  };
+
+  return (
+    <div className="details material-controls">
+      <div className="componentHeader collapsible-header">
+        <span className="componentTitle" title="Material">
+          <span>Material</span>
+        </span>
+      </div>
+      <div className="collapsible-content">
+        {/* The material schema is dynamic per shader (e.g. shader:flat has no
+            roughness), so each optional row is guarded by schema presence. */}
+        {schema.color && (
+          <PropertyRow
+            name="color"
+            label="Color"
+            schema={schema.color}
+            data={data.color}
+            componentname="material"
+            entity={entity}
+          />
+        )}
+        {schema.src && (
+          <PropertyRow
+            name="src"
+            label="Texture"
+            schema={schema.src}
+            data={data.src ?? ''}
+            componentname="material"
+            entity={entity}
+            rightElement={
+              hasTexture ? (
+                <Button variant="ghost" onClick={makeSolidColor}>
+                  Make Solid
+                </Button>
+              ) : null
+            }
+          />
+        )}
+        {hasTexture && schema.repeat && (
+          <PropertyRow
+            name="repeat"
+            label="Texture Repeat"
+            schema={schema.repeat}
+            data={data.repeat}
+            componentname="material"
+            entity={entity}
+          />
+        )}
+        <div className="propertyRow opacity-row">
+          <label
+            className="text"
+            htmlFor="material-opacity"
+            style={{ textTransform: 'none' }}
+          >
+            Opacity
+          </label>
+          <div className="opacity-slider">
+            <input
+              id="material-opacity"
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={opacity}
+              onChange={(e) => setOpacity(parseFloat(e.target.value))}
+            />
+            <span className="opacity-value">{Math.round(opacity * 100)}%</span>
+          </div>
+        </div>
+        {schema.roughness && (
+          <PropertyRow
+            name="roughness"
+            label="Roughness"
+            schema={schema.roughness}
+            data={data.roughness}
+            componentname="material"
+            entity={entity}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+MaterialControls.propTypes = {
+  entity: PropTypes.object.isRequired
+};
+
+export default MaterialControls;

--- a/src/editor/components/elements/MaterialControls.jsx
+++ b/src/editor/components/elements/MaterialControls.jsx
@@ -168,6 +168,16 @@ const MaterialControls = ({ entity }) => {
               entity={entity}
             />
           )}
+          {schema.metalness && (
+            <PropertyRow
+              name="metalness"
+              label="Metalness"
+              schema={schema.metalness}
+              data={data.metalness}
+              componentname="material"
+              entity={entity}
+            />
+          )}
         </div>
       </Collapsible>
     </div>

--- a/src/editor/components/elements/StreetSegmentSidebar.jsx
+++ b/src/editor/components/elements/StreetSegmentSidebar.jsx
@@ -17,19 +17,18 @@ import {
 } from '@shared/icons';
 import { Button } from '../elements';
 import Events from '../../lib/Events';
-
-// Define featured component prefixes that should be shown in their own section
-const FEATURED_COMPONENT_PREFIXES = ['street-generated-'];
+import { isGeneratorComponent } from '../../lib/featuredComponents';
 
 const StreetSegmentSidebar = ({ entity }) => {
   const componentName = 'street-segment';
   const component = entity?.components?.[componentName];
   const components = entity ? entity.components : {};
 
-  // Filter for featured components that exist on this entity
-  const featuredComponents = Object.keys(components).filter((key) =>
-    FEATURED_COMPONENT_PREFIXES.some((prefix) => key.startsWith(prefix))
-  );
+  // Filter for featured generator components that exist on this entity. Shares
+  // the generalized prefix list (see lib/featuredComponents.js) so segments and
+  // generic primitives surface street-generated-* the same way.
+  const featuredComponents =
+    Object.keys(components).filter(isGeneratorComponent);
 
   return (
     <div className="segment-sidebar">

--- a/src/editor/lib/featuredComponents.js
+++ b/src/editor/lib/featuredComponents.js
@@ -13,16 +13,17 @@
 // Generator components follow the managed-children pattern (street-generated-*).
 export const GENERATOR_COMPONENT_PREFIXES = ['street-generated-'];
 
-// Everything promoted to the featured section on a generic entity: the geometry
-// and material of the host primitive, plus any attached generators.
-export const FEATURED_COMPONENT_PREFIXES = [
-  'geometry',
-  'material',
-  ...GENERATOR_COMPONENT_PREFIXES
-];
+// The host primitive's geometry and material are featured by exact name only.
+// Prefix matching here would over-promote unrelated future components whose
+// names merely start with these strings (e.g. the A-Frame community
+// `geometry-merger`, or a hypothetical `materialLibrary`).
+export const FEATURED_COMPONENT_NAMES = ['geometry', 'material'];
 
 export function isFeaturedComponent(name) {
-  return FEATURED_COMPONENT_PREFIXES.some((prefix) => name.startsWith(prefix));
+  return (
+    FEATURED_COMPONENT_NAMES.includes(name) ||
+    GENERATOR_COMPONENT_PREFIXES.some((prefix) => name.startsWith(prefix))
+  );
 }
 
 export function isGeneratorComponent(name) {

--- a/src/editor/lib/featuredComponents.js
+++ b/src/editor/lib/featuredComponents.js
@@ -1,0 +1,46 @@
+// Featured components are promoted to first-class, expanded controls at the top
+// of the properties sidebar, above the collapsed "Advanced Components" section.
+//
+// This generalizes a mechanism that previously lived only in
+// StreetSegmentSidebar (FEATURED_COMPONENT_PREFIXES = ['street-generated-']) so
+// that ANY primitive — Building Box, Asphalt Circle, Grass Box, image planes,
+// etc. — gets its key geometry and material properties surfaced without digging
+// into Advanced Components, plus any street-generated-* generator attached to it.
+//
+// See docs/host-generator-pattern.md for the host-primitive + generator pattern
+// that this enables (Grass Box + street-generated-grass is the first example).
+
+// Generator components follow the managed-children pattern (street-generated-*).
+export const GENERATOR_COMPONENT_PREFIXES = ['street-generated-'];
+
+// Everything promoted to the featured section on a generic entity: the geometry
+// and material of the host primitive, plus any attached generators.
+export const FEATURED_COMPONENT_PREFIXES = [
+  'geometry',
+  'material',
+  ...GENERATOR_COMPONENT_PREFIXES
+];
+
+export function isFeaturedComponent(name) {
+  return FEATURED_COMPONENT_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+export function isGeneratorComponent(name) {
+  return GENERATOR_COMPONENT_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+// Names of featured components actually present on an entity, ordered so the host
+// primitive's geometry and material come first, then any generators.
+export function getFeaturedComponentNames(entity) {
+  if (!entity || !entity.components) {
+    return [];
+  }
+  const order = (name) => {
+    if (name === 'geometry') return 0;
+    if (name === 'material') return 1;
+    return 2;
+  };
+  return Object.keys(entity.components)
+    .filter(isFeaturedComponent)
+    .sort((a, b) => order(a) - order(b) || (a < b ? -1 : 1));
+}

--- a/src/editor/style/components.scss
+++ b/src/editor/style/components.scss
@@ -447,6 +447,37 @@ div.vec4 {
     min-width: 70px; // Added to maintain consistent label width
   }
 }
+// First-class featured controls (geometry / material / generators) shown
+// expanded above Advanced Components.
+.featured-components {
+  .details {
+    border-bottom: 1px solid variables.$darkgray-700;
+  }
+}
+// Curated material panel (#1741): real opacity slider with live preview.
+.material-controls {
+  .opacity-row .opacity-slider {
+    display: flex;
+    align-items: center;
+    column-gap: 10px;
+    width: 100%;
+    margin-right: 12px;
+
+    input[type='range'] {
+      flex: 1;
+      width: auto !important;
+      accent-color: variables.$purple-400;
+      cursor: pointer;
+    }
+
+    .opacity-value {
+      min-width: 40px;
+      text-align: right;
+      font-size: 14px;
+      color: variables.$lightgray-200;
+    }
+  }
+}
 .components * {
   vertical-align: middle;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ require('./aframe-components/street-generated-striping.js');
 require('./aframe-components/street-generated-pedestrians.js');
 require('./aframe-components/street-generated-rail.js');
 require('./aframe-components/street-generated-clones.js');
+require('./aframe-components/street-generated-grass.js');
 require('./aframe-components/polygon-offset.js');
 require('./aframe-components/street-align.js');
 require('./aframe-components/street-ground.js');


### PR DESCRIPTION
## Summary

Addresses #1749 and #1741 together — both converge on promoting an entity's **geometry/material to first-class controls** in the properties sidebar. Grass is the proof-of-concept for a general **host primitive + generator** pattern.

## First-class featured controls (#1749, #1741, relates to #1324)
- Generalized the street-segment-only `FEATURED_COMPONENT_PREFIXES` into a shared `src/editor/lib/featuredComponents.js` (`geometry`, `material`, `street-generated-`), so **any** primitive (Building Box, Asphalt Circle, Grass Box, image planes) surfaces its key dimensions and material color/texture **expanded, above Advanced Components** — no special per-shape sidebar.
- `FeaturedComponents.jsx` renders these in the generic sidebar; geometry and generators reuse the existing schema-driven `Component`/`PropertyRow` widgets.
- `AdvancedComponents.jsx` now excludes featured components so nothing is shown twice.
- `StreetSegmentSidebar.jsx` reuses the shared prefix list (no behavior change).

## Material / opacity UX cleanup (#1741)
- `MaterialControls.jsx`: curated material panel with
  - a one-click **Make Solid** that drops the texture/SRC so the flat color shows through (the common case for AI mask boxes and massing),
  - a real **opacity slider** with live preview that also toggles `transparent` so partial opacity actually renders,
  - plus color / texture / roughness.
- Rows are guarded by schema presence (e.g. `shader: flat` materials have no `roughness`).

## Animated instanced grass generator (#1749)
- New `street-generated-grass` A-Frame component following the canonical `street-generated-*` managed-children pattern (`autocreated` child, `data-no-transform`, `data-parent-component`, seeded RNG, `detach()`). Blades are **not serialized** — the scene saves only the config and regenerates a stable layout on load.
- Ported from the `stage` branch grass prototype with all the review fixes from the issue:
  - animates via `tick()` (not `window.requestAnimationFrame`) → pauses with the scene, correct under WebXR, no competing loops,
  - disposes GPU resources on rebuild/remove,
  - area-scales `density` (blades/m²) with a `MAX_BLADES` quality cap,
  - seeds the blade layout for stability across reloads,
  - drops the no-op `alphaTest`,
  - rebuilds on blade-size and host-geometry changes.
- The 5 textured-box "stage" surface presets are **not** carried over.
- The **Grass Box** add-layer card attaches the generator by default as a live demo; the box stays a plain editable box with grass layered on top.

## Docs
- `docs/host-generator-pattern.md` documents the host-primitive + generator pattern so future combinations can follow it.

## Open decisions for review
- **Grass `detach()`** removes the component (the instanced field has no independent serializable form, unlike cloned model entities). Slightly different semantics from clones' "detach into real entities."
- **No generic "Add Generator" UI yet** — per discussion, grass is reachable only via the Grass Box card for now; the featured sidebar still surfaces its options first-class.
- **density = blades/m²** (area-scaled, capped) rather than an absolute count, so resizing the box keeps a sensible look.

## Test plan
- [x] `npm run lint`, prettier, and `npm run dist:staging` (webpack build) pass.
- [x] All 337 unit tests pass (`npm run test:modern`).
- [ ] Selecting any primitive shows geometry dimensions + material color/texture first-class without opening Advanced.
- [ ] Make Solid drops the texture; opacity slider gives live preview and enables transparency.
- [ ] Grass Box animates, saves/reloads with a stable layout (no blade entities in the JSON), and disposes cleanly with no GPU leak on repeated add/remove.

Closes #1749
Closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUN6nVpp88UUCzpCaiNxqG)_