### PR TITLE
Replace stale 0.5.x version with CalVer + git build-stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Human-facing notes for each 3DStreet release. See `docs/releasing.md` for how
+releases are versioned and cut. Versions use CalVer (`YYYY.M.patch`); the build
+SHA shown in-app (`+a1b2c3d`) identifies the exact deployed commit.
+
+## 2026.6.0
+
+- Adopt CalVer + git build-stamp versioning, replacing the legacy `0.5.x`
+  npm-library version. The deployed build identity (`YYYY.M.patch+sha`) is now
+  shown in the Profile modal and tagged on every Sentry issue.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,45 @@
+# Releasing 3DStreet
+
+3DStreet is a continuously-deployed web app, not a published library, so we
+don't use semver (it exists to signal API-breaking changes to downstream
+importers, of which we have none). We use two identifiers instead.
+
+## Two identifiers, two jobs
+
+1. **Build stamp** (`+a1b2c3d`) — the short git SHA, appended automatically to
+   every build by webpack (`buildVersion()` in `webpack.config.js` /
+   `webpack.prod.config.js`). It uniquely fingerprints the exact deployed
+   bundle. This is what gets set as the Sentry `release`, and what a user reads
+   off the Profile modal when reporting a bug. Nobody touches it by hand.
+
+2. **CalVer base** (`2026.6.0`, `YYYY.M.patch`) — the human-facing "release."
+   Lives in `package.json` `version`. Bumped deliberately, by hand, when we
+   write a release blog post.
+
+Together the app reports e.g. `2026.6.0+a1b2c3d`: the base says how fresh, the
+SHA says exactly which commit.
+
+## Cutting a release
+
+A release == a blog post about what shipped since the last one. Between
+releases the SHA advances on its own and nobody needs to touch the version; it
+will look "stale" but the build stamp proves the deploy is current.
+
+To cut one:
+
+1. Decide the new CalVer base. Same month as the last release → bump the patch
+   (`2026.6.0` → `2026.6.1`). New month → roll the date (`2026.7.0`).
+2. Bump `version` in `package.json`.
+3. Add an entry to `CHANGELOG.md`.
+4. Commit, then tag and push:
+   ```
+   git tag 2026.6.0
+   git push --tags
+   ```
+5. Publish the blog post / Discord announcement.
+
+## Reading the version when debugging
+
+- **In-app:** Profile modal footer shows `3DStreet 2026.6.0+a1b2c3d`.
+- **Console:** logged on load by `src/index.js`.
+- **Sentry:** every issue is tagged with the same string as its `release`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dstreet",
-  "version": "0.5.6",
+  "version": "2026.6.0",
   "description": "Web-based 3D visualization of streets using A-Frame and WebXR",
   "main": "dist/3dstreet-editor.js",
   "scripts": {

--- a/src/editor/components/modals/ProfileModal/ProfileModal.component.jsx
+++ b/src/editor/components/modals/ProfileModal/ProfileModal.component.jsx
@@ -1,3 +1,4 @@
+/* global VERSION */
 import styles from './ProfileModal.module.scss';
 import { useState, useEffect } from 'react';
 
@@ -301,6 +302,20 @@ const ProfileModal = () => {
               ) : null}
             </div>
           </div>
+          {typeof VERSION !== 'undefined' && (
+            <div
+              className={styles.versionLine}
+              style={{
+                marginTop: '16px',
+                fontSize: '11px',
+                opacity: 0.5,
+                textAlign: 'center',
+                userSelect: 'text'
+              }}
+            >
+              3DStreet {VERSION}
+            </div>
+          )}
         </div>
       </Modal>
       {isManagingSubscription && <SavingModal action="Managing subscription" />}

--- a/src/editor/instrument.js
+++ b/src/editor/instrument.js
@@ -1,8 +1,10 @@
+/* global VERSION */
 import * as Sentry from '@sentry/react';
 
 if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
+    release: typeof VERSION !== 'undefined' ? VERSION : undefined,
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,24 @@
 const webpack = require('webpack');
 const path = require('path');
 const net = require('net');
+const { execSync } = require('child_process');
 const Dotenv = require('dotenv-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const DEFAULT_PORT = 3333;
+
+// Full build identity: CalVer base from package.json + short git SHA.
+// e.g. "2026.6.0+a1b2c3d". The base is bumped by hand at release time;
+// the SHA advances automatically on every build so each deploy is unique.
+function buildVersion() {
+  const base = process.env.npm_package_version;
+  try {
+    const sha = execSync('git rev-parse --short HEAD').toString().trim();
+    return `${base}+${sha}`;
+  } catch {
+    return base;
+  }
+}
 
 // Find a free port, starting at `basePort` and incrementing on conflict.
 // Lets multiple dev servers (e.g. one per git worktree) run at once instead
@@ -81,7 +95,7 @@ const config = {
       path: './config/.env.development'
     }),
     new webpack.DefinePlugin({
-      VERSION: JSON.stringify(process.env.npm_package_version)
+      VERSION: JSON.stringify(buildVersion())
     }),
     new CopyWebpackPlugin({
       patterns: [

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,9 +1,23 @@
 const webpack = require('webpack');
 const path = require('path');
+const { execSync } = require('child_process');
 const Dotenv = require('dotenv-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const DEPLOY_ENV = process.env.DEPLOY_ENV ?? 'production';
+
+// Full build identity: CalVer base from package.json + short git SHA.
+// e.g. "2026.6.0+a1b2c3d". The base is bumped by hand at release time;
+// the SHA advances automatically on every build so each deploy is unique.
+function buildVersion() {
+  const base = process.env.npm_package_version;
+  try {
+    const sha = execSync('git rev-parse --short HEAD').toString().trim();
+    return `${base}+${sha}`;
+  } catch {
+    return base;
+  }
+}
 
 module.exports = {
   performance: {
@@ -54,7 +68,7 @@ module.exports = {
       path: `./config/.env.${DEPLOY_ENV}`
     }),
     new webpack.DefinePlugin({
-      VERSION: JSON.stringify(process.env.npm_package_version)
+      VERSION: JSON.stringify(buildVersion())
     }),
     new CopyWebpackPlugin({
       patterns: [


### PR DESCRIPTION
## Why

3DStreet's `version` was stuck at `0.5.6` — a fossil from when it was an npm library imported by a separate editor repo. It's now a continuously-deployed web app with no downstream importers, so semver expresses nothing. Worse, `Sentry.init` set no `release`, so errors couldn't be tied to a deployed build — users had no way to describe an error "relative to the version they're on."

## Approach: two identifiers, two jobs

- **Build stamp** (`+a1b2c3d`) — short git SHA appended automatically at build time. Uniquely fingerprints the exact bundle. Set as the Sentry `release`; never touched by hand.
- **CalVer base** (`2026.6.0`, `YYYY.M.patch`) — the human-facing release, bumped deliberately when we write a release blog post.

The app now reports e.g. `2026.6.0+a1b2c3d`: the base says how fresh, the SHA says exactly which commit.

## Changes

- `webpack.config.js` + `webpack.prod.config.js` — `buildVersion()` injects `<calver>+<sha>` into the existing `VERSION` global (falls back to bare base if git is unavailable).
- `src/editor/instrument.js` — `Sentry.init({ release: VERSION })`. **The line that fixes error-by-version reporting.**
- `src/editor/.../ProfileModal.component.jsx` — muted, selectable version line at the bottom of the Profile modal so users can copy it into bug reports.
- `package.json` — `0.5.6` → `2026.6.0`.
- `docs/releasing.md` — the release ritual: a release == a blog post; bump base, tag, announce. Between releases the SHA advances on its own.
- `CHANGELOG.md` — scaffold + `2026.6.0` entry.

## Notes / follow-ups

- The short SHA renders 8 chars on this repo (git's default), not 7 — harmless.
- CI-on-tag automation (auto GitHub Release from a pushed tag) intentionally left out; the manual ritual works today. Easy follow-up if wanted.