### PR TITLE
Fix require-yield lint error blocking functions deploy

### DIFF
--- a/public/functions/replicate.js
+++ b/public/functions/replicate.js
@@ -1288,7 +1288,7 @@ async function fetchPlyHead(plyUrl, byteCount) {
       const chunks = [];
       await pipeline(
         bucket.file(match[2]).createReadStream({ start: 0, end: byteCount - 1 }),
-        async function* (source) {
+        async function (source) {
           for await (const chunk of source) chunks.push(chunk);
         }
       );


### PR DESCRIPTION
Follow-up to #1746. The functions predeploy lint (`npm --prefix public/functions run lint`) was failing, blocking `firebase deploy --only functions`:

```
replicate.js
  1291:9  error  This generator function does not have 'yield'  require-yield
```

The `.ply` head reader used an async generator (`async function*`) as the final stage of `stream.pipeline`, but it only consumes the source and never yields. A pipeline destination doesn't need to produce output, so this is now a plain `async function` (functionally identical, lint-clean).

Verified with `npm run lint` in `public/functions`.