### PR TITLE
Fix GLB export error toast crashing on raw error object (#1794)

### DIFF
--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -273,7 +273,7 @@ const AppMenu = ({ currentUser }) => {
                   defaultMessage:
                     'Error while trying to save glTF file. Error: {error}'
                 },
-                { error }
+                { error: error?.message ?? String(error) }
               )
             );
           },
@@ -293,7 +293,7 @@ const AppMenu = ({ currentUser }) => {
               defaultMessage:
                 'Error while trying to save glTF file. Error: {error}'
             },
-            { error }
+            { error: error?.message ?? String(error) }
           )
         );
         console.error(error);


### PR DESCRIPTION
Fixes **bug 2** of #1794 (the underlying export regression, bug 1, is tracked separately in that issue for a separate fix).

## Problem
Both glTF export error handlers in `AppMenu.jsx` passed the raw `Error` object into `intl.formatMessage`'s values as `{ error }`. react-intl embeds the object into the message value, which react-hot-toast then tries to render as a React child → `Objects are not valid as a React child (found: TypeError: Cannot read properties of undefined (reading 'x'))`.

Two consequences:
- The error toast itself crashes (unhandled rejection).
- The **real** export error is masked from both the user and Sentry, making the underlying export regression hard to diagnose.

Sentry: [Issue 7592680261](https://3dstreet.sentry.io/issues/7592680261/) — 9 events on `3dstreet.app`, release `2026.6.0+2b653c58`.

## Fix
Stringify the error at both call sites (lines 276 & 296):

```js
{ error: error?.message ?? String(error) }
```

Now the toast shows the actual failure message, and the true export error surfaces in Sentry so the underlying regression (suspected `THREE.BatchedMesh` / #1755 incompatibility with `GLTFExporter`) can be diagnosed.

## Testing
- eslint + prettier clean (pre-commit hooks passed).
- Manual: trigger a glTF export failure → toast now renders the error string instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)