### PR TITLE
Migrate video generation to the async job queue (#1780)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ The cloud URL lives in `gltf-model` / `src`. Firebase Storage download tokens al
 
 **Token system:** TokenSync syncs Firestore → Zustand, PurchaseModal for Stripe checkout
 
-**Async job queue:** Long-running AI jobs use `users/{uid}/generationJobs/{jobId}` (provider-agnostic, survives a closed browser). Two providers today: `replicate` (image→splat via SHARP; webhook + poll + reconciler converge on one idempotent processor) and `cloudrun` (`.ply`→RAD/LOD conversion via the `rad-converter` Cloud Run service; worker-writeback, `tokenCost: 0`, triggered by `onSplatAssetCreated`). A scheduled reconciler backstops both. Design: `docs/generation-job-queue.md`; RAD pipeline: `docs/rad-cloud-run-pipeline.md`.
+**Async job queue:** Long-running AI jobs use `users/{uid}/generationJobs/{jobId}` (provider-agnostic, survives a closed browser). Two providers today: `replicate` (image→splat via SHARP, and image→video via Veo/Kling/LTX — both converge on one idempotent processor via webhook + poll + reconciler; results are saved to the gallery server-side) and `cloudrun` (`.ply`→RAD/LOD conversion via the `rad-converter` Cloud Run service; worker-writeback, `tokenCost: 0`, triggered by `onSplatAssetCreated`). A scheduled reconciler backstops both. Design: `docs/generation-job-queue.md`; RAD pipeline: `docs/rad-cloud-run-pipeline.md`.
 
 ## Shared Library (@shared/*)
 

--- a/docs/generation-job-queue.md
+++ b/docs/generation-job-queue.md
@@ -246,9 +246,11 @@ stream), so the fix is the same create-and-return pattern as splat.
   claimed success branch — fires on real completion, exactly once (the
   `saving` claim serializes webhook/poll/reconciler), with the durable Storage
   URL instead of the ephemeral provider URL.
-- **No geometry gate** (that's a splat-specific SfM sanity check) and **no
-  completion email opt-in** (renders are ~2 min; `notify` is written off, and
-  the email machinery ignores non-opted-in jobs).
+- **No geometry gate** (that's a splat-specific SfM sanity check). The
+  completion-email opt-in works exactly like splat's (checkbox on the tab →
+  `notify: { email, pending }` on the job doc; the `generationReady` template
+  already had video copy) — renders are usually ~2 min, but provider queue
+  waits can stretch far past what anyone keeps a tab open for.
 - **Job doc extras:** `generationParams` ({model_name, prompt, aspect_ratio,
   duration_seconds, scene_id}) — everything the terminal processor needs to
   build the gallery metadata + Discord post without a browser. Terminal result

--- a/docs/generation-job-queue.md
+++ b/docs/generation-job-queue.md
@@ -17,7 +17,7 @@ single completion shape:
 
 | Provider | Kind(s) | Completion model | Tokens |
 | --- | --- | --- | --- |
-| `replicate` | `splat` (image→splat, SHARP) | **convergent**: provider webhook + client poll + reconciler all funnel into one idempotent processor | charged on submit, refunded once on failure |
+| `replicate` | `splat` (image→splat, SHARP), `video` (image→video, Veo/Kling/LTX/…) | **convergent**: provider webhook + client poll + reconciler all funnel into one idempotent processor | charged on submit, refunded once on failure |
 | `cloudrun` | `splat-rad` (.ply→RAD/LOD) | **worker-writeback**: the Cloud Run worker writes its own terminal status; reconciler re-enqueues a stalled task (no external state to poll) | **`tokenCost: 0`** — silent backend optimization, never charges |
 
 The design generalizes further so Replicate image/video, fal, and Teleport/Varjo
@@ -214,6 +214,52 @@ splat asset doc created  (uploaded OR generator-saved)
 | Converter service (Dockerfile + handler) | `rad-converter/` |
 | Bucket byte-range CORS | `public/cors.json` |
 | Full design + deploy/IAM ops | `docs/rad-cloud-run-pipeline.md`, `rad-converter/README.md` |
+
+---
+
+## Second kind on Replicate — Video (image → video) ✅ DONE
+
+**Why it moved here (issue #1780):** `generateReplicateVideo` used to be a
+synchronous callable that blocked on `replicate.run(...)` for the whole render
+(~2 min median) with zero streamed bytes. Safari drops idle data-less HTTPS
+connections well before that — the client surfaced a spurious
+`FirebaseError: internal` while the server kept running, charged tokens, and
+produced a video nobody received. There is no timeout to tune (onCall can't
+stream), so the fix is the same create-and-return pattern as splat.
+
+**What's different from splat (the deltas, everything else is reused as-is):**
+
+- **Model addressing:** video models are official Replicate models addressed by
+  NAME (`replicate.predictions.create({ model: 'google/veo-3.1-fast', ... })`),
+  no version hash — splat pins a resolved `version` because community models
+  404 on the name form. `SUPPORTED_VIDEO_MODELS` in `replicate.js` is the
+  allowlist.
+- **Terminal persist:** `saveVideoToGallery` streams the `.mp4` from the
+  (ephemeral) `replicate.delivery` URL into
+  `users/{uid}/assets/videos/{assetId}.mp4` and writes the same
+  `type: 'video'` / `category: 'ai-render'` asset doc the client-side save used
+  to write, so pre- and post-migration gallery videos render identically. The
+  gallery save previously ran in the browser (`video.js:saveToGallery`) and
+  died with a closed tab — moving it into the terminal processor is the core
+  browser-independence win.
+- **Discord post** moved from the submit callable into the terminal processor's
+  claimed success branch — fires on real completion, exactly once (the
+  `saving` claim serializes webhook/poll/reconciler), with the durable Storage
+  URL instead of the ephemeral provider URL.
+- **No geometry gate** (that's a splat-specific SfM sanity check) and **no
+  completion email opt-in** (renders are ~2 min; `notify` is written off, and
+  the email machinery ignores non-opted-in jobs).
+- **Job doc extras:** `generationParams` ({model_name, prompt, aspect_ratio,
+  duration_seconds, scene_id}) — everything the terminal processor needs to
+  build the gallery metadata + Discord post without a browser. Terminal result
+  field is `videoUrl` (returned to the client as `video_url`, mirroring
+  `splat_url`).
+
+Tokens flipped from charge-after-success to charge-at-submit + refund-once on
+failure (the old ordering is exactly what stranded charges on disconnect).
+Client (`src/generator/video.js`) mirrors `splat.js`: submit → `jobId` →
+`pollVideoStatus` loop; the gallery's pending-job card lights up from the
+existing job-doc listener for free.
 
 ---
 

--- a/public/functions/replicate.js
+++ b/public/functions/replicate.js
@@ -489,11 +489,38 @@ const generateReplicateImage = functions
     }
   });
 
-// Replicate API function for video generation
+// Video models offered by generateReplicateVideo, keyed by Replicate model
+// name. These are official models addressed by NAME (no version hash — unlike
+// SHARP, which must pin a version). The label is the user-facing name shown in
+// the Discord post. Module-scoped because both the submit validation and the
+// terminal processor (Discord post) need it.
+const SUPPORTED_VIDEO_MODELS = {
+  'bytedance/seedance-1-pro-fast': 'SeeDance 1 Pro Fast',
+  'wan-video/wan-2.2-i2v-fast': 'Wan 2.2 I2V Fast',
+  'wan-video/wan-2.6-i2v': 'Wan 2.6 I2V',
+  'kwaivgi/kling-v2.5-turbo-pro': 'Kling v2.5 Turbo Pro',
+  'kwaivgi/kling-v3-video': 'Kling v3.0 Pro',
+  'lightricks/ltx-2-fast': 'LTX-2 Fast',
+  'google/veo-3.1': 'Veo 3.1',
+  'google/veo-3.1-fast': 'Veo 3.1 Fast'
+};
+
+// Replicate API function for video generation (image → video).
+// Asynchronous: creates the Replicate prediction and returns the internal job
+// id immediately; the client polls getGenerationJobStatus until terminal. The
+// old synchronous form (`await replicate.run(...)`) held the callable
+// connection open, idle, for the whole render (~2 min median) — Safari drops
+// idle data-less connections well before that, so the client lost the result
+// while the server finished and charged tokens anyway (issue #1780). Same
+// job-queue pattern as generateReplicateSplat: charge at submit, webhook +
+// poll + reconciler converge on one idempotent terminal processor, which also
+// saves the video to the gallery server-side so it lands even if the tab is
+// closed.
 const generateReplicateVideo = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', 'DISCORD_WEBHOOK_URL'],
-    timeoutSeconds: 540 // 9 minutes - video generation can take several minutes
+    secrets: ['REPLICATE_API_TOKEN'],
+    // Creation only (stage the source image + submit); the render is async.
+    timeoutSeconds: 120
   })
   .https
   .onCall(async (data, context) => {
@@ -512,7 +539,12 @@ const generateReplicateVideo = functions
     assertAppCheck(context);
 
     const userId = context.auth.uid;
-    const { prompt, input_image, model_name = 'lightricks/ltx-2-fast', aspect_ratio = '16:9', duration_seconds = 5 } = data;
+    const { prompt, input_image, model_name = 'lightricks/ltx-2-fast', aspect_ratio = '16:9', duration_seconds = 5, scene_id, source = 'generator' } = data;
+
+    // Validate the model before staging anything or charging tokens.
+    if (!SUPPORTED_VIDEO_MODELS[model_name]) {
+      throw new functions.https.HttpsError('invalid-argument', `Unsupported model: ${model_name}`);
+    }
 
     // Per-model token costs based on duration
     const VIDEO_TOKEN_COSTS = {
@@ -560,7 +592,7 @@ const generateReplicateVideo = functions
     }
 
     const db = admin.firestore();
-    let videoGenerationStartTime;
+    let tempFilePath = null;
 
     try {
       const replicate = new Replicate({
@@ -570,7 +602,9 @@ const generateReplicateVideo = functions
 
       let imageUrl = input_image;
 
-      // If input_image is a base64 string, upload it to Firebase Storage first
+      // If input_image is a base64 string, upload it to Firebase Storage first.
+      // The staged path is recorded on the job doc (tempFilePath) and deleted by
+      // the terminal processor when the job finishes.
       if (!input_image.startsWith('http://') && !input_image.startsWith('https://')) {
         // Assume it's base64 data (without the data URL prefix since we strip it client-side)
         // Reconstruct the data URL
@@ -598,24 +632,8 @@ const generateReplicateVideo = functions
 
         // Get the public URL
         imageUrl = `https://storage.googleapis.com/${bucket.name}/temp/${filename}`;
+        tempFilePath = `temp/${filename}`;
         console.log(`Uploaded input image to: ${imageUrl}`);
-      }
-
-      // Supported models
-      const supportedModels = {
-        'bytedance/seedance-1-pro-fast': 'SeeDance 1 Pro Fast',
-        'wan-video/wan-2.2-i2v-fast': 'Wan 2.2 I2V Fast',
-        'wan-video/wan-2.6-i2v': 'Wan 2.6 I2V',
-        'kwaivgi/kling-v2.5-turbo-pro': 'Kling v2.5 Turbo Pro',
-        'kwaivgi/kling-v3-video': 'Kling v3.0 Pro',
-        'lightricks/ltx-2-fast': 'LTX-2 Fast',
-        'google/veo-3.1': 'Veo 3.1',
-        'google/veo-3.1-fast': 'Veo 3.1 Fast'
-      };
-
-      // Validate model name
-      if (!supportedModels[model_name]) {
-        throw new functions.https.HttpsError('invalid-argument', `Unsupported model: ${model_name}`);
       }
 
       // Prepare model input based on the model
@@ -672,66 +690,98 @@ const generateReplicateVideo = functions
         modelInput.generate_audio = false;
       }
 
-      console.log(`Generating ${duration_seconds}s video for user ${userId} with model ${model_name} (tokenCost: ${tokenCost})`);
+      console.log(`Submitting ${duration_seconds}s video job for user ${userId} with model ${model_name} (tokenCost: ${tokenCost})`);
       console.log('Model input parameters:', JSON.stringify(modelInput, null, 2));
 
-      // Use run() with model name instead of predictions.create with version
-      videoGenerationStartTime = Date.now();
-      const output = await replicate.run(model_name, {
-        input: modelInput
-      });
-      const videoGenerationElapsedMs = Date.now() - videoGenerationStartTime;
+      // Durable job identity, same contract as the splat submit: the internal
+      // jobId (a uuid) is the Firestore doc id, NOT the Replicate prediction id
+      // (stored as providerJobId). The pending row is written BEFORE submit so
+      // a crash mid-submit becomes a visible, reconcilable job.
+      const jobId = crypto.randomUUID();
+      const webhookSecret = crypto.randomUUID();
+      const jobRef = db
+        .collection('users').doc(userId)
+        .collection('generationJobs').doc(jobId);
 
-      console.log(`Video generation completed for user ${userId}`);
+      // Stable names for the saved gallery asset, fixed at submit so the
+      // webhook, poll, and reconciler paths all produce identical metadata.
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      const originalFilename = `ai-video-${stamp}.mp4`;
+      const assetName = `AI Video ${stamp}`;
 
-      // Decrement tokens for ALL users (only after successful video generation)
-      const tokenProfileRef = db.collection('tokenProfile').doc(userId);
-
-      let remainingTokens = 0;
-      let videoTokensBefore = 0;
-      await db.runTransaction(async (transaction) => {
-        const tokenDoc = await transaction.get(tokenProfileRef);
-
-        if (!tokenDoc.exists) {
-          throw new functions.https.HttpsError('not-found', 'Token profile not found');
-        }
-
-        const currentTokens = tokenDoc.data().genToken || 0;
-        videoTokensBefore = currentTokens;
-
-        // Verify user still has enough tokens (double-check after generation)
-        if (currentTokens < tokenCost) {
-          throw new functions.https.HttpsError('resource-exhausted', 'Insufficient tokens');
-        }
-
-        // Deduct the appropriate number of tokens based on duration
-        const newTokenCount = Math.max(0, currentTokens - tokenCost);
-        remainingTokens = newTokenCount;
-
-        transaction.update(tokenProfileRef, {
-          genToken: newTokenCount,
-          updatedAt: admin.firestore.FieldValue.serverTimestamp()
-        });
-      });
-
-      // Fire-and-forget: write generation audit log
-      db.collection('generationLog').add({
-        userId,
+      await jobRef.set({
+        status: 'queued',
+        providerStatus: null,
+        kind: 'video',
         provider: 'replicate',
+        providerJobId: null,
         model: model_name,
-        generationType: 'video',
+        source,
         tokenCost,
-        processingTimeMs: videoGenerationElapsedMs,
-        providerPredictionId: null, // replicate.run() doesn't expose prediction ID; use predictions.create() if needed
-        status: 'succeeded',
+        tokenCharged: false,
+        refunded: false,
+        tempFilePath: tempFilePath || null,
+        webhookSecret,
+        originalFilename,
+        assetName,
+        // Everything the terminal processor needs to finish the job without a
+        // browser: gallery generationMetadata + the Discord post inputs.
+        generationParams: {
+          model_name,
+          prompt,
+          aspect_ratio,
+          duration_seconds,
+          scene_id: scene_id || null
+        },
+        // Videos render in ~2 minutes; the video tab has no completion-email
+        // opt-in, so notify stays off (the notify sweep queries pending:true).
+        notify: { email: false, pending: false },
         createdAt: admin.firestore.FieldValue.serverTimestamp()
-      }).catch(err => console.error('Failed to write generationLog:', err));
+      });
+
+      // Charge BEFORE creating the prediction, with tokenCharged flipped in the
+      // same transaction — same reasoning as the splat submit: every later
+      // refund path is then guaranteed to observe tokenCharged:true and refund
+      // exactly once. This is what closes the #1780 stranded-charge gap: the
+      // charge is tied to the job's real outcome, not to a connection staying
+      // open.
+      const tokenProfileRef = db.collection('tokenProfile').doc(userId);
+      let remainingTokens = 0;
+      let tokensBefore = 0;
+      try {
+        await db.runTransaction(async (transaction) => {
+          const tokenDoc = await transaction.get(tokenProfileRef);
+          if (!tokenDoc.exists) {
+            throw new functions.https.HttpsError('not-found', 'Token profile not found');
+          }
+          const currentTokens = tokenDoc.data().genToken || 0;
+          tokensBefore = currentTokens;
+          if (currentTokens < tokenCost) {
+            throw new functions.https.HttpsError('resource-exhausted', 'Insufficient tokens');
+          }
+          const newTokenCount = Math.max(0, currentTokens - tokenCost);
+          remainingTokens = newTokenCount;
+          transaction.update(tokenProfileRef, {
+            genToken: newTokenCount,
+            updatedAt: admin.firestore.FieldValue.serverTimestamp()
+          });
+          transaction.update(jobRef, { tokenCharged: true });
+        });
+      } catch (chargeError) {
+        await jobRef.update({
+          status: 'failed',
+          error: 'Token charge failed.',
+          completedAt: admin.firestore.FieldValue.serverTimestamp()
+        });
+        await cleanupSplatTempFile(tempFilePath);
+        throw chargeError;
+      }
 
       // Fire-and-forget: write token deduction audit log
       db.collection('tokenLog').add({
         userId,
         type: 'deduction',
-        tokensBefore: videoTokensBefore,
+        tokensBefore,
         tokensAfter: remainingTokens,
         tokenCost,
         source: 'video-generation',
@@ -739,36 +789,74 @@ const generateReplicateVideo = functions
         createdAt: admin.firestore.FieldValue.serverTimestamp()
       }).catch(err => console.error('Failed to write tokenLog:', err));
 
-      // Handle different output formats from Replicate
-      let finalVideoUrl;
-      if (output && output.output) {
-        finalVideoUrl = Array.isArray(output.output) ? output.output[0] : output.output;
-      } else if (Array.isArray(output)) {
-        finalVideoUrl = output[0];
-      } else if (typeof output === 'string') {
-        finalVideoUrl = output;
-      } else {
-        console.error('Unexpected output format from Replicate:', output);
-        throw new Error('Invalid output format from Replicate API');
+      // Webhook URL: uid to locate the job doc, internal jobId, per-job secret.
+      // The webhook body is never trusted; the handler re-fetches the
+      // prediction from Replicate authoritatively.
+      const projectId =
+        process.env.GCLOUD_PROJECT ||
+        process.env.GOOGLE_CLOUD_PROJECT ||
+        admin.app().options.projectId;
+      const region = process.env.FUNCTION_REGION || 'us-central1';
+      const webhookUrl =
+        `https://${region}-${projectId}.cloudfunctions.net/replicateJobWebhook` +
+        `?jobId=${jobId}&uid=${userId}&token=${webhookSecret}`;
+
+      let prediction;
+      try {
+        // Video models are official Replicate models addressed by NAME — the
+        // predictions API takes `model` instead of a `version` hash (splat
+        // pins a version because community models 404 on the name form).
+        prediction = await replicate.predictions.create({
+          model: model_name,
+          input: modelInput,
+          webhook: webhookUrl,
+          webhook_events_filter: ['completed']
+        });
+      } catch (createError) {
+        // Already paid above — refund (once) before failing the job so a
+        // submit failure never costs the user tokens.
+        const refunded = await refundSplatToken(db, userId, jobRef, {
+          kind: 'video',
+          tokenCharged: true,
+          refunded: false,
+          tokenCost,
+          model: model_name
+        });
+        if (typeof refunded !== 'undefined') remainingTokens = refunded;
+        await jobRef.update({
+          status: 'failed',
+          error: `Failed to create prediction: ${createError.message}`,
+          completedAt: admin.firestore.FieldValue.serverTimestamp()
+        });
+        await cleanupSplatTempFile(tempFilePath);
+        throw createError;
       }
 
-      console.log(`Video generation successful for user ${userId}: ${finalVideoUrl}`);
-
-      // Post AI-generated video to Discord (non-blocking)
-      // This runs in the background and won't fail the video generation if it errors
-      const readableModelName = supportedModels[model_name] || model_name;
-      postAIVideoToDiscord(userId, finalVideoUrl, prompt, readableModelName, duration_seconds, data.scene_id)
-        .catch(err => console.error('Discord posting failed:', err));
+      // Record the provider identity for the webhook/poll/reconciler re-fetch.
+      // Only advance the status while it's still the pre-submit 'queued' —
+      // never regress a status a racing completion path already moved past.
+      await db.runTransaction(async (tx) => {
+        const snap = await tx.get(jobRef);
+        const j = snap.data() || {};
+        const update = { providerJobId: prediction.id };
+        if (j.status === 'queued') {
+          update.status = normalizeReplicateStatus(prediction.status);
+          update.providerStatus = prediction.status || null;
+        }
+        tx.update(jobRef, update);
+      });
 
       return {
         success: true,
-        video_url: finalVideoUrl,
-        message: 'Video generated successfully!',
-        remainingTokens: remainingTokens
+        jobId,
+        status: normalizeReplicateStatus(prediction.status),
+        remainingTokens
       };
     } catch (error) {
-      console.error('Error generating video with Replicate:', error);
-      console.error('Error details:', error.message);
+      console.error('Error creating video prediction:', error);
+
+      // Best-effort cleanup of the staged input on failure.
+      await cleanupSplatTempFile(tempFilePath);
 
       // Fire-and-forget: write failed generation audit log
       db.collection('generationLog').add({
@@ -777,14 +865,14 @@ const generateReplicateVideo = functions
         model: model_name,
         generationType: 'video',
         tokenCost,
-        processingTimeMs: videoGenerationStartTime ? Date.now() - videoGenerationStartTime : null,
-        providerPredictionId: null, // replicate.run() doesn't expose prediction ID; use predictions.create() if needed
         status: 'failed',
         error: error.message,
         createdAt: admin.firestore.FieldValue.serverTimestamp()
       }).catch(err => console.error('Failed to write generationLog:', err));
 
-      // If it's a Replicate error, include more details
+      if (error instanceof functions.https.HttpsError) {
+        throw error;
+      }
       if (error.response) {
         console.error('Response status:', error.response.status);
         console.error('Response data:', error.response.data);
@@ -1204,9 +1292,11 @@ function extractSplatUrl(output) {
   return null;
 }
 
-// Refund a failed splat job's charge exactly once, guarded by the job's
+// Refund a failed generation job's charge exactly once, guarded by the job's
 // `refunded` flag inside a transaction. Returns the resulting token count, or
-// undefined if there was nothing to refund / the refund failed.
+// undefined if there was nothing to refund / the refund failed. Kind-generic
+// despite the name (splat was the first consumer): the tokenLog source is
+// derived from job.kind.
 async function refundSplatToken(db, userId, jobRef, job) {
   if (job.refunded || !job.tokenCharged) return undefined;
   const tokenCost = job.tokenCost || 1;
@@ -1240,7 +1330,7 @@ async function refundSplatToken(db, userId, jobRef, job) {
       userId,
       type: 'refund',
       tokenCost,
-      source: 'splat-generation-failed',
+      source: `${job.kind || 'splat'}-generation-failed`,
       relatedModel: job.model,
       createdAt: admin.firestore.FieldValue.serverTimestamp()
     }).catch(err => console.error('Failed to write tokenLog:', err));
@@ -1449,6 +1539,100 @@ async function saveSplatToGallery(userId, plyUrl, job) {
   return { assetId, storageUrl };
 }
 
+// Copy the finished video from Replicate's (short-lived) CDN URL into the
+// user's gallery server-side — the same asset contract the client's
+// assetsService.addAsset used to write for videos (Storage file at
+// users/{uid}/assets/videos/ + users/{uid}/assets/{assetId} doc with
+// type 'video' / category 'ai-render'), so the gallery grid and the
+// onAssetWritten quota trigger pick it up unchanged. Moving this server-side
+// is the core of the #1780 fix: the save no longer dies with a closed tab.
+// Streamed like saveSplatToGallery so memory stays flat regardless of size,
+// and keyed on the deterministic assetId so webhook/poll/reconciler retries
+// converge on one Storage object + one asset doc.
+async function saveVideoToGallery(userId, videoUrl, job) {
+  validateSplatUserId(userId);
+
+  const assetId = deterministicAssetId(job.predictionId || crypto.randomUUID());
+  const filename = `${assetId}.mp4`;
+  const storagePath = `users/${userId}/assets/videos/${filename}`;
+  const downloadToken = crypto.randomUUID();
+
+  const bucket = admin.storage().bucket();
+  const file = bucket.file(storagePath);
+
+  const response = await fetch(videoUrl);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download video from provider (${response.status})`);
+  }
+  const writeStream = file.createWriteStream({
+    metadata: {
+      contentType: 'video/mp4',
+      // Immutable content (keyed by assetId): matches the client upload path.
+      cacheControl: 'public, max-age=31536000',
+      metadata: {
+        firebaseStorageDownloadTokens: downloadToken,
+        assetRole: 'original',
+        assetId
+      }
+    }
+  });
+  await pipeline(Readable.fromWeb(response.body), writeStream);
+
+  const [meta] = await file.getMetadata();
+  const size = Number(meta.size) || 0;
+
+  const storageUrl =
+    `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/` +
+    `${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
+
+  const originalFilename = job.originalFilename || filename;
+  const lastDot = originalFilename.lastIndexOf('.');
+  const defaultName =
+    lastDot > 0 ? originalFilename.slice(0, lastDot) : originalFilename;
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const params = job.generationParams || {};
+
+  await admin
+    .firestore()
+    .collection('users').doc(userId)
+    .collection('assets').doc(assetId)
+    .set({
+      assetId,
+      userId,
+      type: 'video',
+      category: 'ai-render',
+      storagePath,
+      storageUrl,
+      name: job.assetName || defaultName,
+      filename,
+      originalFilename,
+      size,
+      mimeType: 'video/mp4',
+      generationMetadata: {
+        // Same shape the old client-side save wrote (src/generator/video.js
+        // saveToGallery) so pre-migration and job-queue videos render
+        // identically in the gallery.
+        model: params.model_name || job.model || null,
+        prompt: params.prompt || null,
+        aspect_ratio: params.aspect_ratio || null,
+        duration_seconds: params.duration_seconds || null,
+        source: job.source || 'generator',
+        predictionId: job.predictionId || null,
+        timestamp: new Date().toISOString()
+      },
+      createdAt: now,
+      updatedAt: now,
+      uploadedAt: now,
+      publishedAt: now,
+      visibility: 'public',
+      tags: [],
+      collections: [],
+      deleted: false
+    });
+
+  return { assetId, storageUrl };
+}
+
 // Guard a uid before using it in a Storage/Firestore path. Mirrors the client's
 // validateUserIdForPath so a forged webhook uid can't escape the user subtree.
 function validateSplatUserId(userId) {
@@ -1489,11 +1673,13 @@ function estimateModalCostUsd(metrics) {
   return priced ? Math.round(usd * 100) / 100 : null;
 }
 
-// Idempotently handle a terminal Replicate prediction. Called by BOTH the
-// webhook and the poller, possibly concurrently, so the success path claims the
-// save by flipping status → 'saving' in a transaction; only the winner uploads.
-// Failure refunds once (guarded by refundSplatToken). Returns a client-facing
-// status object.
+// Idempotently handle a terminal Replicate prediction. Called by the webhook,
+// the poller, AND the scheduled reconciler, possibly concurrently, so the
+// success path claims the save by flipping status → 'saving' in a transaction;
+// only the winner uploads. Failure refunds once (guarded by refundSplatToken).
+// Returns a client-facing status object. Kind-aware: `job.kind` picks the
+// finalize path — 'video' saves an .mp4 gallery asset + posts to Discord;
+// 'splat' (the default, for pre-kind docs) runs the geometry gate + .ply save.
 async function processTerminalPrediction(db, userId, jobRef, prediction) {
   const normalized = normalizeReplicateStatus(prediction.status);
 
@@ -1541,8 +1727,12 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
     if (!claimed) {
       const snap = await jobRef.get();
       const j = snap.data() || {};
-      // Already saved by a racing caller.
+      // Already saved by a racing caller. The result field is kind-specific
+      // (video_url vs splat_url) so each client keys off its own terminal.
       if (j.status === 'succeeded') {
+        if ((j.kind || 'splat') === 'video') {
+          return { status: 'succeeded', video_url: j.videoUrl, assetId: j.assetId };
+        }
         return { status: 'succeeded', splat_url: j.splatUrl, assetId: j.assetId };
       }
       // Already finalized as failed/canceled (e.g. the reconciler gave up and
@@ -1561,9 +1751,11 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
       };
     }
 
+    // Output normalization is shared across kinds — video models return the
+    // same string/array/object shapes SHARP does.
     const splatUrl = extractSplatUrl(prediction.output);
     if (!splatUrl) {
-      console.error('Unexpected SHARP output:', JSON.stringify(prediction.output, null, 2));
+      console.error('Unexpected model output:', JSON.stringify(prediction.output, null, 2));
       const remainingTokens = await refundSplatToken(db, userId, jobRef, job);
       await cleanupSplatTempFile(job.tempFilePath);
       await jobRef.update({
@@ -1572,6 +1764,62 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
         completedAt: admin.firestore.FieldValue.serverTimestamp()
       });
       return { status: 'failed', error: 'Invalid output from model.', remainingTokens };
+    }
+
+    // kind: 'video' — persist the .mp4 to the gallery and finish. No geometry
+    // gate (that's a splat-specific SfM sanity check). The Discord post lives
+    // HERE (not in the submit callable) so it fires on real completion, and the
+    // claim above guarantees it fires exactly once even when webhook + poll +
+    // reconciler all reach terminal.
+    if ((job.kind || 'splat') === 'video') {
+      try {
+        const { assetId, storageUrl } = await saveVideoToGallery(userId, splatUrl, {
+          ...job,
+          predictionId: job.providerJobId || jobRef.id
+        });
+        await cleanupSplatTempFile(job.tempFilePath);
+        await jobRef.update({
+          status: 'succeeded',
+          assetId,
+          videoUrl: storageUrl,
+          completedAt: admin.firestore.FieldValue.serverTimestamp()
+        });
+        db.collection('generationLog').add({
+          userId,
+          provider: job.provider || 'replicate',
+          model: job.model,
+          generationType: 'video',
+          tokenCost: job.tokenCost,
+          // Submit → saved-to-gallery, i.e. the user-perceived duration
+          // (includes provider queue wait, unlike the old replicate.run timing).
+          processingTimeMs: job.createdAt?.toMillis
+            ? Date.now() - job.createdAt.toMillis()
+            : null,
+          providerPredictionId: job.providerJobId || null,
+          status: 'succeeded',
+          source: job.source,
+          createdAt: admin.firestore.FieldValue.serverTimestamp()
+        }).catch(err => console.error('Failed to write generationLog:', err));
+
+        // Fire-and-forget: post the durable Storage URL (the replicate.delivery
+        // URL is ephemeral). Errors never fail the (already-committed) save.
+        const params = job.generationParams || {};
+        postAIVideoToDiscord(
+          userId,
+          storageUrl,
+          params.prompt || '',
+          SUPPORTED_VIDEO_MODELS[job.model] || job.model,
+          params.duration_seconds,
+          params.scene_id
+        ).catch(err => console.error('Discord posting failed:', err));
+
+        return { status: 'succeeded', video_url: storageUrl, assetId };
+      } catch (saveError) {
+        console.error('Failed to save video to gallery:', saveError);
+        // Release the claim so a webhook retry / next poll can re-attempt.
+        await jobRef.update({ status: 'running' });
+        throw new functions.https.HttpsError('internal', `Failed to save video: ${saveError.message}`);
+      }
     }
 
     // Sanity-gate the generated .ply BEFORE we keep the charge and save a
@@ -1682,12 +1930,14 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
   if (normalized === 'failed' || normalized === 'canceled') {
     const snap = await jobRef.get();
     const job = snap.data() || {};
+    const kind = job.kind || 'splat';
+    const genericError = `${kind === 'video' ? 'Video' : 'Splat'} generation failed.`;
     const remainingTokens = await refundSplatToken(db, userId, jobRef, job);
     await cleanupSplatTempFile(job.tempFilePath);
     await jobRef.update({
       status: normalized,
       providerStatus: prediction.status,
-      error: prediction.error || 'Splat generation failed.',
+      error: prediction.error || genericError,
       completedAt: admin.firestore.FieldValue.serverTimestamp()
     });
     db.collection('generationLog').add({
@@ -1695,7 +1945,7 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
       provider: job.provider || 'replicate',
       model: job.model,
       modelId: job.modelId || null,
-      generationType: 'splat',
+      generationType: kind,
       tokenCost: job.tokenCost,
       processingTimeMs: job.createdAt?.toMillis
         ? Date.now() - job.createdAt.toMillis()
@@ -1707,7 +1957,7 @@ async function processTerminalPrediction(db, userId, jobRef, prediction) {
     }).catch(err => console.error('Failed to write generationLog:', err));
     return {
       status: normalized,
-      error: prediction.error || 'Splat generation failed.',
+      error: prediction.error || genericError,
       remainingTokens
     };
   }
@@ -1742,7 +1992,9 @@ async function ackClientSeen(jobRef, job) {
 
 const getGenerationJobStatus = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', ...MODAL_SECRETS],
+    // DISCORD_WEBHOOK_URL: the shared terminal processor posts finished videos
+    // to Discord, and a poll can be the path that carries a job to terminal.
+    secrets: ['REPLICATE_API_TOKEN', 'DISCORD_WEBHOOK_URL', ...MODAL_SECRETS],
     // saveSplatToGallery streams the .ply through (no full-file buffering), so
     // memory no longer scales with splat size. 512 MB is fixed headroom over the
     // firebase-admin cold-start baseline, not sized to the file.
@@ -1777,7 +2029,12 @@ const getGenerationJobStatus = functions
     }
     const job = jobSnap.data();
 
-    // Terminal in our records (likely the webhook already handled it).
+    // Terminal in our records (likely the webhook already handled it). The
+    // result field is kind-specific: video jobs carry videoUrl, splats splatUrl.
+    if (job.status === 'succeeded' && (job.kind || 'splat') === 'video' && job.videoUrl) {
+      await ackClientSeen(jobRef, job);
+      return { status: 'succeeded', video_url: job.videoUrl, assetId: job.assetId };
+    }
     if (job.status === 'succeeded' && job.splatUrl) {
       await ackClientSeen(jobRef, job);
       return { status: 'succeeded', splat_url: job.splatUrl, assetId: job.assetId };
@@ -1942,7 +2199,9 @@ const replicateJobWebhook = functions
   .runWith({
     // POSTMARK_API_KEY: the webhook sends the completion email in real time
     // (sendGenerationReadyEmail), so it needs the Postmark secret in its env.
-    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY'],
+    // DISCORD_WEBHOOK_URL: the terminal processor posts finished videos to
+    // Discord, and the webhook is the usual path that reaches terminal.
+    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL'],
     // Same streamed save as the poll path; 512 MB is fixed cold-start headroom,
     // not sized to the splat.
     memory: '512MB',

--- a/public/functions/replicate.js
+++ b/public/functions/replicate.js
@@ -539,7 +539,14 @@ const generateReplicateVideo = functions
     assertAppCheck(context);
 
     const userId = context.auth.uid;
-    const { prompt, input_image, model_name = 'lightricks/ltx-2-fast', aspect_ratio = '16:9', duration_seconds = 5, scene_id, source = 'generator' } = data;
+    const { prompt, input_image, model_name = 'lightricks/ltx-2-fast', aspect_ratio = '16:9', duration_seconds = 5, scene_id, source = 'generator', notify } = data;
+
+    // Opt-in completion email, same contract as the splat submit: `pending:
+    // true` is the flag the notify sweep queries on; it clears when the email
+    // is sent OR when a live poll acks the result (tab was open → no email).
+    // Renders are usually ~2 min, but provider queue waits can stretch a job
+    // far past what anyone keeps a tab open for.
+    const wantsEmail = notify?.email === true;
 
     // Validate the model before staging anything or charging tokens.
     if (!SUPPORTED_VIDEO_MODELS[model_name]) {
@@ -733,9 +740,7 @@ const generateReplicateVideo = functions
           duration_seconds,
           scene_id: scene_id || null
         },
-        // Videos render in ~2 minutes; the video tab has no completion-email
-        // opt-in, so notify stays off (the notify sweep queries pending:true).
-        notify: { email: false, pending: false },
+        notify: { email: wantsEmail, pending: wantsEmail },
         createdAt: admin.firestore.FieldValue.serverTimestamp()
       });
 

--- a/public/functions/scheduled/generation-job-reconcile.js
+++ b/public/functions/scheduled/generation-job-reconcile.js
@@ -540,7 +540,7 @@ function escalateIfNeeded(summary, notify) {
 
 const reconcileGenerationJobs = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', ...MODAL_SECRETS],
+    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL', ...MODAL_SECRETS],
     // processTerminalPrediction may stream a .ply save (no full-file buffering);
     // 512 MB is fixed headroom, not sized to the file. 540s covers a backlog.
     timeoutSeconds: 540,
@@ -581,7 +581,7 @@ const reconcileGenerationJobs = functions
 
 const triggerReconcileGenerationJobs = functions
   .runWith({
-    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', ...MODAL_SECRETS],
+    secrets: ['REPLICATE_API_TOKEN', 'POSTMARK_API_KEY', 'DISCORD_WEBHOOK_URL', ...MODAL_SECRETS],
     timeoutSeconds: 540,
     memory: '512MB'
   })

--- a/src/generator/video.js
+++ b/src/generator/video.js
@@ -219,6 +219,7 @@ const VideoTab = {
     this.elements.generateText = document.getElementById('video-generate-text');
     this.elements.tokenCostDisplay =
       document.getElementById('video-token-cost');
+    this.elements.notifyEmail = document.getElementById('video-notify-email');
 
     // Verify critical elements
     let missingElements = [];
@@ -364,6 +365,16 @@ const VideoTab = {
                             <span id="video-token-cost" class="text-sm font-medium">10</span>
                         </span>
                     </button>
+
+                    <!-- Email when done. Renders are usually ~2 minutes, but
+                         provider queue waits can stretch a job much longer;
+                         the email is suppressed server-side if this tab is
+                         still open when it finishes (same as the splat tab). -->
+                    <label class="flex items-center gap-2 mt-3 text-sm text-gray-600 cursor-pointer select-none">
+                        <input id="video-notify-email" type="checkbox" checked
+                            class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+                        Email me when my video is ready
+                    </label>
                 </div>
 
                 <!-- Preview Column -->
@@ -763,6 +774,10 @@ const VideoTab = {
 
     // Add duration (5 or 10 seconds)
     params.duration_seconds = this.getSelectedDuration();
+
+    // Opt-in completion email, recorded on the job doc. The server only sends
+    // it if this tab isn't around to ack the result (i.e. closed).
+    params.notify = { email: !!this.elements.notifyEmail?.checked };
 
     // Seed functionality removed - doesn't work for video models
     // Check if seed should be randomized before generation

--- a/src/generator/video.js
+++ b/src/generator/video.js
@@ -1,6 +1,15 @@
 /**
  * Video Generator - Video Tab
- * Video generation functionality using Replicate API
+ * Video generation functionality using Replicate API.
+ *
+ * Async, browser-independent flow (mirrors splat.js — see issue #1780):
+ * generateReplicateVideo creates a generation job (with a Replicate webhook)
+ * and returns its jobId immediately, instead of holding the callable
+ * connection open for the whole multi-minute render (which Safari drops,
+ * losing the result while tokens were still charged). When the job finishes,
+ * the webhook saves the video to the user's gallery server-side, so it lands
+ * even if this tab was closed. This UI polls getGenerationJobStatus only to
+ * reflect progress and show the result while open.
  */
 
 import FluxUI from './main.js';
@@ -8,7 +17,6 @@ import { httpsCallable } from 'firebase/functions';
 import { functions } from '@shared/services/firebase.js';
 import useImageGenStore from './store.js';
 import ImageUploadUtils from './image-upload-utils.js';
-import galleryService from '@shared/assets/services/assetsService.js';
 import { VIDEO_MODELS } from '@shared/constants/replicateModels.js';
 import { mountVideoModelSelector } from './mount-video-model-selector.js';
 
@@ -27,6 +35,16 @@ const VideoTab = {
   elapsedTime: 0,
   renderProgress: 0,
   timerInterval: null,
+
+  // Job-status poll state (see pollVideoStatus)
+  pollTimeout: null, // setTimeout handle for the status poll loop
+  pollDeadline: 0, // wall-clock ms after which we stop polling
+
+  // Poll cadence and overall ceiling. Renders run ~1.5–2.5 minutes; 15 min is
+  // generous headroom before we give up locally (the job still finishes
+  // server-side regardless — the video lands in the gallery either way).
+  POLL_INTERVAL_MS: 3000,
+  POLL_MAX_MS: 15 * 60 * 1000,
 
   // Estimated generation times (in seconds) - built from VIDEO_MODELS
   estimatedTimes: Object.entries(VIDEO_MODELS).reduce((acc, [key, model]) => {
@@ -586,35 +604,34 @@ const VideoTab = {
     this.currentParams = params;
 
     // Show loading state
+    this.stopPolling();
     this.toggleLoading(true);
 
-    // Make the API request using Firebase callable function
-    // Set timeout to 9 minutes (540000ms) to match server-side timeout
+    // Submit the job. The callable returns { success, jobId } immediately —
+    // no multi-minute open connection for Safari to drop (#1780). Completion
+    // is handled server-side (webhook saves to the gallery); we poll only to
+    // drive this tab's live UI.
     const generateReplicateVideo = httpsCallable(
       functions,
-      'generateReplicateVideo',
-      {
-        timeout: 540000 // 9 minutes in milliseconds
-      }
+      'generateReplicateVideo'
     );
 
     generateReplicateVideo(params)
       .then((result) => {
-        if (result.data.success && result.data.video_url) {
-          // Display the video
-          this.displayVideo(result.data.video_url);
-
-          // Save to gallery
-          this.saveToGallery(result.data.video_url);
-
-          // Dispatch custom event to refresh token count in UI
-          window.dispatchEvent(new CustomEvent('tokenCountChanged'));
-
-          this.toggleLoading(false);
-          FluxUI.showNotification('Video generated successfully!', 'success');
-        } else {
-          throw new Error(result.data.message || 'Failed to generate video');
+        if (!result.data || !result.data.success || !result.data.jobId) {
+          throw new Error(
+            result.data?.message || 'Could not start video generation'
+          );
         }
+
+        // Tokens are charged at submit (refunded on failure); reflect that.
+        window.dispatchEvent(new CustomEvent('tokenCountChanged'));
+
+        // The job now shows as a pending card in the assets gallery, driven by
+        // the live Firestore listener on the job doc — it persists across
+        // reloads and tabs without any client state here.
+        this.pollDeadline = Date.now() + this.POLL_MAX_MS;
+        this.pollVideoStatus(result.data.jobId);
       })
       .catch((error) => {
         console.error('Video generation error:', error);
@@ -636,6 +653,85 @@ const VideoTab = {
         FluxUI.showNotification(message, 'error');
         this.toggleLoading(false);
       });
+  },
+
+  // Poll getGenerationJobStatus until the job is terminal. Re-schedules itself
+  // with setTimeout (not setInterval) so a slow request can't overlap the next
+  // tick. Any non-terminal status (queued|running|saving) just keeps polling.
+  pollVideoStatus: async function (jobId) {
+    const getGenerationJobStatus = httpsCallable(
+      functions,
+      'getGenerationJobStatus'
+    );
+
+    try {
+      const { data } = await getGenerationJobStatus({ jobId });
+
+      if (data.status === 'succeeded' && data.video_url) {
+        // The video was saved to the gallery server-side (works even if this
+        // tab had been closed). Just show it and refresh the gallery island so
+        // the pending-job card hands its slot to the real asset.
+        this.displayVideo(data.video_url);
+        this.toggleLoading(false);
+        window.dispatchEvent(new Event('assets:refresh'));
+        window.dispatchEvent(new CustomEvent('tokenCountChanged'));
+        FluxUI.showNotification(
+          'Video generated and saved to your gallery!',
+          'success'
+        );
+        return;
+      }
+
+      if (data.status === 'failed' || data.status === 'canceled') {
+        // The server refunds on failure; refresh the displayed balance.
+        window.dispatchEvent(new CustomEvent('tokenCountChanged'));
+        this.toggleLoading(false);
+        FluxUI.showNotification(
+          data.error
+            ? `Video generation failed: ${data.error}`
+            : 'Video generation failed. Your tokens were refunded.',
+          'error'
+        );
+        return;
+      }
+
+      // Still queued/running/saving — keep polling until the deadline.
+      if (Date.now() > this.pollDeadline) {
+        this.toggleLoading(false);
+        FluxUI.showNotification(
+          'Video generation is taking longer than expected. Check your gallery shortly — it will appear there when finished.',
+          'error'
+        );
+        return;
+      }
+      this.pollTimeout = setTimeout(
+        () => this.pollVideoStatus(jobId),
+        this.POLL_INTERVAL_MS
+      );
+    } catch (error) {
+      console.error('Error polling video status:', error);
+      // Transient poll error — retry until the deadline rather than failing
+      // hard; the job is unaffected server-side.
+      if (Date.now() > this.pollDeadline) {
+        this.toggleLoading(false);
+        FluxUI.showNotification(
+          'Lost track of the video job. Check your gallery shortly — it will appear there when finished.',
+          'error'
+        );
+        return;
+      }
+      this.pollTimeout = setTimeout(
+        () => this.pollVideoStatus(jobId),
+        this.POLL_INTERVAL_MS
+      );
+    }
+  },
+
+  stopPolling: function () {
+    if (this.pollTimeout) {
+      clearTimeout(this.pollTimeout);
+      this.pollTimeout = null;
+    }
   },
 
   // Build request parameters
@@ -949,79 +1045,12 @@ const VideoTab = {
     this.elements.imagePreviewContainer.classList.add('hidden');
     this.elements.imageUploadLabel.classList.remove('hidden');
     this.elements.imageInput.value = '';
-  },
-
-  // Save video to gallery
-  saveToGallery: async function (videoUrl) {
-    // Check if gallery service is available
-    if (!galleryService) {
-      return;
-    }
-
-    // Initialize gallery service with current user
-    const currentUser = window.authState?.currentUser;
-    if (currentUser && !galleryService.userId) {
-      try {
-        await galleryService.init(currentUser.uid);
-      } catch (err) {
-        console.warn('Failed to initialize gallery V2, using V1:', err);
-      }
-    }
-
-    // Convert the video URL to a Data URL so gallery can store as Blob
-    fetch(videoUrl)
-      .then((response) => response.blob())
-      .then(
-        (blob) =>
-          new Promise((resolve, reject) => {
-            const reader = new FileReader();
-            reader.onloadend = () => resolve(reader.result);
-            reader.onerror = reject;
-            reader.readAsDataURL(blob);
-          })
-      )
-      .then(async (dataUrl) => {
-        // Build comprehensive metadata for the video
-        const metadata = {
-          model: this.currentParams.model_name || this.selectedModel,
-          prompt: this.currentParams.prompt || this.elements.promptInput.value,
-          aspect_ratio: this.currentParams.aspect_ratio,
-          duration_seconds: this.currentParams.duration_seconds,
-          ...(this.currentParams.seed && { seed: this.currentParams.seed })
-        };
-
-        try {
-          const currentUser = window.authState?.currentUser;
-          if (!currentUser) {
-            console.warn('User not authenticated, skipping gallery save');
-            return;
-          }
-
-          // Initialize gallery service if needed
-          await galleryService.init();
-
-          // Use V2 API: addAsset(file, metadata, type, category, userId)
-          await galleryService.addAsset(
-            dataUrl,
-            metadata,
-            'video', // type
-            'ai-render', // category
-            currentUser.uid // userId
-          );
-          FluxUI.showNotification('Video saved to gallery!', 'success');
-        } catch (e) {
-          console.error('Gallery addAsset error:', e);
-          FluxUI.showNotification('Failed to save video to gallery.', 'error');
-        }
-      })
-      .catch((error) => {
-        console.error('Error saving video to gallery:', error);
-        FluxUI.showNotification(
-          'Failed to save video to gallery: ' + error.message,
-          'error'
-        );
-      });
   }
+
+  // NOTE: the old client-side saveToGallery was removed — the video is now
+  // persisted to the gallery server-side by the generation job's terminal
+  // processor (public/functions/replicate.js:saveVideoToGallery), so it saves
+  // even if this tab is closed mid-render (#1780).
 };
 
 export default VideoTab;

--- a/src/shared/assets/components/PendingJobCard.jsx
+++ b/src/shared/assets/components/PendingJobCard.jsx
@@ -26,7 +26,8 @@ const STATUS_LABELS = {
 // Map job kind → the noun shown on the card.
 const KIND_NOUNS = {
   splat: 'Splat',
-  image: 'Image'
+  image: 'Image',
+  video: 'Video'
 };
 
 const PendingJobCard = ({ job }) => {


### PR DESCRIPTION
## Why

Fixes #1780. `generateReplicateVideo` was a synchronous callable that blocked on `replicate.run()` for the whole render (~2 min median, per prod logs) with zero streamed bytes. Safari drops idle data-less HTTPS connections well before that, surfacing a spurious `FirebaseError: internal` while the server kept running, **charged tokens, and produced a video nobody received**. `onCall` can't stream, so there's no timeout to tune — the fix is the same create-and-return async job queue already used for image→splat (`users/{uid}/generationJobs/{jobId}`, `docs/generation-job-queue.md`).

## Server (`public/functions/replicate.js`)

- **Submit-and-return:** `generateReplicateVideo` now writes a pending job doc (`kind: 'video'`), charges tokens at submit (`tokenCharged` flipped in the same transaction, mirroring the splat submit's exactly-once refund guarantee), submits via `replicate.predictions.create({ model, input, webhook })`, and returns `{ success, jobId, status, remainingTokens }` immediately. Video models are official models addressed by **name** (no version hash — unlike SHARP, which pins a version). Per-model input shaping is unchanged.
- **Server-side gallery save (the biggest new piece):** `processTerminalPrediction` gains a `kind: 'video'` finalize branch. `saveVideoToGallery` streams the `.mp4` from the ephemeral `replicate.delivery` URL into `users/{uid}/assets/videos/{assetId}.mp4` and writes the same `type: 'video'` / `category: 'ai-render'` asset doc (same `generationMetadata` shape) the client-side `saveToGallery` used to write — so the save now survives a closed tab, and pre-/post-migration gallery videos render identically. Keyed on a deterministic assetId so webhook/poll/reconciler retries converge on one asset.
- **Token model:** flipped from charge-after-success to charge-at-submit + refund-once-on-failure via the shared `refundSplatToken` path (audit-log source is now kind-aware: `video-generation-failed`). The old ordering is exactly what stranded charges on disconnect.
- **Discord post** moved from the submit callable into the terminal processor's claimed success branch — fires on real completion, exactly once (the `saving` claim serializes webhook + poll + reconciler), with the durable Storage URL. `DISCORD_WEBHOOK_URL` secret added to the webhook, poll, and reconciler functions since any of them can carry a job to terminal.
- **Completion email:** the video submit honors the same `notify: { email, pending }` opt-in contract as splat — the webhook emails in real time when the tab is gone, the reconciler sweep backstops it, and a live poll ack suppresses it. The `generationReady` template already carried video copy.
- **`getGenerationJobStatus`** returns `video_url` for `kind === 'video'` terminal jobs (mirrors `splat_url`).
- The staged temp input image is now recorded on the job doc (`tempFilePath`) and cleaned up at terminal — previously it was never deleted.
- Reused unchanged: `replicateJobWebhook`, `normalizeReplicateStatus`, the claim/finalize machinery, and the scheduled reconciler (verified kind-agnostic — it queries non-terminal jobs and its `failJob` refund/cleanup path is already generic).

## Client (`src/generator/video.js` + shared)

- Mirrors `splat.js`: submit → `jobId` → `pollVideoStatus` self-rescheduling `setTimeout` loop. Terminal on `succeeded && video_url` (display + `assets:refresh` + `tokenCountChanged`), terminal on `failed`/`canceled` (refund message + `tokenCountChanged`), 15-min poll-deadline fallback ("check your gallery shortly").
- "Email me when my video is ready" checkbox (default on, same as the splat tab) — renders are usually ~2 min, but provider queue waits can stretch a job far past what anyone keeps a tab open for.
- Client-side `saveToGallery` and the 9-minute callable timeout are removed.
- `PendingJobCard` learns the `video` kind noun; the existing `generationJobs` listener (`useAssets.js`) is kind-agnostic, so video jobs show as pending gallery cards across tabs/reloads for free.
- Docs updated: `docs/generation-job-queue.md` (new "second kind on Replicate" section) and the CLAUDE.md queue blurb.

## Testing

- `npm run test:core` (51 pass) and `npm run test:modern` (357 pass) green; ESLint + Prettier clean on all touched files (`test:components` fails in this container on a pre-existing Playwright browser-version mismatch, identical on a clean tree).
- **Still needs manual verification on staging/emulator** (needs Replicate + webhook secrets, not available in this environment):
  - [ ] Submit returns immediately with a `jobId`; job doc goes `queued → processing → succeeded`; `getGenerationJobStatus` returns `video_url`
  - [ ] **Close-the-tab test (the actual #1780 regression):** start a job, close the tab, reopen — video appears in the gallery, tokens charged exactly once, completion email arrives (opt-in checked)
  - [ ] Open-tab email suppression: keep the tab open to completion → no email
  - [ ] Failure path: Replicate `Prediction failed` → job `failed`, tokens refunded exactly once, no gallery item, no Discord post
  - [ ] Idempotency: webhook + poll racing → one gallery asset, one `tokenLog` deduction, one Discord post
  - [ ] Reconciler finalizes a job whose webhook never arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jb5xervTvwbE3Kyovqohts