### PR TITLE
Add saving-style blocking indicator during GLB export (#1797)

### DIFF
--- a/src/editor/components/Main.jsx
+++ b/src/editor/components/Main.jsx
@@ -16,6 +16,7 @@ import EditorUpgradeModal from './EditorUpgradeModal.jsx';
 import { AddLayerPanel } from './elements/AddLayerPanel';
 import { NewModal } from './modals/NewModal';
 import { LoadingSceneModal } from './modals/LoadingSceneModal';
+import { ExportingSceneModal } from './modals/ExportingSceneModal';
 import AssetDeepLinkModal from './AssetDeepLinkModal.jsx';
 import JobHealthModal from './JobHealthModal.jsx';
 import { ToolbarWrapper } from './scenegraph/ToolbarWrapper.jsx';
@@ -97,6 +98,7 @@ export default function Main() {
       <ProfileModal />
       <NewModal />
       <LoadingSceneModal />
+      <ExportingSceneModal />
       <AssetDeepLinkModal />
       <JobHealthModal />
       <LoadScript

--- a/src/editor/components/modals/ExportingSceneModal/ExportingSceneModal.component.jsx
+++ b/src/editor/components/modals/ExportingSceneModal/ExportingSceneModal.component.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import useStore from '@/store';
+import { Loader } from '@shared/icons';
+import styles from './ExportingSceneModal.module.scss';
+
+const TIMEOUT_MS = 60000;
+
+/**
+ * Full-screen blocking indicator shown while a GLB/glTF export is running
+ * (issue #1797). Same saving/loading style as LoadingSceneModal. Export runs
+ * on the main thread and can take several seconds on large scenes; this keeps
+ * the user informed and prevents interaction with a scene that has been
+ * temporarily mutated for export (helpers hidden, BatchedMeshes expanded).
+ */
+const ExportingSceneModal = () => {
+  const isExportingScene = useStore((state) => state.isExportingScene);
+  const message = useStore((state) => state.exportingSceneMessage);
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    if (isExportingScene) {
+      // Safety valve: if the exporter never fires either callback, quietly
+      // dismiss so the UI is never permanently blocked.
+      timeoutRef.current = setTimeout(() => {
+        useStore.getState().finishExportingScene();
+      }, TIMEOUT_MS);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [isExportingScene]);
+
+  if (!isExportingScene) return null;
+
+  return (
+    <div className={styles.exportingModalWrapper}>
+      <div className={styles.spinnerBox}>
+        <Loader className={styles.spinner} />
+      </div>
+      <span className={styles.message}>{message}</span>
+    </div>
+  );
+};
+
+export { ExportingSceneModal };

--- a/src/editor/components/modals/ExportingSceneModal/ExportingSceneModal.module.scss
+++ b/src/editor/components/modals/ExportingSceneModal/ExportingSceneModal.module.scss
@@ -1,0 +1,46 @@
+@use '../../../style/variables.scss';
+
+.exportingModalWrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 10001;
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+  width: 100vw;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.7);
+  pointer-events: all;
+}
+
+.spinnerBox {
+  display: flex;
+  max-width: 100px;
+  max-height: 100px;
+  padding: 20px;
+  background-color: rgba(21, 21, 21, 0.7);
+  border-radius: 50%;
+
+  .spinner {
+    animation: spin 1s linear infinite;
+  }
+}
+
+.message {
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 400;
+  color: variables.$white;
+}
+
+@keyframes spin {
+  from {
+    transform: rotateZ(0deg);
+  }
+  to {
+    transform: rotateZ(359deg);
+  }
+}

--- a/src/editor/components/modals/ExportingSceneModal/index.js
+++ b/src/editor/components/modals/ExportingSceneModal/index.js
@@ -1,0 +1,1 @@
+export { ExportingSceneModal } from './ExportingSceneModal.component.jsx';

--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -128,6 +128,8 @@ const AppMenu = ({ currentUser }) => {
     setGeojsonImportData,
     setRightPanelTab,
     startCheckout,
+    startExportingScene,
+    finishExportingScene,
     locale,
     setLocale
   } = useStore();
@@ -188,7 +190,21 @@ const AppMenu = ({ currentUser }) => {
   };
 
   const exportSceneToGLTF = (arReady) => {
-    if (authUser?.isPro) {
+    if (!authUser?.isPro) {
+      startCheckout('export');
+      return;
+    }
+    // Blocking saving-style indicator (issue #1797) — export runs on the
+    // main thread and can take several seconds on large scenes.
+    startExportingScene(
+      intl.formatMessage({
+        id: 'appMenu.export.exportingGlb',
+        defaultMessage: 'Exporting scene as GLB file...'
+      })
+    );
+    // Defer the export so the indicator paints before the heavy synchronous
+    // export work blocks the main thread.
+    setTimeout(() => {
       let restoreExportScene;
       try {
         posthog.capture('export_initiated', {
@@ -222,58 +238,83 @@ const AppMenu = ({ currentUser }) => {
             filterHelpers(scene, true);
             filterRiggedEntities(scene, true);
 
-            // Lazy-load the GLB post-processing helpers. They pull in the heavy
-            // @gltf-transform/* libraries, which we keep out of the core bundle
-            // (loaded only when a user actually exports a GLB) to stay under the
-            // webpack entrypoint size budget.
-            const { transformUVs, addGLBMetadata } =
-              await import('../modals/ScreenshotModal/gltfTransforms');
+            try {
+              // Lazy-load the GLB post-processing helpers. They pull in the heavy
+              // @gltf-transform/* libraries, which we keep out of the core bundle
+              // (loaded only when a user actually exports a GLB) to stay under the
+              // webpack entrypoint size budget.
+              const { transformUVs, addGLBMetadata } =
+                await import('../modals/ScreenshotModal/gltfTransforms');
 
-            let finalBuffer = buffer;
+              let finalBuffer = buffer;
 
-            // Post-process GLB if AR Ready option is selected
-            if (arReady) {
-              try {
-                finalBuffer = await transformUVs(buffer);
-                console.log('Successfully post-processed GLB file');
-              } catch (error) {
-                console.warn('Error in GLB post-processing:', error);
-                // Fall back to original buffer if post-processing fails
-                STREET.notify.warningMessage(
-                  intl.formatMessage({
-                    id: 'appMenu.export.uvTransformSkipped',
-                    defaultMessage:
-                      'UV transformation skipped - using original export'
-                  })
+              // Post-process GLB if AR Ready option is selected
+              if (arReady) {
+                try {
+                  finalBuffer = await transformUVs(buffer);
+                  console.log('Successfully post-processed GLB file');
+                } catch (error) {
+                  console.warn('Error in GLB post-processing:', error);
+                  // Fall back to original buffer if post-processing fails
+                  STREET.notify.warningMessage(
+                    intl.formatMessage({
+                      id: 'appMenu.export.uvTransformSkipped',
+                      defaultMessage:
+                        'UV transformation skipped - using original export'
+                    })
+                  );
+                }
+              }
+
+              // fetch metadata from scene
+              const geoLayer = document.getElementById('reference-layers');
+              if (geoLayer && geoLayer.hasAttribute('street-geo')) {
+                const metadata = {
+                  longitude: geoLayer.getAttribute('street-geo').longitude,
+                  latitude: geoLayer.getAttribute('street-geo').latitude,
+                  orthometricHeight:
+                    geoLayer.getAttribute('street-geo').orthometricHeight,
+                  geoidHeight: geoLayer.getAttribute('street-geo').geoidHeight,
+                  ellipsoidalHeight:
+                    geoLayer.getAttribute('street-geo').ellipsoidalHeight,
+                  orientation: 270
+                };
+                finalBuffer = await addGLBMetadata(finalBuffer, metadata);
+                console.log(
+                  'Successfully added geospatial metadata to GLB file'
                 );
               }
+              const blob = new Blob([finalBuffer], {
+                type: 'application/octet-stream'
+              });
+              saveBlob(blob, sceneName + '.glb');
+              STREET.notify.successMessage(
+                intl.formatMessage({
+                  id: 'appMenu.export.gltfSuccess',
+                  defaultMessage: '3DStreet scene exported as glTF file.'
+                })
+              );
+            } catch (error) {
+              console.error(error);
+              STREET.notify.errorMessage(
+                intl.formatMessage(
+                  {
+                    id: 'appMenu.export.gltfError',
+                    defaultMessage:
+                      'Error while trying to save glTF file. Error: {error}'
+                  },
+                  { error: error?.message ?? String(error) }
+                )
+              );
+            } finally {
+              finishExportingScene();
             }
-
-            // fetch metadata from scene
-            const geoLayer = document.getElementById('reference-layers');
-            if (geoLayer && geoLayer.hasAttribute('street-geo')) {
-              const metadata = {
-                longitude: geoLayer.getAttribute('street-geo').longitude,
-                latitude: geoLayer.getAttribute('street-geo').latitude,
-                orthometricHeight:
-                  geoLayer.getAttribute('street-geo').orthometricHeight,
-                geoidHeight: geoLayer.getAttribute('street-geo').geoidHeight,
-                ellipsoidalHeight:
-                  geoLayer.getAttribute('street-geo').ellipsoidalHeight,
-                orientation: 270
-              };
-              finalBuffer = await addGLBMetadata(finalBuffer, metadata);
-              console.log('Successfully added geospatial metadata to GLB file');
-            }
-            const blob = new Blob([finalBuffer], {
-              type: 'application/octet-stream'
-            });
-            saveBlob(blob, sceneName + '.glb');
           },
           function (error) {
             restoreExportScene();
             filterHelpers(scene, true);
             filterRiggedEntities(scene, true);
+            finishExportingScene();
             console.error(error);
             STREET.notify.errorMessage(
               intl.formatMessage(
@@ -288,14 +329,9 @@ const AppMenu = ({ currentUser }) => {
           },
           { binary: true }
         );
-        STREET.notify.successMessage(
-          intl.formatMessage({
-            id: 'appMenu.export.gltfSuccess',
-            defaultMessage: '3DStreet scene exported as glTF file.'
-          })
-        );
       } catch (error) {
         restoreExportScene?.();
+        finishExportingScene();
         STREET.notify.errorMessage(
           intl.formatMessage(
             {
@@ -308,9 +344,7 @@ const AppMenu = ({ currentUser }) => {
         );
         console.error(error);
       }
-    } else {
-      startCheckout('export');
-    }
+    }, 50);
   };
 
   const exportSceneToJSON = () => {

--- a/src/editor/i18n/locales/.translation-manifest.json
+++ b/src/editor/i18n/locales/.translation-manifest.json
@@ -584,7 +584,8 @@
     "save.savedSaveAgain": "Scene saved to cloud, press to save again",
     "save.saving": "Saving...",
     "undoRedo.redo": "Redo",
-    "undoRedo.undo": "Undo"
+    "undoRedo.undo": "Undo",
+    "appMenu.export.exportingGlb": "Exporting scene as GLB file..."
   },
   "fr": {
     "actionBar.handTool": "Hand Tool (h) - pan and rotate the view without selecting objects",
@@ -1171,7 +1172,8 @@
     "save.savedSaveAgain": "Scene saved to cloud, press to save again",
     "save.saving": "Saving...",
     "undoRedo.redo": "Redo",
-    "undoRedo.undo": "Undo"
+    "undoRedo.undo": "Undo",
+    "appMenu.export.exportingGlb": "Exporting scene as GLB file..."
   },
   "pt-BR": {
     "actionBar.handTool": "Hand Tool (h) - pan and rotate the view without selecting objects",
@@ -1758,6 +1760,7 @@
     "save.savedSaveAgain": "Scene saved to cloud, press to save again",
     "save.saving": "Saving...",
     "undoRedo.redo": "Redo",
-    "undoRedo.undo": "Undo"
+    "undoRedo.undo": "Undo",
+    "appMenu.export.exportingGlb": "Exporting scene as GLB file..."
   }
 }

--- a/src/editor/i18n/locales/en.json
+++ b/src/editor/i18n/locales/en.json
@@ -188,6 +188,9 @@
   "appMenu.export.arReadyGlb": {
     "defaultMessage": "AR Ready GLB"
   },
+  "appMenu.export.exportingGlb": {
+    "defaultMessage": "Exporting scene as GLB file..."
+  },
   "appMenu.export.glb": {
     "defaultMessage": "GLB glTF"
   },

--- a/src/editor/i18n/locales/es.json
+++ b/src/editor/i18n/locales/es.json
@@ -62,6 +62,7 @@
   "addLayer.unsupportedFileType": "Tipo de archivo no compatible: {fileName}. Formatos admitidos: GLB, GLTF, JPG, PNG, WebP, AVIF, PLY, SPLAT, SPZ.",
   "aiChatPanel.inputPlaceholder": "Escribe un comando o escribe /help para ver las opciones",
   "appMenu.export.arReadyGlb": "GLB listo para AR",
+  "appMenu.export.exportingGlb": "Exportando escena como archivo GLB...",
   "appMenu.export.glb": "GLB glTF",
   "appMenu.export.gltfError": "Error al intentar guardar el archivo glTF. Error: {error}",
   "appMenu.export.gltfSuccess": "Escena de 3DStreet exportada como archivo glTF.",

--- a/src/editor/i18n/locales/fr.json
+++ b/src/editor/i18n/locales/fr.json
@@ -62,6 +62,7 @@
   "addLayer.unsupportedFileType": "Type de fichier non pris en charge : {fileName}. Formats pris en charge : GLB, GLTF, JPG, PNG, WebP, AVIF, PLY, SPLAT, SPZ.",
   "aiChatPanel.inputPlaceholder": "Tapez une commande ou tapez /help pour voir les options",
   "appMenu.export.arReadyGlb": "GLB prêt pour l'AR",
+  "appMenu.export.exportingGlb": "Exportation de la scène en fichier GLB...",
   "appMenu.export.glb": "GLB glTF",
   "appMenu.export.gltfError": "Erreur lors de l'enregistrement du fichier glTF. Erreur : {error}",
   "appMenu.export.gltfSuccess": "Scène 3DStreet exportée en fichier glTF.",

--- a/src/editor/i18n/locales/pt-BR.json
+++ b/src/editor/i18n/locales/pt-BR.json
@@ -62,6 +62,7 @@
   "addLayer.unsupportedFileType": "Tipo de arquivo não suportado: {fileName}. Formatos suportados: GLB, GLTF, JPG, PNG, WebP, AVIF, PLY, SPLAT, SPZ.",
   "aiChatPanel.inputPlaceholder": "Digite um comando ou digite /help para ver as opções",
   "appMenu.export.arReadyGlb": "GLB pronto para AR",
+  "appMenu.export.exportingGlb": "Exportando cena como arquivo GLB...",
   "appMenu.export.glb": "GLB glTF",
   "appMenu.export.gltfError": "Erro ao tentar salvar o arquivo glTF. Erro: {error}",
   "appMenu.export.gltfSuccess": "Cena do 3DStreet exportada como arquivo glTF.",

--- a/src/store.js
+++ b/src/store.js
@@ -102,6 +102,18 @@ const useStore = create(
             loadingSceneError: errorMessage,
             loadingSceneMessage: 'Error loading scene'
           }),
+        // Blocking overlay shown while a GLB/glTF export is running (issue
+        // #1797). Export work happens on the main thread and can take several
+        // seconds on large scenes, so we surface a saving-style indicator.
+        isExportingScene: false,
+        exportingSceneMessage: '',
+        startExportingScene: (message) =>
+          set({
+            isExportingScene: true,
+            exportingSceneMessage: message || 'Exporting scene...'
+          }),
+        finishExportingScene: () =>
+          set({ isExportingScene: false, exportingSceneMessage: '' }),
         sceneTitle: null,
         setSceneTitle: (newSceneTitle) => set({ sceneTitle: newSceneTitle }),
         locationString: null,


### PR DESCRIPTION
- New ExportingSceneModal: full-screen spinner + message overlay in the same style as LoadingSceneModal, with a 60s safety-valve dismiss
- Store: isExportingScene / exportingSceneMessage state with startExportingScene / finishExportingScene actions
- AppMenu exportSceneToGLTF: show the indicator before export, defer the heavy synchronous export work so the overlay paints first, and dismiss it on every terminal path (success, exporter error, post-processing error, sync throw)
- Move the export success toast into the exporter success callback so it no longer fires before the export has actually finished


Claude-Session: https://claude.ai/code/session_016NTYiWKwci2pjnCwQ3yHQu