### PR TITLE
Fix drag-to-place drag ghost in Safari (#1527)

### DIFF
--- a/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
@@ -24,12 +24,9 @@ import { LayersOptions } from './LayersOptions.js';
 import Events from '../../../lib/Events.js';
 import useStore from '@/store.js';
 import { getGroupedMixinOptions } from '../../../lib/mixinUtils';
+import { getEmptyDragImage } from '@shared/utils/dragImage.js';
 
 const ASSET_CARD_MIME = 'application/x-3dstreet-asset';
-
-// Create an empty image
-const emptyImg = new Image();
-emptyImg.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
 
 // get array with objects data (cardsData) from mixinGroups of selectedOption
 const getSelectedMixinCards = (groupedMixins, selectedOption) => {
@@ -653,8 +650,10 @@ const AddLayerPanel = () => {
                       'application/json',
                       JSON.stringify(transferData)
                     );
-                    // Set the empty image as the drag image
-                    e.dataTransfer.setDragImage(emptyImg, 0, 0);
+                    // Set the empty image as the drag image (suppress the
+                    // browser's default card ghost). Uses a DOM-attached
+                    // transparent image so Safari honors it — see #1527.
+                    e.dataTransfer.setDragImage(getEmptyDragImage(), 0, 0);
                   }
                   return false;
                 }}

--- a/src/shared/assets/components/AssetsItem.jsx
+++ b/src/shared/assets/components/AssetsItem.jsx
@@ -10,12 +10,7 @@ import {
   getAssetTypeLabel,
   is3dViewerType
 } from '../utils.js';
-
-// 1×1 transparent gif used to suppress the default browser drag ghost so the
-// 3D preview at the cursor isn't fighting with a card thumbnail floating along.
-const emptyDragImage = new Image();
-emptyDragImage.src =
-  'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+import { getEmptyDragImage } from '@shared/utils/dragImage.js';
 
 const MeshPlaceholder = () => (
   <div className={styles.meshPlaceholder} aria-label="3D model">
@@ -121,7 +116,9 @@ const AssetsItem = ({
       })
     );
     e.dataTransfer.effectAllowed = 'copy';
-    e.dataTransfer.setDragImage(emptyDragImage, 0, 0);
+    // DOM-attached transparent image so Safari suppresses the default
+    // card ghost too (a detached Image is ignored by WebKit) — see #1527.
+    e.dataTransfer.setDragImage(getEmptyDragImage(), 0, 0);
   };
 
   const typeLabel = getAssetTypeLabel(item);

--- a/src/shared/utils/dragImage.js
+++ b/src/shared/utils/dragImage.js
@@ -1,0 +1,63 @@
+/**
+ * Suppress the browser's default drag ghost image for HTML5 drag-and-drop.
+ *
+ * We drag cards (Add Layer panel, Assets panel) into the 3D viewport and want a
+ * 3D preview entity to follow the cursor instead of a floating card thumbnail.
+ * The usual trick is `e.dataTransfer.setDragImage(transparentImg, 0, 0)`.
+ *
+ * The catch: WebKit/Safari only honors setDragImage() when the passed element
+ * is actually rendered in the document. A detached `new Image()` (never
+ * appended to the DOM) is silently ignored, and Safari then falls back to
+ * dragging a ghost of the source card — which reads as "dragging an image out
+ * of the page" and breaks the intended drop-to-place UX (see issue #1527).
+ * Hiding the element with `display:none`/`visibility:hidden` also disqualifies
+ * it, so we keep it rendered but invisible off-screen with `opacity:0`.
+ */
+
+// 1×1 transparent gif.
+const TRANSPARENT_GIF =
+  'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+
+let sharedEmptyDragImage = null;
+
+/**
+ * Returns a shared, DOM-attached transparent image suitable for passing to
+ * `DataTransfer.setDragImage()` on all browsers including Safari. Lazily
+ * created and appended off-screen on first use.
+ *
+ * @returns {HTMLImageElement}
+ */
+export function getEmptyDragImage() {
+  if (sharedEmptyDragImage) return sharedEmptyDragImage;
+
+  const img = new Image(1, 1);
+  img.src = TRANSPARENT_GIF;
+  img.setAttribute('aria-hidden', 'true');
+  // Keep it genuinely rendered (Safari ignores display:none / visibility:hidden
+  // / opacity:0 drag images) but harmless: it's a 1×1 fully-transparent pixel
+  // pinned to the corner, so there's nothing to see and nothing to click.
+  Object.assign(img.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '1px',
+    height: '1px',
+    pointerEvents: 'none'
+  });
+
+  if (typeof document !== 'undefined') {
+    const attach = () => {
+      if (!img.isConnected && document.body) {
+        document.body.appendChild(img);
+      }
+    };
+    if (document.body) {
+      attach();
+    } else {
+      document.addEventListener('DOMContentLoaded', attach, { once: true });
+    }
+  }
+
+  sharedEmptyDragImage = img;
+  return img;
+}


### PR DESCRIPTION
Safari/WebKit ignores setDragImage() when the passed image isn't rendered in the document. The Add Layer and Assets panel cards used a detached new Image(), so Safari fell back to dragging a ghost of the card instead of suppressing it — which reads as 'dragging an image out of the page' and breaks the drop-to-place UX.

Add a shared getEmptyDragImage() helper that lazily appends a 1x1 transparent image to the DOM (off-screen, kept genuinely rendered so WebKit honors it) and use it from both drag sources.


Claude-Session: https://claude.ai/code/session_01H7ifkR3GNan4Tv1V9c6Sp6