### PR TITLE
Fix GLB/glTF export crash and BatchedMesh export handling (#1794 bug 1)

### DIFF
--- a/src/batch-models.js
+++ b/src/batch-models.js
@@ -1741,6 +1741,55 @@ export function isBatched(el) {
   return !!el?.object3D?.userData?._batchSlots?.length;
 }
 
+// Make a batched scene exportable by GLTFExporter, which has no BatchedMesh support: it
+// serializes one as a plain Mesh — the merged capacity buffer, parked at the batch root,
+// with no per-instance transforms — so batched entities come out as a garbage blob (or
+// vanish once the BatchedMesh is filtered out). Instead, re-expand every batched member
+// into ordinary Meshes for the duration of the export:
+// - Each member object3D found under `root` gets one temporary Mesh per batch slot, built
+//   from the slot's source geometry (the template collectRefSubMeshes/batchMergedByMaterial
+//   registered) and the BatchedMesh's material, with the slot's entity-local matrix — the
+//   exact geometry/material/transform the slot renders. matrixAutoUpdate stays false so the
+//   exporter serializes the matrix as-is (a decompose would lose shear).
+// - The temp meshes are export-only: layers.mask = 0 keeps the renderer, shadow pass, and
+//   raycasters from ever seeing them (no GPU upload), while GLTFExporter ignores layers.
+// - Every BatchedMesh under `root` is hidden so the exporter's default onlyVisible pass
+//   skips its merged blob. The viewport shows neither copy until restore() runs, matching
+//   how exports already hide inspector helpers mid-export.
+// Returns an idempotent restore() that detaches the temp meshes and re-shows the
+// BatchedMeshes. Works for whole-scene roots and for a single member entity's object3D
+// (whose BatchedMesh lives outside `root` and is then simply not part of the export).
+export function expandBatchedMeshesForExport(root) {
+  const batchedMeshes = [];
+  const memberRoots = [];
+  root.traverse((node) => {
+    if (node.isBatchedMesh && node.visible) batchedMeshes.push(node);
+    if (node.userData._batchSlots?.length) memberRoots.push(node);
+  });
+
+  const tempMeshes = [];
+  for (const object3D of memberRoots) {
+    for (const slot of object3D.userData._batchSlots) {
+      const mesh = new THREE.Mesh(slot.geometry, slot.batchedMesh.material);
+      mesh.name = slot.geometry.name || '';
+      mesh.matrix.copy(slot.localMatrix);
+      mesh.matrixAutoUpdate = false;
+      mesh.layers.mask = 0;
+      object3D.add(mesh);
+      tempMeshes.push(mesh);
+    }
+  }
+  for (const batched of batchedMeshes) batched.visible = false;
+
+  let restored = false;
+  return function restore() {
+    if (restored) return;
+    restored = true;
+    for (const mesh of tempMeshes) mesh.parent?.remove(mesh);
+    for (const batched of batchedMeshes) batched.visible = true;
+  };
+}
+
 // All batched members are stripped (no original mesh), so popMember can't restore the
 // original in place. Drop the slot and trigger a fresh GLB load; once model-loaded fires
 // the entity is a normal unbatched gltf-model with the new (unsafe) component applied.

--- a/src/editor/components/elements/CommonComponents.js
+++ b/src/editor/components/elements/CommonComponents.js
@@ -4,6 +4,7 @@ import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropertyRow from './PropertyRow';
 import Events from '../../lib/Events';
 import { saveBlob } from '../../lib/utils';
+import { prepareSceneForGltfExport } from '../../lib/prepareGltfExport';
 
 export default class CommonComponents extends React.Component {
   static propTypes = {
@@ -65,13 +66,19 @@ export default class CommonComponents extends React.Component {
 
   exportToGLTF() {
     const entity = this.props.entity;
+    // A batched entity's own mesh was stripped into a scene-level BatchedMesh; expansion
+    // rebuilds temporary meshes under the entity so the export isn't empty. Also
+    // normalizes the pivot property the bundled exporter expects (see prepareGltfExport).
+    const restoreExportScene = prepareSceneForGltfExport(entity.object3D);
     AFRAME.INSPECTOR.exporters.gltf.parse(
       entity.object3D,
       function (buffer) {
+        restoreExportScene();
         const blob = new Blob([buffer], { type: 'application/octet-stream' });
         saveBlob(blob, (entity.id || 'entity') + '.glb');
       },
       function (error) {
+        restoreExportScene();
         console.error(error);
       },
       { binary: true }

--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -7,6 +7,7 @@ import posthog from 'posthog-js';
 import Events from '../../lib/Events.js';
 import { useAuthContext } from '@/editor/contexts';
 import { saveBlob } from '../../lib/utils';
+import { prepareSceneForGltfExport } from '../../lib/prepareGltfExport';
 import {
   uploadAndPlaceAsset,
   FILE_PICKER_ACCEPT
@@ -188,6 +189,7 @@ const AppMenu = ({ currentUser }) => {
 
   const exportSceneToGLTF = (arReady) => {
     if (authUser?.isPro) {
+      let restoreExportScene;
       try {
         posthog.capture('export_initiated', {
           export_type: arReady ? 'ar_glb' : 'glb',
@@ -209,10 +211,14 @@ const AppMenu = ({ currentUser }) => {
           filterRiggedEntities(scene, false);
         }
         filterHelpers(scene, false);
+        // Expand BatchedMeshes into exportable meshes and normalize the pivot property
+        // (see prepareGltfExport.js) — restored in BOTH exporter callbacks below.
+        restoreExportScene = prepareSceneForGltfExport(scene);
         // Modified to handle post-processing
         AFRAME.INSPECTOR.exporters.gltf.parse(
           scene,
           async function (buffer) {
+            restoreExportScene();
             filterHelpers(scene, true);
             filterRiggedEntities(scene, true);
 
@@ -265,6 +271,9 @@ const AppMenu = ({ currentUser }) => {
             saveBlob(blob, sceneName + '.glb');
           },
           function (error) {
+            restoreExportScene();
+            filterHelpers(scene, true);
+            filterRiggedEntities(scene, true);
             console.error(error);
             STREET.notify.errorMessage(
               intl.formatMessage(
@@ -286,6 +295,7 @@ const AppMenu = ({ currentUser }) => {
           })
         );
       } catch (error) {
+        restoreExportScene?.();
         STREET.notify.errorMessage(
           intl.formatMessage(
             {

--- a/src/editor/lib/prepareGltfExport.js
+++ b/src/editor/lib/prepareGltfExport.js
@@ -1,0 +1,27 @@
+import { expandBatchedMeshesForExport } from '../../batch-models';
+
+// The editor bundles its own copy of three (the npm `three` package) for GLTFExporter,
+// while the scene graph is built by the super-three bundled inside the A-Frame script the
+// app loads. three r184's GLTFExporter branches on `object.pivot !== null` into a pivot
+// container path that immediately reads `pivot.x` — but objects created by a super-three
+// build without the Object3D.pivot feature leave the property undefined, so EVERY node
+// takes that branch and export dies on the first one with
+// "TypeError: Cannot read properties of undefined (reading 'x')". Normalizing the missing
+// property to null (what a pivot-aware Object3D constructor sets) keeps those nodes on the
+// regular path. Harmless where super-three does have pivot: the value is already null.
+function normalizePivots(root) {
+  root.traverse((node) => {
+    if (node.pivot === undefined) node.pivot = null;
+  });
+}
+
+// Put `root` (a scene or a single entity's object3D) into an exportable state for
+// GLTFExporter: expand BatchedMesh members back into ordinary meshes and paper over the
+// super-three / npm-three Object3D.pivot mismatch. Returns an idempotent restore()
+// that callers MUST invoke from both the exporter's onDone and onError callbacks.
+export function prepareSceneForGltfExport(root) {
+  const restore = expandBatchedMeshesForExport(root);
+  // After expansion so the temporary meshes are normalized too.
+  normalizePivots(root);
+  return restore;
+}

--- a/test/components/prepare-gltf-export.test.js
+++ b/test/components/prepare-gltf-export.test.js
@@ -1,0 +1,144 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+// The editor's exporter copy: the npm `three` package, NOT window.THREE (A-Frame's bundled
+// super-three). Importing it here mirrors production, where the two copies coexist and the
+// exporter from one serializes objects built by the other.
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter';
+
+// batch-models references the global THREE that A-Frame's build installs on window. Import
+// A-Frame first so those globals exist, then the modules under test. These run in a real
+// Chromium (browser mode) because THREE.BatchedMesh allocates data textures and behaves
+// like production only in a real browser.
+let batch;
+let prepareSceneForGltfExport;
+let THREE;
+
+beforeAll(async () => {
+  window.AFRAME_ASYNC = true;
+  await import('aframe');
+  THREE = window.THREE;
+  window.STREET = window.STREET || {};
+  batch = await import('../../src/batch-models.js');
+  ({ prepareSceneForGltfExport } =
+    await import('../../src/editor/lib/prepareGltfExport.js'));
+  window.AFRAME.emitReady?.();
+});
+
+// A root holding one BatchedMesh (2 box instances) and two member object3Ds carrying the
+// _batchSlots batch-models leaves on batched entities — the state a batched scene is in
+// when the user hits export.
+function makeBatchedScene() {
+  const root = new THREE.Scene();
+  const geometry = new THREE.BoxGeometry();
+  geometry.name = 'box-sub-mesh';
+  const material = new THREE.MeshBasicMaterial();
+  const batchedMesh = new THREE.BatchedMesh(2, 256, 512, material);
+  batchedMesh.userData.batchIdToEl = [];
+  batchedMesh.userData.freeInstanceIds = [];
+  const geometryId = batchedMesh.addGeometry(geometry);
+  root.add(batchedMesh);
+
+  const members = [];
+  for (let i = 0; i < 2; i++) {
+    const memberRoot = new THREE.Object3D();
+    memberRoot.position.set(i * 4, 0, 0);
+    root.add(memberRoot);
+    memberRoot.updateMatrixWorld(true);
+    const localMatrix = new THREE.Matrix4().makeTranslation(0, 1 + i, 0);
+    const instanceId = batchedMesh.addInstance(geometryId);
+    batchedMesh.setMatrixAt(
+      instanceId,
+      new THREE.Matrix4().multiplyMatrices(memberRoot.matrixWorld, localMatrix)
+    );
+    memberRoot.userData._batchSlots = [
+      { batchedMesh, instanceId, localMatrix, geometry }
+    ];
+    members.push(memberRoot);
+  }
+  return { root, batchedMesh, members, geometry, material };
+}
+
+// Strip the Object3D.pivot property from every node, simulating a scene built by a
+// super-three build that predates the pivot feature — the production state that made
+// three r184's GLTFExporter crash with "Cannot read properties of undefined (reading 'x')".
+function stripPivots(root) {
+  root.traverse((node) => delete node.pivot);
+}
+
+function exportGltf(root) {
+  return new Promise((resolve, reject) => {
+    new GLTFExporter().parse(root, resolve, reject, { binary: false });
+  });
+}
+
+describe('expandBatchedMeshesForExport', () => {
+  it('creates export-only meshes per slot and hides the BatchedMesh', () => {
+    const { root, batchedMesh, members, geometry, material } =
+      makeBatchedScene();
+    const restore = batch.expandBatchedMeshesForExport(root);
+
+    expect(batchedMesh.visible).toBe(false);
+    for (const memberRoot of members) {
+      const temps = memberRoot.children.filter((c) => c.isMesh);
+      expect(temps).toHaveLength(1);
+      const temp = temps[0];
+      expect(temp.geometry).toBe(geometry);
+      expect(temp.material).toBe(material);
+      expect(temp.matrixAutoUpdate).toBe(false);
+      expect(
+        temp.matrix.equals(memberRoot.userData._batchSlots[0].localMatrix)
+      ).toBe(true);
+      // Renderer/raycaster never see the temp mesh; only the exporter (which
+      // ignores layers) does.
+      expect(temp.layers.mask).toBe(0);
+    }
+
+    restore();
+    expect(batchedMesh.visible).toBe(true);
+    for (const memberRoot of members) {
+      expect(memberRoot.children.filter((c) => c.isMesh)).toHaveLength(0);
+    }
+    restore(); // idempotent — a second call must not double-toggle anything
+    expect(batchedMesh.visible).toBe(true);
+  });
+
+  it('expands a single member root whose BatchedMesh lives outside it', () => {
+    const { batchedMesh, members } = makeBatchedScene();
+    const restore = batch.expandBatchedMeshesForExport(members[0]);
+    expect(members[0].children.filter((c) => c.isMesh)).toHaveLength(1);
+    expect(batchedMesh.visible).toBe(true); // not under the export root — untouched
+    restore();
+    expect(members[0].children.filter((c) => c.isMesh)).toHaveLength(0);
+  });
+});
+
+describe('prepareSceneForGltfExport + GLTFExporter (production pairing)', () => {
+  it('reproduces the "reading \'x\'" crash on a pivot-less scene without prep', async () => {
+    const { root } = makeBatchedScene();
+    stripPivots(root);
+    await expect(exportGltf(root)).rejects.toThrow(/reading 'x'/);
+  });
+
+  it('exports a batched, pivot-less scene once prepared, then restores', async () => {
+    const { root, batchedMesh, members } = makeBatchedScene();
+    stripPivots(root);
+
+    const restore = prepareSceneForGltfExport(root);
+    const gltf = await exportGltf(root);
+    restore();
+
+    // One node per member, each carrying the expanded mesh as a child; the hidden
+    // BatchedMesh (merged capacity blob) must not be exported.
+    const meshNodes = (gltf.nodes || []).filter((n) => n.mesh !== undefined);
+    expect(meshNodes).toHaveLength(2);
+    expect(meshNodes.every((n) => n.name === 'box-sub-mesh')).toBe(true);
+    // Slot-local transform survives via the node matrix.
+    expect(meshNodes[0].matrix?.[13]).toBe(1); // translation.y of slot 0
+    expect(meshNodes[1].matrix?.[13]).toBe(2); // translation.y of slot 1
+
+    // Scene is back to its renderable state.
+    expect(batchedMesh.visible).toBe(true);
+    for (const memberRoot of members) {
+      expect(memberRoot.children.filter((c) => c.isMesh)).toHaveLength(0);
+    }
+  });
+});


### PR DESCRIPTION
The prod export crash ("Cannot read properties of undefined (reading 'x')") is a three-copies mismatch, not the BatchedMesh merge itself: the editor's GLTFExporter comes from the npm three package (r184), whose exporter branches on `object.pivot !== null` into a pivot-container path that immediately reads `pivot.x`. Scene objects are built by the super-three bundled in the A-Frame script, and builds predating the Object3D.pivot feature leave that property undefined — so every node takes the pivot branch and export dies on the first one. prepareSceneForGltfExport now normalizes the missing property to null before parsing (test reproduces the exact crash against the real exporter).

Batched scenes were additionally unexportable even without the crash: GLTFExporter has no BatchedMesh support and serializes the merged capacity buffer as one untransformed blob. expandBatchedMeshesForExport re-expands every batched member into ordinary meshes for the duration of the export — one temporary mesh per batch slot, built from the slot's source geometry and the BatchedMesh material with the slot's entity-local matrix, and kept invisible to the renderer/raycasters via layers.mask = 0 (GLTFExporter ignores layers). BatchedMeshes are hidden so the exporter's onlyVisible pass skips them, and an idempotent restore() runs from both exporter callbacks.

Wired into both export paths (AppMenu scene/AR export, CommonComponents single-entity export); the AppMenu error callback now also restores the helper/rigged-entity visibility filters so a failed export no longer leaves the scene hidden.


Claude-Session: https://claude.ai/code/session_01LDoHMa17c1Py9uRrknZ8Fj