### PR TITLE
Fix GLB export post-processing failing with EXT_texture_webp on webp-textured scenes

### DIFF
--- a/src/editor/components/modals/ScreenshotModal/gltfTransforms.js
+++ b/src/editor/components/modals/ScreenshotModal/gltfTransforms.js
@@ -1,15 +1,13 @@
 import { NodeIO } from '@gltf-transform/core';
-import {
-  KHRXMP,
-  ALL_EXTENSIONS,
-  KHRTextureTransform
-} from '@gltf-transform/extensions';
+import { KHRXMP, ALL_EXTENSIONS } from '@gltf-transform/extensions';
 import { vec3, mat3 } from 'gl-matrix';
 
-async function transformUVs(glbBuffer) {
+export async function transformUVs(glbBuffer) {
   try {
-    // Initialize IO with extension
-    const io = new NodeIO().registerExtensions([KHRTextureTransform]);
+    // ALL_EXTENSIONS so required extensions in the exporter output (e.g.
+    // EXT_texture_webp, emitted for textures loaded from webp images) don't
+    // make readBinary throw "Missing required extension".
+    const io = new NodeIO().registerExtensions(ALL_EXTENSIONS);
 
     // Read the buffer directly instead of file
     const document = await io.readBinary(new Uint8Array(glbBuffer));
@@ -69,9 +67,7 @@ async function transformUVs(glbBuffer) {
   }
 }
 
-export { transformUVs };
-
-async function addGLBMetadata(glbBuffer, metadata) {
+export async function addGLBMetadata(glbBuffer, metadata) {
   try {
     const io = new NodeIO().registerExtensions(ALL_EXTENSIONS);
     // Create an Extension attached to the Document.
@@ -101,5 +97,3 @@ async function addGLBMetadata(glbBuffer, metadata) {
     throw error;
   }
 }
-
-export { addGLBMetadata };

--- a/test/components/gltf-transforms.test.js
+++ b/test/components/gltf-transforms.test.js
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+// The editor's exporter copy: the npm `three` package, NOT window.THREE (A-Frame's bundled
+// super-three) — mirrors production, where the exporter serializes the live scene graph.
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter';
+
+let THREE;
+let transformUVs;
+let addGLBMetadata;
+
+beforeAll(async () => {
+  window.AFRAME_ASYNC = true;
+  await import('aframe');
+  THREE = window.THREE;
+  ({ transformUVs, addGLBMetadata } =
+    await import('../../src/editor/components/modals/ScreenshotModal/gltfTransforms.js'));
+  window.AFRAME.emitReady?.();
+});
+
+// A scene with one textured mesh whose texture was "loaded from a webp image":
+// GLTFLoader stamps userData.mimeType on textures it loads, and GLTFExporter keeps
+// such textures as webp and marks EXT_texture_webp as a REQUIRED extension.
+function makeWebpTexturedScene() {
+  const scene = new THREE.Scene();
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 4;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#f00';
+  ctx.fillRect(0, 0, 4, 4);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.userData.mimeType = 'image/webp';
+  const material = new THREE.MeshBasicMaterial({ map: texture });
+  scene.add(new THREE.Mesh(new THREE.BoxGeometry(), material));
+  return scene;
+}
+
+function exportGlb(scene) {
+  return new Promise((resolve, reject) => {
+    new GLTFExporter().parse(scene, resolve, reject, { binary: true });
+  });
+}
+
+describe('gltfTransforms on a GLB with webp textures', () => {
+  it('post-processes a GLB whose exporter output requires EXT_texture_webp', async () => {
+    const glb = await exportGlb(makeWebpTexturedScene());
+    // Sanity: the exporter really did declare the required extension the reader
+    // must have registered (the JSON chunk lives at the start of the GLB).
+    const json = new TextDecoder().decode(new Uint8Array(glb));
+    expect(json).toContain('EXT_texture_webp');
+
+    const transformed = await transformUVs(glb);
+    expect(transformed.byteLength).toBeGreaterThan(0);
+
+    const withMetadata = await addGLBMetadata(transformed.buffer, {
+      longitude: 1,
+      latitude: 2
+    });
+    expect(withMetadata.byteLength).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

GLB export post-processing (`transformUVs` in `ScreenshotModal/gltfTransforms.js`) failed with:

```
Error: Missing required extension, "EXT_texture_webp".
```

on any scene containing assets with webp textures (most 3DStreet assets).

## Why

three r184's GLTFExporter keeps textures loaded from webp images as webp — GLTFLoader stamps `texture.userData.mimeType`, and the exporter then declares `EXT_texture_webp` in `extensionsRequired`. glTF-Transform's `readBinary` throws for any *required* extension not registered on the IO, and `transformUVs` only registered `KHRTextureTransform`. Fix: register `ALL_EXTENSIONS`, as `addGLBMetadata` in the same file already does.

Also inlines the `export` statements with the function declarations in `gltfTransforms.js`.

## Testing

New browser-mode regression test (`test/components/gltf-transforms.test.js`) exports a scene with a webp-stamped texture, asserts the GLB declares `EXT_texture_webp`, then runs `transformUVs` + `addGLBMetadata` on it. Verified the test fails with exactly the production error when the fix is reverted. `npm run test:components` (34 passed) and `npm run lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)