### PR TITLE
feat(generator): restructure tabs by medium + 3D Model tab shell (#1767)

### DIFF
--- a/public/generator/index.html
+++ b/public/generator/index.html
@@ -78,17 +78,11 @@
     <div class="bg-white shadow-sm">
         <div class="container mx-auto px-4">
             <div class="tab-navigation">
-                <button class="tab-button active" data-tab="modify-tab">
+                <button class="tab-button active" data-tab="image-tab">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                     </svg>
-                    Modify
-                </button>
-                <button class="tab-button" data-tab="create-tab">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-                    </svg>
-                    Create
+                    Image
                 </button>
                 <button class="tab-button" data-tab="video-tab">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -105,6 +99,13 @@
                     </svg>
                     Splat
                 </button>
+                <button class="tab-button" data-tab="model3d-tab">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.27 6.96L12 12.01l8.73-5.05M12 22.08V12" />
+                    </svg>
+                    3D Model
+                </button>
                 <!-- More tabs will be added here -->
             </div>
         </div>
@@ -112,10 +113,25 @@
 
     <main class="flex-grow container mx-auto px-4 py-6">
         <!-- Tab contents - each will be populated by its respective JS file -->
-        <div id="modify-tab" class="tab-content active"></div>
-        <div id="create-tab" class="tab-content"></div>
+        <!-- Image tab hosts Create + Modify as an in-tab mode toggle -->
+        <div id="image-tab" class="tab-content active">
+            <div class="flex justify-center mb-6">
+                <div id="image-mode-toggle" class="inline-flex rounded-lg border border-gray-300 bg-gray-100 p-1" role="tablist" aria-label="Image generation mode">
+                    <button type="button" data-mode="create" class="image-mode-button px-4 py-1.5 rounded-md text-sm font-medium transition-colors">
+                        Create
+                    </button>
+                    <button type="button" data-mode="modify" class="image-mode-button px-4 py-1.5 rounded-md text-sm font-medium transition-colors">
+                        Modify
+                    </button>
+                </div>
+            </div>
+            <!-- Create + Modify panels are populated by their respective JS files -->
+            <div id="create-tab" class="image-mode-panel"></div>
+            <div id="modify-tab" class="image-mode-panel hidden"></div>
+        </div>
         <div id="video-tab" class="tab-content"></div>
         <div id="splat-tab" class="tab-content"></div>
+        <div id="model3d-tab" class="tab-content"></div>
     </main>
 
     <!-- Notification -->

--- a/src/generator/image-tab.js
+++ b/src/generator/image-tab.js
@@ -1,0 +1,67 @@
+/**
+ * Image Tab Controller
+ *
+ * The Image tab is a single medium-based tab that hosts both the Create and
+ * Modify image generators (previously separate top-level tabs). Create and
+ * Modify are now an in-tab mode toggle; each mode is still driven by its own
+ * GeneratorTabBase instance mounted into #create-tab / #modify-tab, so no
+ * generation functionality changes here — this module only shows/hides the
+ * relevant panel and keeps the toggle buttons in sync.
+ */
+
+const ImageTab = {
+  // Default landing mode for the Image tab
+  defaultMode: 'create',
+
+  elements: {
+    toggle: null,
+    buttons: [],
+    panels: {}
+  },
+
+  init() {
+    this.elements.toggle = document.getElementById('image-mode-toggle');
+    if (!this.elements.toggle) {
+      console.error('Image Tab: mode toggle not found');
+      return;
+    }
+
+    this.elements.buttons = Array.from(
+      this.elements.toggle.querySelectorAll('.image-mode-button')
+    );
+    this.elements.panels = {
+      create: document.getElementById('create-tab'),
+      modify: document.getElementById('modify-tab')
+    };
+
+    this.elements.buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        this.setMode(button.dataset.mode);
+      });
+    });
+
+    // Support legacy #create / #modify deep links by mapping them onto the
+    // Image tab's mode. The main tab router falls back to the Image tab for
+    // these hashes; here we select the matching mode.
+    const hash = window.location.hash.slice(1).replace('-tab', '');
+    const initialMode =
+      hash === 'create' || hash === 'modify' ? hash : this.defaultMode;
+
+    this.setMode(initialMode);
+  },
+
+  setMode(mode) {
+    if (mode !== 'create' && mode !== 'modify') return;
+
+    this.elements.buttons.forEach((button) => {
+      button.classList.toggle('active', button.dataset.mode === mode);
+    });
+
+    Object.entries(this.elements.panels).forEach(([panelMode, panel]) => {
+      if (!panel) return;
+      panel.classList.toggle('hidden', panelMode !== mode);
+    });
+  }
+};
+
+export default ImageTab;

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -26,10 +26,12 @@ import { mountAssets } from './mount-assets.js';
 
 // Import all modules
 import FluxUI from './main.js';
+import ImageTab from './image-tab.js';
 import ModifyTab from './modify.js';
 import CreateTab from './create.js';
 import VideoTab from './video.js';
 import SplatTab from './splat.js';
+import Model3DTab from './model3d.js';
 
 // Initialize PostHog so capture() calls in handlers/effects below are not no-ops
 initPostHog();
@@ -58,10 +60,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   await mountAssets();
 
   // Initialize tabs
-  ModifyTab.init();
+  // Create + Modify mount into the Image tab's mode panels; ImageTab wires the
+  // Create/Modify mode toggle around them.
   CreateTab.init();
+  ModifyTab.init();
+  ImageTab.init();
   VideoTab.init();
   SplatTab.init();
+  Model3DTab.init();
 
   // Hide loading screen once everything is initialized
   // Use requestAnimationFrame to ensure styles are applied

--- a/src/generator/model3d.js
+++ b/src/generator/model3d.js
@@ -1,0 +1,267 @@
+/**
+ * 3D Model Tab (shell)
+ *
+ * Adds the "3D Model" medium alongside Image, Video and Splat. This first pass
+ * ships the tab's input UI — model selection (Hunyuan3D / TRELLIS), an optional
+ * reference image, an optional text prompt — plus the empty-image nudge dialog.
+ *
+ * Generation is intentionally not wired here: the fal 3D endpoints and the
+ * decimation-on-ingest pass land in a follow-up. Submitting today surfaces a
+ * "coming soon" notice so the flow is honest while the UI is reviewable.
+ *
+ * Named "3D Model" (not "Model") to avoid confusion with the AI Model selector
+ * used elsewhere in the app.
+ */
+
+import FluxUI from './main.js';
+import ImageUploadUtils from './image-upload-utils.js';
+
+// Recommended-not-required amber for the reference image indicator (#1767).
+const AMBER = '#F5A623';
+
+// Selectable text/image -> mesh models (both GLB output via fal).
+const MODEL3D_MODELS = [
+  { id: 'hunyuan-3d', name: 'Hunyuan3D (latest)' },
+  { id: 'trellis', name: 'TRELLIS (latest)' }
+];
+
+const Model3DTab = {
+  imageData: null,
+
+  elements: {},
+
+  init() {
+    const container = document.getElementById('model3d-tab');
+    if (!container) {
+      console.error('3D Model Tab: container element not found');
+      return;
+    }
+
+    this.createTabContent(container);
+    this.getElements();
+    this.setupEventListeners();
+  },
+
+  createTabContent(container) {
+    const modelOptions = MODEL3D_MODELS.map(
+      (model) => `<option value="${model.id}">${model.name}</option>`
+    ).join('');
+
+    container.innerHTML = `
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Parameters Column -->
+        <div class="lg:col-span-1 bg-white rounded-lg shadow p-6">
+          <h2 class="text-lg font-medium mb-1">3D Model Settings</h2>
+          <p class="text-sm text-gray-500 mb-4">
+            Generate a 3D mesh (GLB) from a reference image and/or text prompt.
+            Best for placemaking objects and props — shelters, kiosks, benches,
+            bollards, wayfinding, vehicles.
+          </p>
+
+          <!-- Model Selection -->
+          <div class="mb-4">
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="model3d-model-select">Model</label>
+            <select id="model3d-model-select" class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              ${modelOptions}
+            </select>
+          </div>
+
+          <!-- Reference Image (recommended, not required) -->
+          <div class="mb-4 param-group">
+            <label class="block text-sm font-medium text-gray-700 mb-1">
+              Reference Image <span style="color: ${AMBER};" title="Recommended for better results">*</span>
+            </label>
+            <div class="flex flex-col space-y-2">
+              <label id="model3d-image-upload-label" class="flex items-center justify-center w-full h-20 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer hover:bg-gray-50">
+                <div class="flex flex-col items-center">
+                  <p class="text-sm text-gray-500">Click to upload an image</p>
+                  <p id="model3d-image-name" class="text-xs text-gray-400 mt-1">No file selected</p>
+                </div>
+                <input id="model3d-image-input" type="file" class="hidden" accept="image/png, image/jpeg, image/jpg" />
+              </label>
+              <div id="model3d-image-preview-container" class="hidden relative">
+                <img id="model3d-image-preview" class="w-full rounded-lg border border-gray-300" alt="Reference image">
+                <button id="model3d-image-clear" class="absolute top-2 right-2 p-1 bg-white bg-opacity-80 rounded-full hover:bg-opacity-100 hover:bg-red-50 shadow hover:shadow-lg transition-all duration-200" title="Clear image">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-600 hover:text-red-600 transition-colors duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <p class="text-xs text-gray-500">
+                A reference image gives the AI real-world structure to match. Text-only works too, but results are rougher.
+              </p>
+            </div>
+          </div>
+
+          <!-- Prompt (optional) -->
+          <div class="mb-4">
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="model3d-prompt-input">Prompt (Optional)</label>
+            <textarea id="model3d-prompt-input" rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      placeholder="Describe the object to generate..."></textarea>
+          </div>
+
+          <!-- Generate Button -->
+          <button id="model3d-generate-btn" class="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 flex items-center justify-center gap-2">
+            <span id="model3d-generate-text">Generate 3D Model</span>
+          </button>
+        </div>
+
+        <!-- Preview Column -->
+        <div class="lg:col-span-2 bg-white rounded-lg shadow">
+          <div class="p-6 border-b border-gray-200">
+            <h2 class="text-lg font-medium">Preview</h2>
+          </div>
+          <div class="p-6 flex flex-col items-center justify-center min-h-[500px]">
+            <div class="text-center text-gray-400">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M3.27 6.96L12 12.01l8.73-5.05M12 22.08V12" />
+              </svg>
+              <p>Your generated 3D model (GLB) will appear here</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  },
+
+  getElements() {
+    this.elements = {
+      modelSelect: document.getElementById('model3d-model-select'),
+      imageInput: document.getElementById('model3d-image-input'),
+      imageName: document.getElementById('model3d-image-name'),
+      imageUploadLabel: document.getElementById('model3d-image-upload-label'),
+      imagePreviewContainer: document.getElementById(
+        'model3d-image-preview-container'
+      ),
+      imagePreview: document.getElementById('model3d-image-preview'),
+      imageClear: document.getElementById('model3d-image-clear'),
+      promptInput: document.getElementById('model3d-prompt-input'),
+      generateBtn: document.getElementById('model3d-generate-btn')
+    };
+  },
+
+  setupEventListeners() {
+    this.elements.imageInput.addEventListener(
+      'change',
+      this.handleImageUpload.bind(this)
+    );
+
+    ImageUploadUtils.setupDragAndDrop(
+      this.elements.imageUploadLabel,
+      this.elements.imageInput,
+      (dataUrl, fileName) => {
+        this.setImage(dataUrl, fileName);
+      }
+    );
+
+    this.elements.imageClear.addEventListener(
+      'click',
+      this.clearImage.bind(this)
+    );
+
+    this.elements.generateBtn.addEventListener(
+      'click',
+      this.handleGenerate.bind(this)
+    );
+  },
+
+  handleImageUpload(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      this.setImage(event.target.result, file.name);
+    };
+    reader.readAsDataURL(file);
+  },
+
+  setImage(dataUrl, fileName) {
+    this.imageData = dataUrl;
+    this.elements.imageName.textContent = fileName;
+    this.elements.imagePreview.src = dataUrl;
+    this.elements.imageUploadLabel.classList.add('hidden');
+    this.elements.imagePreviewContainer.classList.remove('hidden');
+  },
+
+  clearImage() {
+    this.imageData = null;
+    this.elements.imageInput.value = '';
+    this.elements.imageName.textContent = 'No file selected';
+    this.elements.imagePreview.src = '';
+    this.elements.imagePreviewContainer.classList.add('hidden');
+    this.elements.imageUploadLabel.classList.remove('hidden');
+  },
+
+  handleGenerate() {
+    // Empty-image nudge: encourage a reference image, but allow text-only.
+    if (!this.imageData) {
+      this.showImageNudge();
+      return;
+    }
+
+    this.startGeneration();
+  },
+
+  /**
+   * Placeholder for the real generation call (fal 3D endpoint + GLB ingest),
+   * which lands in a follow-up. For now, keep the flow honest.
+   */
+  startGeneration() {
+    FluxUI.showNotification('3D model generation is coming soon.', 'warning');
+  },
+
+  /**
+   * Empty-image nudge dialog (#1767): recommend a reference image without
+   * disparaging text-only generation, with a proceed-anyway escape hatch.
+   */
+  showImageNudge() {
+    const existing = document.getElementById('model3d-nudge-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'model3d-nudge-modal';
+    modal.className = 'modal';
+    modal.innerHTML = `
+      <div class="modal-content p-6">
+        <h3 class="text-lg font-semibold mb-2">Add a reference image for better results</h3>
+        <p class="text-sm text-gray-500 mb-6">
+          A photo or reference image gives the AI real-world structure to match —
+          producing far more accurate, usable models. Text-only generation works,
+          but results are rougher and best for quick placeholders.
+        </p>
+        <div class="flex justify-end gap-3">
+          <button id="model3d-nudge-generate" class="px-4 py-2 border border-gray-300 bg-white text-gray-700 rounded-md text-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            Generate anyway
+          </button>
+          <button id="model3d-nudge-add" class="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            Add image
+          </button>
+        </div>
+      </div>
+    `;
+
+    const close = () => modal.remove();
+
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) close();
+    });
+
+    modal.querySelector('#model3d-nudge-add').addEventListener('click', () => {
+      close();
+      this.elements.imageInput.click();
+    });
+
+    modal
+      .querySelector('#model3d-nudge-generate')
+      .addEventListener('click', () => {
+        close();
+        this.startGeneration();
+      });
+
+    document.body.appendChild(modal);
+  }
+};
+
+export default Model3DTab;

--- a/src/generator/mount-assets.js
+++ b/src/generator/mount-assets.js
@@ -9,6 +9,7 @@ import { auth } from '@shared/services/firebase';
 import posthog from 'posthog-js';
 import FluxUI from './main.js';
 import ModifyTab from './modify.js';
+import ImageTab from './image-tab.js';
 import VideoTab from './video.js';
 
 /**
@@ -47,12 +48,15 @@ const handleUseForGenerator = async (item) => {
     try {
       const imageUrl = item.storageUrl || item.objectURL;
       const dataUri = await getBlobDataUri(imageUrl);
-      const modifyTabButton = document.querySelector(
-        '.tab-button[data-tab="modify-tab"]'
+      // Modify now lives inside the Image tab as a mode: activate the Image
+      // tab, then switch it to Modify before setting the source image.
+      const imageTabButton = document.querySelector(
+        '.tab-button[data-tab="image-tab"]'
       );
-      if (modifyTabButton) modifyTabButton.click();
+      if (imageTabButton) imageTabButton.click();
+      ImageTab.setMode('modify');
       ModifyTab.setImagePrompt(dataUri, `Gallery Image ${item.id}`);
-      FluxUI.showNotification('Image sent to Modify tab!', 'success');
+      FluxUI.showNotification('Image sent to Modify!', 'success');
     } catch (error) {
       console.error('Error sending to Modify:', error);
       FluxUI.showNotification('Failed to prepare image for Modify.', 'error');

--- a/src/generator/styles/styles.css
+++ b/src/generator/styles/styles.css
@@ -153,6 +153,42 @@ button:active {
     display: block;
 }
 
+/* Image tab mode toggle (Create / Modify) */
+.image-mode-button {
+    color: #6b7280; /* gray-500 */
+    background: transparent;
+    border: none;
+    cursor: pointer;
+}
+
+.image-mode-button:hover {
+    color: var(--primary);
+}
+
+.image-mode-button.active {
+    color: var(--primary);
+    background-color: #ffffff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.dark #image-mode-toggle {
+    background-color: #111827; /* gray-900 */
+    border-color: #374151; /* gray-700 */
+}
+
+.dark .image-mode-button {
+    color: #9ca3af; /* gray-400 */
+}
+
+.dark .image-mode-button:hover {
+    color: #a5b4fc; /* indigo-300 */
+}
+
+.dark .image-mode-button.active {
+    color: #c7d2fe; /* indigo-200 */
+    background-color: #374151; /* gray-700 */
+}
+
 /* Dark Mode Styles */
 .dark body {
     background-color: #111827; /* gray-900 */


### PR DESCRIPTION
## Summary

First slice of #1767 — the **UI restructure**, standalone and reviewable on its own. It reframes the AI Generator tabs as *mediums* (not actions) and lays the groundwork for text/image → 3D mesh generation, without touching any external services yet.

Generation for the new 3D Model tab is intentionally **not wired** here — the fal 3D endpoints (Hunyuan3D / TRELLIS), GLB ingest, and the decimation-on-ingest guardrail land in a follow-up PR. Submitting today surfaces a "coming soon" notice so the flow stays honest while the UI is reviewable.

## What's in this PR

- **Merge Create + Modify into a single Image tab.** Create/Modify become an in-tab mode toggle (new `image-tab.js` controller). Both modes are still driven by their existing `GeneratorTabBase` instances mounted into `#create-tab` / `#modify-tab`, so **no generation functionality changes** — only which panel is visible.
- **Add a 3D Model tab shell** (`model3d.js`): model selection (Hunyuan3D / TRELLIS), an optional reference image, and an optional text prompt. Named "3D Model" (not "Model") to avoid confusion with the AI Model selector used elsewhere.
- **Tabs now read as mediums:** Image · Video · Splat · 3D Model.
- **Amber recommended indicator.** The reference-image `*` uses amber (`#F5A623`) to signal *recommended*, not *required*.
- **Empty-image nudge dialog.** Submitting 3D generation with no image shows an encouragement dialog with an "Add image" action and a "Generate anyway" escape hatch (issue copy).
- **Handoff/deep-link compatibility.** The editor's "use image for Modify" handoff and legacy `#modify` / `#create` deep links now resolve onto the Image tab's Modify mode.

## Acceptance criteria (from #1767) covered here

- [x] 3D Model tab present; Hunyuan3D + TRELLIS selectable; text and/or image input; image optional
- [x] Create + Modify merged into Image tab with a mode toggle; no lost functionality
- [x] Tabs read as mediums: Image · Video · Splat · 3D Model
- [x] Image `*` is amber/orange, not red
- [x] Submitting 3D Model generation with no image shows the encouragement dialog with a proceed-anyway option

## Deferred to follow-up (generation slice)

- [ ] fal 3D generation for Hunyuan3D / TRELLIS (endpoints + async job flow, modeled on the Splat pipeline)
- [ ] GLB output saved as a first-class `mesh` asset (the asset system already supports the `mesh` type — wiring the ingest is what's left)
- [ ] Polygon / file-size decimation guardrail on ingest

## Testing

- `npm run test:generator` — 149 passing
- `npx eslint` on changed files — clean
- Generator webpack bundle compiles successfully with the new modules
- HTML ↔ JS markup contract verified (tab ids, mode panels, 3D shell)

> Note: the live app was not run end-to-end (requires Firebase env config); verification is build + lint + unit tests + markup-contract checks. This slice is UI-only with no backend calls.

Files: `public/generator/index.html`, `src/generator/image-tab.js` (new), `src/generator/model3d.js` (new), `src/generator/index.js`, `src/generator/mount-assets.js`, `src/generator/styles/styles.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AdVe2XhpRNaJbcHCVh1bn)_