### PR TITLE
Show out-of-tokens notice for Pro/Max users in generator

### DIFF
--- a/src/generator/mount-purchase-modal.jsx
+++ b/src/generator/mount-purchase-modal.jsx
@@ -9,6 +9,7 @@ import { AuthProvider, useAuthContext } from '../editor/contexts';
 import UpgradeModal from '@shared/components/UpgradeModal';
 import { getTokenProfile } from '@shared/utils/tokens';
 import useImageGenStore from './store.js';
+import FluxUI from './main.js';
 
 const GeneratorUpgradeModal = () => {
   const { modal, setModal } = useImageGenStore();
@@ -33,12 +34,25 @@ const GeneratorUpgradeModal = () => {
     return false;
   }, [currentUser]);
 
+  // The modal is only opened on a token shortfall (gen_token_limit). For an
+  // already-Pro/Max user that means they're out of tokens, not that they need
+  // to upgrade — UpgradeModal would otherwise silently self-close, leaving no
+  // feedback that the job couldn't start. Toast the real reason instead.
+  const onAlreadyPro = useCallback(() => {
+    setModal(null);
+    FluxUI.showNotification(
+      "You're out of generation tokens, so this couldn't start. Your monthly tokens refill with your plan.",
+      'error'
+    );
+  }, [setModal]);
+
   return (
     <UpgradeModal
       isOpen={modal === 'purchase'}
       onClose={() => setModal(null)}
       source="generator"
       trigger="gen_token_limit"
+      onAlreadyPro={onAlreadyPro}
       onCheckoutStart={handleCheckoutStart}
       // rememberPrevious=true so closing/completing sign-in lands the user
       // back in the upgrade modal where they started.


### PR DESCRIPTION
## Problem

In the generator (splat / video / image tabs), a paid (Pro/Max) user who is **out of generation tokens** clicks Generate and sees **nothing** — no error, no modal — and the job silently never starts.

## Root cause

On a token shortfall, `validate()` fires the `openPurchaseModal` event, which opens the shared `UpgradeModal`. But `UpgradeModal` short-circuits and self-closes when `currentUser.isPro` is true (it's an *upgrade* prompt — irrelevant to someone who already has a plan and is just out of tokens). It calls `onAlreadyPro()`, or `handleClose()` if none was passed.

The generator's `mount-purchase-modal.jsx` never passed `onAlreadyPro`, so the modal just closed instantly with no feedback. (Free users are unaffected — they see the pricing/upsell.) The editor already handles this case via its own `onAlreadyPro`.

## Fix

Wire an `onAlreadyPro` handler in the generator's modal that closes the modal and toasts the real reason:

> You're out of generation tokens, so this couldn't start. Your monthly tokens refill with your plan.

One mounted modal is shared across all three generator tabs via the `openPurchaseModal` event, so this covers splat, video, and image generation in one place.

## Testing

Lint clean. Verified `UpgradeModal` initializes `modalState='pricing'`, so the `onAlreadyPro` effect fires on fresh open for a Pro user (the path hit here).