### PR TITLE
chore(readme): fix stale npm version badge, use calver from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # 3DStreet
-[![Version](http://img.shields.io/npm/v/3dstreet.svg)](https://npmjs.org/package/3dstreet)
-[![License](http://img.shields.io/npm/l/3dstreet.svg)](LICENSE)
+[![Version](https://img.shields.io/github/package-json/v/3DStreet/3dstreet)](https://github.com/3DStreet/3dstreet/commits/main)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 [![Build Status](https://github.com/3DStreet/3dstreet/actions/workflows/ci.yml/badge.svg)](https://github.com/3DStreet/3dstreet/actions/workflows/ci.yml)
 
 3DStreet is an open-source geospatial design application for creating urban planning scenes with detailed street configurations. Based on three.js and A-Frame, 3DStreet empowers users to rapidly prototype custom urban design scenarios using procedural street design tools combined with a rich library of accurately scaled and oriented creative-commons licensed 3D models. 


### PR DESCRIPTION
The README version badge pointed at the `3dstreet` npm package, which is frozen at 0.4.15 (we no longer publish releases to npm). It now reads the calver version straight from `package.json` on main via shields.io, currently rendering v2026.6.0, and links to the commit history. The license badge also sourced from npm; GitHub can't auto-classify our dual AGPL-3.0/CC BY-NC LICENSE file, so it's now a static AGPL-3.0 badge linking to LICENSE. CI badge unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)