### PR TITLE
feat(email): lifecycle email foundation — emailLog, send service, Postmark streams (P0 PR 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ The cloud URL lives in `gltf-model` / `src`. Firebase Storage download tokens al
 
 **Test:** `npm test` (Mocha + Vitest), `npm run lint`, `npm run prettier`
 
-**Firestore rules tests:** `npm run test:rules` — local-only (boots the firestore emulator via `firebase emulators:exec`, runs vitest against `test/rules/`). Not wired into CI to keep CI cheap; run manually when touching `public/firestore.rules`. Requires JDK 21+ on `PATH` (Firestore emulator dependency).
+**Firestore emulator tests:** `npm run test:rules` — local-only (boots the firestore + auth emulators via `firebase emulators:exec`, runs vitest against `test/rules/`). Covers security rules AND the lifecycle email send service (`sendLifecycleEmail`). Not wired into CI to keep CI cheap; run manually when touching `public/firestore.rules` or `public/functions/email/`. Requires JDK 21+ on `PATH` (emulator dependency; if `java -version` shows an older default, prefix with `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"`).
 
 **Deploy:** `npm run deploy` or `npm run deploy:staging`
 

--- a/docs/email-lifecycle-p0-plan.md
+++ b/docs/email-lifecycle-p0-plan.md
@@ -1,0 +1,84 @@
+# Email Lifecycle P0 — Implementation Plan (draft)
+
+**Status:** PR 1 in review (`feat/email-lifecycle-pr1-foundation`) · **Created:** 2026-07-06
+**Goal:** ship the P0 lifecycle email wave on Postmark with in-repo orchestration, building on the existing `scheduledEmails.js` system. Mailchimp decommission is the end state (Phase 3).
+
+## Inputs (read these first)
+
+- **Phase 0 audit (start here):** `~/dev/3dstreet-private/reports/email-lifecycle-phase0-audit-2026-07-06.md` — trigger inventory, Firestore state, Postmark/Stripe/Mailchimp account state, volumes, gap list.
+- **Spec / architecture decisions:** Google Doc `1VA9AvNQyaLhWEOVPmYENIP-KuX8PDjKOxYaXzU33Jvc` ("Lifecycle Email System: Audit + Build").
+- **P0 email copy:** Google Doc `1oT0RgoAgC7TFJbcMJCLlxw-ITzCFm0r733oEa_YzIm8` (3DStreet_P0_Emails.md).
+- **Prioritization sheet:** Google Sheet `11vK-xi3B92lzbgy-GLTWoka8ppyV5MhoD6gkGW7_zBM`.
+- **Existing system:** `public/functions/scheduled/scheduledEmails.js` + `public/functions/scheduled/SCHEDULED_EMAILS_SYSTEM.md`.
+
+## Fixed decisions (from spec + audit)
+
+1. Postmark only; Mailchimp removed at the end. Templates stay **in-repo** (inline HTML as today; no Postmark-hosted templates).
+2. Two routing rules: **transactional** → existing `outbound` stream, no unsubscribe (Welcome, Failed Payment, Post-Upgrade Welcome). **Marketing/behavioral** → broadcast streams with Postmark-managed unsubscribe (Checkout Abandoned, Pricing Page, Geo Not Used).
+3. Broadcast streams double as the category preference center: create `conversion` and `lifecycle` streams for P0 (create `expansion` / `re-engagement` when P1 needs them). Wire Postmark's **Subscription Change webhook** → Firestore.
+4. Orchestration lives in Cloud Functions + Firestore `emailLog`; eligibility and stop-rules are code.
+5. Don't over-build: if orchestration outgrows a few hundred lines, flag for a purpose-built ESP instead.
+
+## P0 emails, triggers, and stop-rules
+
+| # | Email | Stream | Trigger | Stop-rules |
+|---|-------|--------|---------|-----------|
+| 1 | Welcome | outbound (transactional) | new Firebase Auth user | once ever |
+| 2 | Post-Upgrade Welcome | outbound | `checkout.session.completed` (existing `stripeWebhook`) | once per upgrade |
+| 3 | Failed Payment | outbound | `invoice.payment_failed` (new webhook event) | max 1 per invoice; stop if paid |
+| 4 | Checkout Abandoned 1h | conversion (broadcast) | checkout session open >1h (new `checkoutSessions` record + sweep) | stop if completed/upgraded; once per session; ≤1 per user per 7d |
+| 5 | Checkout Abandoned 72h | conversion | same, >72h | **build but ship disabled** (flag); skip if 1h converted |
+| 6 | Pricing Page, No Checkout | conversion | payment modal opened, no checkout within 24h (see open decision D2) | once per user per 30d; stop if upgraded |
+| 7 | Activation: Geo Not Used | lifecycle (broadcast) | signed up ≥3d ago, never activated geo (needs `firstGeoActivatedAt`, see PR 2) | once ever; stop if activated or Pro |
+
+## PR sequence
+
+### PR 1 — Foundation: `emailLog` + send service + streams ✅ (in review)
+
+- ✅ `emailLog/{uid}` summary doc (per-email `lastSentAt`/`sentCount`/`dedupeKeys` + per-category `lastSentAt`) backs stop-rules in one read; `emailLog/{uid}/sends/{autoId}` is the append-only audit (`{ emailId, category, stream, to, subject, dedupeKey, status, messageId, sentAt }`). This resolves **D3**: one summary doc per uid (not flat `{uid}_{emailId}`) so the "≤1 per category per 7d" check needs no query, + the sends subcollection. `notifyLog` untouched (tokenExhaustion back-compat).
+- ✅ `sendLifecycleEmail({ db, uid, emailId, category, stream, template, data, rules, dedupeKey, dryRun })` in `public/functions/email/lifecycle-email.js`; stop-rules are a pure module (`email/stop-rules.js`, unit-tested: `onceEver`, `notWithinDays`, `categoryNotWithinDays`, `stopIfPro`, `dedupeKey`). Claim happens in a transaction (safe under Stripe webhook retries), rolled back on Postmark failure. Broadcast sends get an `{{{ pm:unsubscribe_url }}}` footer + `emailPrefs` check.
+- ✅ Firestore rules: `emailLog` (+ `sends`) and `emailPrefs` cloud-only, with rules tests.
+- ✅ `postmarkSubscriptionWebhook` — Basic-auth-gated (secret `POSTMARK_WEBHOOK_AUTH`), writes per-stream opt-outs to `emailPrefs/{uid}` via Auth email lookup.
+- ✅ `triggerLifecycleEmail` admin callable + `adminTools.testLifecycleEmail()` console helper — end-to-end pipeline test (`testPing` email, dry-run default, stream selectable).
+- **Manual (Kieran, Postmark dashboard):** create `conversion` + `lifecycle` broadcast streams (stream IDs must be exactly those strings); set secret `firebase functions:secrets:set POSTMARK_WEBHOOK_AUTH` (value `user:pass`); after deploy, add Subscription Change webhook on both broadcast streams pointing at `https://user:pass@<region>-<project>.cloudfunctions.net/postmarkSubscriptionWebhook`. Confirm DKIM status while in there (audit couldn't check: server token only).
+
+### PR 2 — Trigger instrumentation
+
+- `createStripeSession`: write `checkoutSessions/{sessionId}` `{ userId, email, plan, createdAt, status:'open' }` (cloud-only rules); `stripeWebhook` marks `status:'complete'`.
+- Refactor `stripeWebhook` to switch on `event.type` (today it blindly assumes checkout.session.completed — see audit) and subscribe the endpoint to `invoice.payment_failed` (+ optionally `checkout.session.expired` for hygiene). **Manual:** update the webhook's enabled events in Stripe dashboard or via API.
+- `geoid-height.js`: set `firstGeoActivatedAt` on `tokenProfile` at the existing decrement site (also set for Pro users who skip decrement).
+- Note: firebase-functions is pinned ^13-compatible in `public/functions` — check before adding v2 auth triggers (see D1).
+
+### PR 3 — Transactional wave (emails 1–3)
+
+- Templates from the P0 copy doc into `EMAIL_TEMPLATES` (or a new `templates/` module).
+- Post-Upgrade Welcome: event-driven send inside `stripeWebhook` (pattern: `sendGenerationReadyEmail`).
+- Failed Payment: send from the new `invoice.payment_failed` handler; resolve uid via `userProfile.stripeCustomerId`.
+- Welcome: trigger per decision D1.
+
+### PR 4 — Broadcast wave (emails 4–7)
+
+- New sweep (either extend `sendScheduledEmails` or a second hourly cron — abandoned-1h needs hourly granularity, the daily 9am cron is too coarse):
+  - Checkout Abandoned 1h (+72h behind a flag), from `checkoutSessions`.
+  - Geo Not Used, from Auth `creationTime` + `firstGeoActivatedAt`.
+  - Pricing Page nudge per D2.
+- Route through broadcast streams so Postmark injects unsubscribe; check `emailPrefs` before send.
+
+### PR 5 / Phase 3 — Mailchimp decommission (separate effort)
+
+- **Blocked on:** locating the Firebase→Mailchimp sync (not in code — check Mailchimp Integrations / Zapier).
+- Move newsletter to a `newsletter` broadcast stream (drafts already in `3dstreet-private/newsletters/`); import Mailchimp unsubscribes into stream suppressions before first send; cancel Mailchimp (~$150/mo).
+
+## Open decisions (resolve before/at PR 3)
+
+- **D1 Welcome trigger:** Auth `onCreate` function (instant, but new users only) vs. hourly sweep via Admin `listUsers` (also catches backlog; slight delay). Lean: `onCreate` + no backfill.
+- **D2 Pricing Page signal:** the only signal today is client-side PostHog (`modal_opened {modal:'payment'}`, `checkout_started`). Options: (a) cron queries PostHog API (needs personal API key as a function secret), (b) add a tiny server-side counter (callable or Firestore write from client on modal open) and keep orchestration Firestore-only. Lean: (b) — one field `lastPaymentModalAt` on `tokenProfile`, no PostHog dependency.
+- **D3 emailLog shape:** ~~subcollection per user vs. flat collection~~ **Resolved in PR 1:** summary doc `emailLog/{uid}` (all stop-rule state in one transactional read) + `sends` audit subcollection.
+
+## Testing / rollout
+
+- Unit: stop-rule logic (pure functions). Rules: `npm run test:rules` (JDK 21+).
+- Dry-run every new email type via `triggerScheduledEmails`-style admin callable before enabling.
+- Stripe: replay events with Stripe CLI (`stripe trigger invoice.payment_failed`) against the deployed dev project.
+- Deploy to dev project first; verify sends land in Postmark activity with correct stream; then prod.
+- Volumes are tiny (~11 signups/day, ~1 abandoned checkout/2 days) — monitor the first week manually via Postmark activity.

--- a/docs/email-lifecycle-p0-plan.md
+++ b/docs/email-lifecycle-p0-plan.md
@@ -5,6 +5,8 @@
 
 ## Inputs (read these first)
 
+Note: several inputs live in the private ops repo (`3dstreet-private`) or in access-controlled Google Docs — paths/IDs below are for Kieran (and agents running on his machine), not resolvable from this public repo alone.
+
 - **Phase 0 audit (start here):** `~/dev/3dstreet-private/reports/email-lifecycle-phase0-audit-2026-07-06.md` — trigger inventory, Firestore state, Postmark/Stripe/Mailchimp account state, volumes, gap list.
 - **Spec / architecture decisions:** Google Doc `1VA9AvNQyaLhWEOVPmYENIP-KuX8PDjKOxYaXzU33Jvc` ("Lifecycle Email System: Audit + Build").
 - **P0 email copy:** Google Doc `1oT0RgoAgC7TFJbcMJCLlxw-ITzCFm0r733oEa_YzIm8` (3DStreet_P0_Emails.md).
@@ -35,9 +37,9 @@
 
 ### PR 1 — Foundation: `emailLog` + send service + streams ✅ (in review)
 
-- ✅ `emailLog/{uid}` summary doc (per-email `lastSentAt`/`sentCount`/`dedupeKeys` + per-category `lastSentAt`) backs stop-rules in one read; `emailLog/{uid}/sends/{autoId}` is the append-only audit (`{ emailId, category, stream, to, subject, dedupeKey, status, messageId, sentAt }`). This resolves **D3**: one summary doc per uid (not flat `{uid}_{emailId}`) so the "≤1 per category per 7d" check needs no query, + the sends subcollection. `notifyLog` untouched (tokenExhaustion back-compat).
+- ✅ `emailLog/{uid}` summary doc (per-email `lastSentAt`/`sentCount`/`dedupeKeys` + per-category `lastSentAt`) backs stop-rules in one read; `emailLog/{uid}/sends/{autoId}` is the audit (`{ emailId, category, stream, to, subject, dedupeKey, status, messageId, createdAt, sentAt }`); `status` goes `pending` (written atomically with the claim) → `sent`/`error`, so a record stuck on `pending` is the detectable signal of an instance dying mid-send (claim survives, no email — accepted crash window at current volumes, no orphan sweep yet). This resolves **D3**: one summary doc per uid (not flat `{uid}_{emailId}`) so the "≤1 per category per 7d" check needs no query, + the sends subcollection. `notifyLog` untouched (tokenExhaustion back-compat).
 - ✅ `sendLifecycleEmail({ db, uid, emailId, category, stream, template, data, rules, dedupeKey, dryRun })` in `public/functions/email/lifecycle-email.js`; stop-rules are a pure module (`email/stop-rules.js`, unit-tested: `onceEver`, `notWithinDays`, `categoryNotWithinDays`, `stopIfPro`, `dedupeKey`). Claim happens in a transaction (safe under Stripe webhook retries), rolled back on Postmark failure. Broadcast sends get an `{{{ pm:unsubscribe_url }}}` footer + `emailPrefs` check.
-- ✅ Firestore rules: `emailLog` (+ `sends`) and `emailPrefs` cloud-only, with rules tests.
+- ✅ Firestore rules: `emailLog` (+ `sends`) and `emailPrefs` cloud-only, with rules tests. Emulator-backed tests for `sendLifecycleEmail` itself (claim + audit records, failure rollback, suppression, unsubscribe footer, concurrent idempotency) run in the same `npm run test:rules` suite (now boots firestore + auth emulators).
 - ✅ `postmarkSubscriptionWebhook` — Basic-auth-gated (secret `POSTMARK_WEBHOOK_AUTH`), writes per-stream opt-outs to `emailPrefs/{uid}` via Auth email lookup.
 - ✅ `triggerLifecycleEmail` admin callable + `adminTools.testLifecycleEmail()` console helper — end-to-end pipeline test (`testPing` email, dry-run default, stream selectable).
 - **Manual (Kieran, Postmark dashboard):** create `conversion` + `lifecycle` broadcast streams (stream IDs must be exactly those strings); set secret `firebase functions:secrets:set POSTMARK_WEBHOOK_AUTH` (value `user:pass`); after deploy, add Subscription Change webhook on both broadcast streams pointing at `https://user:pass@<region>-<project>.cloudfunctions.net/postmarkSubscriptionWebhook`. Confirm DKIM status while in there (audit couldn't check: server token only).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:components": "vitest run --config vitest.components.config.js",
     "test:components:watch": "vitest --config vitest.components.config.js",
     "test:setup": "npx playwright install chromium-headless-shell",
-    "test:rules": "cd public && firebase emulators:exec --only firestore --project demo-3dstreet-rules \"cd .. && vitest run --config vitest.rules.config.js\"",
+    "test:rules": "cd public && firebase emulators:exec --only firestore,auth --project demo-3dstreet-rules \"cd .. && vitest run --config vitest.rules.config.js\"",
     "prettier": "prettier --write 'src/**/*.js' 'src/**/*.jsx' 'src/**/*.scss'",
     "i18n:extract": "formatjs extract 'src/**/*.{js,jsx}' --ignore '**/*.d.ts' --out-file src/editor/i18n/locales/en.json --flatten && npm run i18n:extract:catalog",
     "i18n:extract:catalog": "node scripts/i18n/extract-catalog.mjs",

--- a/public/firebase.json
+++ b/public/firebase.json
@@ -53,6 +53,9 @@
     "firestore": {
       "port": 8080
     },
+    "auth": {
+      "port": 9099
+    },
     "hosting": {
       "port": 5002
     },

--- a/public/firestore.rules
+++ b/public/firestore.rules
@@ -107,6 +107,24 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // Lifecycle email log (PRIVATE - cloud functions only)
+    // Summary doc backs stop-rules (once-ever, cooldowns, dedupe keys);
+    // sends subcollection is the append-only audit of every attempted send.
+    // See public/functions/email/lifecycle-email.js.
+    match /emailLog/{userId} {
+      allow read, write: if false;
+      match /sends/{sendId} {
+        allow read, write: if false;
+      }
+    }
+
+    // Email preferences / suppression (PRIVATE - cloud functions only)
+    // Per-stream opt-out state mirrored from Postmark's Subscription Change
+    // webhook (postmarkSubscriptionWebhook); checked before broadcast sends.
+    match /emailPrefs/{userId} {
+      allow read, write: if false;
+    }
+
     // Asset usage doc (PRIVATE - cloud functions write, owner reads)
     // Maintained by onAssetWritten trigger; read by getUploadQuota and the
     // Assets panel storage meter.

--- a/public/functions/email/lifecycle-email.js
+++ b/public/functions/email/lifecycle-email.js
@@ -9,7 +9,14 @@
  *
  * Firestore (all cloud-only, see firestore.rules):
  *   emailLog/{uid}            — summary doc backing stop-rules (shape in stop-rules.js)
- *   emailLog/{uid}/sends/{id} — append-only audit of every attempted send
+ *   emailLog/{uid}/sends/{id} — audit of every attempted send. status is
+ *                               'pending' (claimed, Postmark call in flight;
+ *                               written atomically with the claim) → 'sent' or
+ *                               'error' (claim rolled back). A record stuck on
+ *                               'pending' means the instance died mid-send:
+ *                               the claim survives but no email went out —
+ *                               rare enough at current volumes that we surface
+ *                               it as data instead of building a sweep.
  *   emailPrefs/{uid}          — per-stream suppression state, written by
  *                               postmarkSubscriptionWebhook
  *
@@ -108,9 +115,24 @@ const sendLifecycleEmail = async ({
 
   const summaryRef = db.collection('emailLog').doc(uid);
 
+  const subject = template.getSubject(userInfo.displayName, data);
+  let htmlBody = template.getHtmlBody(userInfo.displayName, data);
+  let textBody = template.getTextBody(userInfo.displayName, data);
+  if (isBroadcast) {
+    htmlBody = htmlBody.includes('</body>')
+      ? htmlBody.replace('</body>', `${UNSUBSCRIBE_HTML}</body>`)
+      : htmlBody + UNSUBSCRIBE_HTML;
+    textBody += UNSUBSCRIBE_TEXT;
+  }
+
   // Transaction: evaluate stop-rules against the live summary doc and claim
-  // the send by writing it. `prevEntries` captures the pre-claim state so a
-  // failed Postmark call can roll the claim back.
+  // the send by writing it, atomically with a status:'pending' audit record.
+  // `prevEntries` captures the pre-claim state so a failed Postmark call can
+  // roll the claim back. If the instance dies between this commit and the
+  // Postmark response, the claim sticks and the audit record stays 'pending'
+  // forever — that's the detectable signal for a (future) orphan sweep; at
+  // current volumes we accept the tiny crash window rather than build one now.
+  const sendRef = summaryRef.collection('sends').doc();
   let outcome = null; // { action, reason } when blocked/dry-run; null → claimed
   let prevEntries = null;
   await db.runTransaction(async (tx) => {
@@ -158,20 +180,20 @@ const sendLifecycleEmail = async ({
       },
       { merge: true }
     );
+    tx.set(sendRef, {
+      emailId,
+      category,
+      stream,
+      to: userInfo.email,
+      subject,
+      dedupeKey,
+      status: 'pending',
+      createdAt: now
+    });
   });
 
   if (outcome) {
     return outcome;
-  }
-
-  const subject = template.getSubject(userInfo.displayName, data);
-  let htmlBody = template.getHtmlBody(userInfo.displayName, data);
-  let textBody = template.getTextBody(userInfo.displayName, data);
-  if (isBroadcast) {
-    htmlBody = htmlBody.includes('</body>')
-      ? htmlBody.replace('</body>', `${UNSUBSCRIBE_HTML}</body>`)
-      : htmlBody + UNSUBSCRIBE_HTML;
-    textBody += UNSUBSCRIBE_TEXT;
   }
 
   try {
@@ -182,13 +204,7 @@ const sendLifecycleEmail = async ({
       textBody,
       { stream }
     );
-    await summaryRef.collection('sends').add({
-      emailId,
-      category,
-      stream,
-      to: userInfo.email,
-      subject,
-      dedupeKey,
+    await sendRef.update({
       status: 'sent',
       messageId: result.MessageID || null,
       sentAt: admin.firestore.FieldValue.serverTimestamp()
@@ -199,27 +215,23 @@ const sendLifecycleEmail = async ({
     return { action: 'sent', messageId: result.MessageID };
   } catch (err) {
     // Roll the claim back so a retry/sweep isn't blocked by a send that never
-    // happened. Restoring the captured pre-claim entries can race another
-    // concurrent send of a *different* email to the same user (only the
-    // category entry overlaps); at current volumes that's acceptable.
+    // happened. update() with FieldPath replaces the ENTIRE entry (unlike
+    // set+merge, which would leave a freshly-added dedupeKey behind and block
+    // the retry forever); FieldPath segments are literal, so Stripe ids and
+    // other dotted keys are safe. Restoring the captured pre-claim entries can
+    // race another concurrent send of a *different* email to the same user
+    // (only the category entry overlaps); at current volumes that's acceptable.
+    const { FieldPath, FieldValue } = admin.firestore;
     await summaryRef
-      .set(
-        {
-          emails: { [emailId]: prevEntries.email },
-          categories: { [category]: prevEntries.category }
-        },
-        { merge: true }
+      .update(
+        new FieldPath('emails', emailId),
+        prevEntries.email ?? FieldValue.delete(),
+        new FieldPath('categories', category),
+        prevEntries.category ?? FieldValue.delete()
       )
       .catch(() => {});
-    await summaryRef
-      .collection('sends')
-      .add({
-        emailId,
-        category,
-        stream,
-        to: userInfo.email,
-        subject,
-        dedupeKey,
+    await sendRef
+      .update({
         status: 'error',
         error: String(err?.message || err),
         sentAt: admin.firestore.FieldValue.serverTimestamp()

--- a/public/functions/email/lifecycle-email.js
+++ b/public/functions/email/lifecycle-email.js
@@ -1,0 +1,411 @@
+/**
+ * Lifecycle email foundation (P0 wave, PR 1).
+ *
+ * One send path for every lifecycle email: suppression check → stop-rules
+ * (transactional claim on the emailLog summary doc) → Postmark send → audit
+ * record. Email *definitions* (templates + triggers) arrive in later PRs;
+ * this module only ships the plumbing plus a `testPing` definition so the
+ * whole pipeline can be exercised end-to-end via the admin callable.
+ *
+ * Firestore (all cloud-only, see firestore.rules):
+ *   emailLog/{uid}            — summary doc backing stop-rules (shape in stop-rules.js)
+ *   emailLog/{uid}/sends/{id} — append-only audit of every attempted send
+ *   emailPrefs/{uid}          — per-stream suppression state, written by
+ *                               postmarkSubscriptionWebhook
+ *
+ * Streams: 'outbound' is transactional (no unsubscribe). 'conversion' and
+ * 'lifecycle' are Postmark broadcast streams that double as the category
+ * preference center; broadcast sends get an unsubscribe footer appended and
+ * are checked against emailPrefs first. Postmark manages the unsubscribe UI
+ * and reports opt-outs back through the Subscription Change webhook.
+ */
+
+const functions = require('firebase-functions/v1');
+const admin = require('firebase-admin');
+const { getAuth } = require('firebase-admin/auth');
+const { assertAppCheck } = require('../app-check.js');
+const { isUserProInternal } = require('../token-management.js');
+const {
+  sendPostmarkEmail,
+  getUserInfo
+} = require('../scheduled/scheduledEmails.js');
+const { evaluateStopRules } = require('./stop-rules.js');
+
+const TRANSACTIONAL_STREAM = 'outbound';
+// Broadcast streams live in Postmark (created manually in the dashboard;
+// stream IDs must match these strings). Add 'expansion' / 're-engagement'
+// when P1 emails need them.
+const BROADCAST_STREAMS = ['conversion', 'lifecycle'];
+
+// Appended to broadcast-stream messages. Postmark replaces the placeholder
+// with a per-recipient, per-stream unsubscribe URL.
+const UNSUBSCRIBE_HTML = `
+  <p style="font-size: 12px; color: #999;">
+    Don't want these emails?
+    <a href="{{{ pm:unsubscribe_url }}}" style="color: #6366f1;">Unsubscribe</a>.
+  </p>`;
+const UNSUBSCRIBE_TEXT = `
+
+---
+Don't want these emails? Unsubscribe: {{{ pm:unsubscribe_url }}}`;
+
+/**
+ * Send one lifecycle email to one user, enforcing suppression + stop-rules.
+ *
+ * Idempotent under concurrent triggers (e.g. a retried Stripe webhook): the
+ * stop-rule check and the send claim happen in one Firestore transaction on
+ * emailLog/{uid}, so only one caller can claim a given send. On a Postmark
+ * failure the claim is rolled back so a later sweep can retry.
+ *
+ * @param {Object} p
+ * @param {Object} p.db - Firestore instance
+ * @param {string} p.uid - Firebase Auth uid of the recipient
+ * @param {string} p.emailId - stable id, e.g. 'welcome', 'checkoutAbandoned1h'
+ * @param {string} p.category - preference category, e.g. 'transactional', 'conversion'
+ * @param {string} p.stream - Postmark stream ('outbound' | broadcast stream id)
+ * @param {Object} p.template - { getSubject(name, data), getHtmlBody(name, data), getTextBody(name, data) }
+ * @param {Object} [p.data] - template data
+ * @param {Object} [p.rules] - stop-rules (see stop-rules.js)
+ * @param {string} [p.dedupeKey] - once-per-key guard (invoice id, session id)
+ * @param {boolean} [p.dryRun] - evaluate everything, claim and send nothing
+ * @returns {Promise<{action: 'sent'|'would-send'|'skipped'|'no-email'|'error', reason?: string, messageId?: string}>}
+ */
+const sendLifecycleEmail = async ({
+  db,
+  uid,
+  emailId,
+  category,
+  stream,
+  template,
+  data = {},
+  rules = {},
+  dedupeKey = null,
+  dryRun = false
+}) => {
+  const isBroadcast = stream !== TRANSACTIONAL_STREAM;
+  if (isBroadcast && !BROADCAST_STREAMS.includes(stream)) {
+    return { action: 'error', reason: `unknown stream: ${stream}` };
+  }
+
+  const userInfo = await getUserInfo(uid);
+  if (!userInfo?.email) {
+    return { action: 'no-email' };
+  }
+
+  // Async pre-checks happen outside the transaction; the transaction re-checks
+  // everything that lives in the summary doc.
+  const isPro = rules.stopIfPro ? await isUserProInternal(uid) : false;
+
+  // Broadcast sends respect the recipient's stream-level opt-out. Postmark
+  // also suppresses server-side; this check just avoids counting a suppressed
+  // send against stop-rule windows. Transactional mail skips it by design.
+  if (isBroadcast) {
+    const prefs = await db.collection('emailPrefs').doc(uid).get();
+    if (prefs.exists && prefs.data()?.streams?.[stream]?.suppressed) {
+      return { action: 'skipped', reason: 'unsubscribed' };
+    }
+  }
+
+  const summaryRef = db.collection('emailLog').doc(uid);
+
+  // Transaction: evaluate stop-rules against the live summary doc and claim
+  // the send by writing it. `prevEntries` captures the pre-claim state so a
+  // failed Postmark call can roll the claim back.
+  let outcome = null; // { action, reason } when blocked/dry-run; null → claimed
+  let prevEntries = null;
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(summaryRef);
+    const summary = snap.exists ? snap.data() : null;
+
+    const verdict = evaluateStopRules({
+      emailId,
+      category,
+      rules,
+      summary,
+      dedupeKey,
+      isPro
+    });
+    if (!verdict.allowed) {
+      outcome = { action: 'skipped', reason: verdict.reason };
+      return;
+    }
+    if (dryRun) {
+      outcome = { action: 'would-send' };
+      return;
+    }
+
+    prevEntries = {
+      email: summary?.emails?.[emailId] ?? null,
+      category: summary?.categories?.[category] ?? null
+    };
+    const now = admin.firestore.FieldValue.serverTimestamp();
+    // set + merge (not update) so map keys like Stripe ids are literal and the
+    // doc is created on first send.
+    tx.set(
+      summaryRef,
+      {
+        userId: uid,
+        email: userInfo.email,
+        updatedAt: now,
+        emails: {
+          [emailId]: {
+            lastSentAt: now,
+            sentCount: admin.firestore.FieldValue.increment(1),
+            ...(dedupeKey ? { dedupeKeys: { [dedupeKey]: now } } : {})
+          }
+        },
+        categories: { [category]: { lastSentAt: now } }
+      },
+      { merge: true }
+    );
+  });
+
+  if (outcome) {
+    return outcome;
+  }
+
+  const subject = template.getSubject(userInfo.displayName, data);
+  let htmlBody = template.getHtmlBody(userInfo.displayName, data);
+  let textBody = template.getTextBody(userInfo.displayName, data);
+  if (isBroadcast) {
+    htmlBody = htmlBody.includes('</body>')
+      ? htmlBody.replace('</body>', `${UNSUBSCRIBE_HTML}</body>`)
+      : htmlBody + UNSUBSCRIBE_HTML;
+    textBody += UNSUBSCRIBE_TEXT;
+  }
+
+  try {
+    const result = await sendPostmarkEmail(
+      userInfo.email,
+      subject,
+      htmlBody,
+      textBody,
+      { stream }
+    );
+    await summaryRef.collection('sends').add({
+      emailId,
+      category,
+      stream,
+      to: userInfo.email,
+      subject,
+      dedupeKey,
+      status: 'sent',
+      messageId: result.MessageID || null,
+      sentAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+    console.log(
+      `Sent lifecycle email ${emailId} to ${userInfo.email} (stream=${stream}, MessageID=${result.MessageID})`
+    );
+    return { action: 'sent', messageId: result.MessageID };
+  } catch (err) {
+    // Roll the claim back so a retry/sweep isn't blocked by a send that never
+    // happened. Restoring the captured pre-claim entries can race another
+    // concurrent send of a *different* email to the same user (only the
+    // category entry overlaps); at current volumes that's acceptable.
+    await summaryRef
+      .set(
+        {
+          emails: { [emailId]: prevEntries.email },
+          categories: { [category]: prevEntries.category }
+        },
+        { merge: true }
+      )
+      .catch(() => {});
+    await summaryRef
+      .collection('sends')
+      .add({
+        emailId,
+        category,
+        stream,
+        to: userInfo.email,
+        subject,
+        dedupeKey,
+        status: 'error',
+        error: String(err?.message || err),
+        sentAt: admin.firestore.FieldValue.serverTimestamp()
+      })
+      .catch(() => {});
+    console.error(`Lifecycle email ${emailId} failed for ${uid}:`, err);
+    return { action: 'error', reason: err?.message || String(err) };
+  }
+};
+
+// ============================================================================
+// TEST EMAIL — exercises the full pipeline (prefs → stop-rules → stream →
+// emailLog) before any real P0 email exists. Admin-only via the callable.
+// ============================================================================
+
+const TEST_TEMPLATE = {
+  getSubject: (userName, { stream }) =>
+    `[3DStreet test] lifecycle email pipeline (${stream} stream)`,
+  getTextBody: (userName, { stream }) => `Hi ${userName},
+
+This is a test of the 3DStreet lifecycle email pipeline, sent via the "${stream}" Postmark stream.
+
+If you weren't expecting this, an admin is testing email infrastructure — no action needed.
+
+The 3DStreet Team
+https://3dstreet.com`,
+  getHtmlBody: (userName, { stream }) => `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h2 style="color: #1a1a1a;">Hi ${userName},</h2>
+  <p>This is a test of the 3DStreet lifecycle email pipeline, sent via the <strong>${stream}</strong> Postmark stream.</p>
+  <p>If you weren't expecting this, an admin is testing email infrastructure — no action needed.</p>
+  <p style="color: #666;">The 3DStreet Team<br>
+  <a href="https://3dstreet.com" style="color: #6366f1;">https://3dstreet.com</a></p>
+</body>
+</html>`
+};
+
+/**
+ * Admin callable to exercise sendLifecycleEmail end-to-end. Defaults to a
+ * dry run against the caller themselves.
+ *
+ * From the browser console (admin claim required):
+ *   await adminTools.testLifecycleEmail()                          // dry run, outbound
+ *   await adminTools.testLifecycleEmail({ stream: 'conversion' })  // dry run, broadcast
+ *   await adminTools.testLifecycleEmail({ dryRun: false })         // actually send
+ */
+const triggerLifecycleEmail = functions
+  .runWith({
+    timeoutSeconds: 60,
+    memory: '256MB',
+    secrets: ['POSTMARK_API_KEY', 'ALLOWED_PRO_TEAM_DOMAINS']
+  })
+  .https.onCall(async (data, context) => {
+    assertAppCheck(context);
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'unauthenticated',
+        'User must be authenticated.'
+      );
+    }
+    if (!context.auth.token.admin) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'Admin access required.'
+      );
+    }
+
+    const uid = data?.uid || context.auth.uid;
+    const stream = data?.stream || TRANSACTIONAL_STREAM;
+    const dryRun = data?.dryRun ?? true; // default to dry run for safety
+    const isBroadcast = stream !== TRANSACTIONAL_STREAM;
+
+    const result = await sendLifecycleEmail({
+      db: admin.firestore(),
+      uid,
+      emailId: 'testPing',
+      category: isBroadcast ? stream : 'transactional',
+      stream,
+      template: TEST_TEMPLATE,
+      data: { stream },
+      rules: {}, // repeatable on purpose — it's an admin-only test
+      dryRun
+    });
+
+    console.log(
+      `triggerLifecycleEmail uid=${uid} stream=${stream} dryRun=${dryRun}:`,
+      JSON.stringify(result)
+    );
+    return { uid, stream, dryRun, ...result };
+  });
+
+// ============================================================================
+// POSTMARK SUBSCRIPTION CHANGE WEBHOOK
+// ============================================================================
+
+/**
+ * Receives Postmark's Subscription Change webhook and mirrors per-stream
+ * opt-out state into emailPrefs/{uid}. Postmark enforces suppression on its
+ * side regardless; this sync exists so eligibility sweeps can skip suppressed
+ * users up front (and so we have consent state in our own database).
+ *
+ * Payload (RecordType 'SubscriptionChange'): Recipient, MessageStream,
+ * SuppressSender (true = suppressed, false = reactivated), SuppressionReason
+ * ('ManualSuppression' | 'HardBounce' | 'SpamComplaint'), Origin, ChangedAt.
+ *
+ * Auth: the webhook URL is configured in Postmark with HTTP Basic credentials
+ * that must match the POSTMARK_WEBHOOK_AUTH secret ("username:password").
+ * Fail closed — without the secret or with a bad header, reject.
+ */
+const postmarkSubscriptionWebhook = functions
+  .runWith({ secrets: ['POSTMARK_WEBHOOK_AUTH'] })
+  .https.onRequest(async (req, res) => {
+    if (req.method !== 'POST') {
+      return res.status(405).send('Method Not Allowed');
+    }
+
+    const expected = process.env.POSTMARK_WEBHOOK_AUTH;
+    if (!expected) {
+      console.error('POSTMARK_WEBHOOK_AUTH is not configured');
+      return res.status(500).send('Webhook auth not configured');
+    }
+    const expectedHeader = `Basic ${Buffer.from(expected).toString('base64')}`;
+    if (req.headers.authorization !== expectedHeader) {
+      console.warn('postmarkSubscriptionWebhook: bad or missing auth header');
+      return res.status(401).send('Unauthorized');
+    }
+
+    const body = req.body || {};
+    // Postmark's "send test" and other record types land here too; ack and
+    // ignore anything that isn't a subscription change.
+    if (body.RecordType !== 'SubscriptionChange' || !body.Recipient) {
+      console.log(
+        `postmarkSubscriptionWebhook: ignoring RecordType=${body.RecordType}`
+      );
+      return res.status(200).json({ ok: true, ignored: true });
+    }
+
+    let userRecord;
+    try {
+      userRecord = await getAuth().getUserByEmail(body.Recipient);
+    } catch (err) {
+      // Not one of our users (or a deleted account). Postmark still enforces
+      // its own suppression; nothing to record. 200 so Postmark doesn't retry.
+      console.warn(
+        `postmarkSubscriptionWebhook: no user for ${body.Recipient} (${err.code || err.message})`
+      );
+      return res.status(200).json({ ok: true, matched: false });
+    }
+
+    const stream = body.MessageStream || 'unknown';
+    await admin
+      .firestore()
+      .collection('emailPrefs')
+      .doc(userRecord.uid)
+      .set(
+        {
+          userId: userRecord.uid,
+          email: body.Recipient,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          streams: {
+            [stream]: {
+              suppressed: body.SuppressSender === true,
+              reason: body.SuppressionReason || null,
+              origin: body.Origin || null,
+              changedAt: body.ChangedAt ? new Date(body.ChangedAt) : null
+            }
+          }
+        },
+        { merge: true }
+      );
+
+    console.log(
+      `postmarkSubscriptionWebhook: ${body.Recipient} stream=${stream} suppressed=${body.SuppressSender === true}`
+    );
+    return res.status(200).json({ ok: true, matched: true });
+  });
+
+module.exports = {
+  sendLifecycleEmail,
+  triggerLifecycleEmail,
+  postmarkSubscriptionWebhook,
+  TRANSACTIONAL_STREAM,
+  BROADCAST_STREAMS
+};

--- a/public/functions/email/stop-rules.js
+++ b/public/functions/email/stop-rules.js
@@ -1,0 +1,81 @@
+/**
+ * Pure stop-rule evaluation for lifecycle emails.
+ *
+ * No firebase-admin dependency on purpose: this module is unit-tested directly
+ * (test/core/email-stop-rules.test.js) without an emulator. The send service
+ * (lifecycle-email.js) calls evaluateStopRules inside a Firestore transaction
+ * against the user's emailLog summary doc.
+ *
+ * Summary doc shape (emailLog/{uid}):
+ *   {
+ *     userId, email, updatedAt,
+ *     emails:     { [emailId]:  { lastSentAt, sentCount, dedupeKeys: { [key]: sentAt } } },
+ *     categories: { [category]: { lastSentAt } }
+ *   }
+ *
+ * Supported rules:
+ *   onceEver: true              — never resend this emailId
+ *   notWithinDays: N            — skip if this emailId sent in the last N days
+ *   categoryNotWithinDays: N    — skip if ANY email in this category sent in
+ *                                 the last N days (e.g. ≤1 conversion email / 7d)
+ *   stopIfPro: true             — evaluated by the caller (async Auth lookup);
+ *                                 pass the result in as `isPro`
+ *   dedupeKey (send param)      — skip if this exact key was already recorded
+ *                                 for this emailId (once per invoice/session)
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Accepts Firestore Timestamp, Date, or epoch ms; null when absent/unparseable.
+const toMillis = (v) => {
+  if (v == null) return null;
+  if (typeof v.toMillis === 'function') return v.toMillis();
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === 'number') return v;
+  return null;
+};
+
+/**
+ * @returns {{allowed: boolean, reason: string|null}} reason is set iff blocked
+ */
+const evaluateStopRules = ({
+  emailId,
+  category,
+  rules = {},
+  summary = null,
+  dedupeKey = null,
+  isPro = false,
+  nowMs = Date.now()
+}) => {
+  if (rules.stopIfPro && isPro) {
+    return { allowed: false, reason: 'pro' };
+  }
+
+  const emailEntry = summary?.emails?.[emailId];
+
+  if (rules.onceEver && emailEntry?.lastSentAt) {
+    return { allowed: false, reason: 'onceEver' };
+  }
+
+  if (rules.notWithinDays > 0) {
+    const last = toMillis(emailEntry?.lastSentAt);
+    if (last != null && nowMs - last < rules.notWithinDays * DAY_MS) {
+      return { allowed: false, reason: 'notWithinDays' };
+    }
+  }
+
+  if (rules.categoryNotWithinDays > 0 && category) {
+    const last = toMillis(summary?.categories?.[category]?.lastSentAt);
+    if (last != null && nowMs - last < rules.categoryNotWithinDays * DAY_MS) {
+      return { allowed: false, reason: 'categoryNotWithinDays' };
+    }
+  }
+
+  if (dedupeKey && emailEntry?.dedupeKeys?.[dedupeKey] != null) {
+    return { allowed: false, reason: 'dedupeKey' };
+  }
+
+  return { allowed: true, reason: null };
+};
+
+module.exports = { evaluateStopRules, toMillis, DAY_MS };

--- a/public/functions/index.js
+++ b/public/functions/index.js
@@ -8,6 +8,7 @@ const { checkAndRefillImageTokens, checkUserProStatus } = require('./token-manag
 const { generateFalImage } = require('./fal-proxy.js');
 const { assertAppCheck } = require('./app-check.js');
 const { sendScheduledEmails, triggerScheduledEmails } = require('./scheduled/scheduledEmails.js');
+const { triggerLifecycleEmail, postmarkSubscriptionWebhook } = require('./email/lifecycle-email.js');
 const { auditUserSubscriptions, auditUserSubscriptionsHttp } = require('./utilities/user-audit.js');
 const { onAssetWritten, getUploadQuota } = require('./asset-quota.js');
 const { purgeSoftDeletedAssets, triggerPurgeSoftDeletedAssets } = require('./scheduled/asset-gc.js');
@@ -39,6 +40,11 @@ exports.generateFalImage = generateFalImage;
 // Re-export the scheduled email functions
 exports.sendScheduledEmails = sendScheduledEmails;
 exports.triggerScheduledEmails = triggerScheduledEmails;
+
+// Lifecycle email foundation — admin test callable + Postmark Subscription
+// Change webhook (opt-outs → emailPrefs). See email/lifecycle-email.js.
+exports.triggerLifecycleEmail = triggerLifecycleEmail;
+exports.postmarkSubscriptionWebhook = postmarkSubscriptionWebhook;
 
 // Re-export the user audit functions
 exports.auditUserSubscriptions = auditUserSubscriptions;

--- a/public/functions/scheduled/SCHEDULED_EMAILS_SYSTEM.md
+++ b/public/functions/scheduled/SCHEDULED_EMAILS_SYSTEM.md
@@ -2,6 +2,13 @@
 
 This document describes the scheduled email notification system that sends transactional emails via Postmark.
 
+> **Lifecycle emails (P0 wave):** new lifecycle emails should use the send
+> service in `../email/lifecycle-email.js` (per-stream routing, `emailPrefs`
+> suppression, `emailLog` stop-rules + audit) rather than adding more
+> `notifyLog` booleans here. This system continues to run `tokenExhaustion`
+> and provides `sendPostmarkEmail` / `getUserInfo` that the lifecycle service
+> reuses. Plan: `docs/email-lifecycle-p0-plan.md` (repo root).
+
 ## Overview
 
 A daily scheduled Cloud Function queries Firestore for users who meet certain criteria (e.g., exhausted tokens) and sends notification emails. The system is designed to be extensible for adding new email types.

--- a/public/functions/scheduled/scheduledEmails.js
+++ b/public/functions/scheduled/scheduledEmails.js
@@ -332,8 +332,15 @@ const EMAIL_TYPES = {
 
 /**
  * Send email via Postmark API
+ *
+ * options.stream selects the Postmark message stream: 'outbound'
+ * (transactional, default) or a broadcast stream ('conversion', 'lifecycle')
+ * where Postmark manages unsubscribe. Callers sending to a broadcast stream
+ * must include an unsubscribe link/placeholder in the body (the lifecycle
+ * send service in ../email/lifecycle-email.js appends one).
  */
-const sendPostmarkEmail = async (toEmail, subject, htmlBody, textBody) => {
+const sendPostmarkEmail = async (toEmail, subject, htmlBody, textBody, options = {}) => {
+  const { stream = 'outbound' } = options;
   const apiKey = process.env.POSTMARK_API_KEY;
 
   if (!apiKey) {
@@ -353,7 +360,7 @@ const sendPostmarkEmail = async (toEmail, subject, htmlBody, textBody) => {
       Subject: subject,
       HtmlBody: htmlBody,
       TextBody: textBody,
-      MessageStream: 'outbound'
+      MessageStream: stream
     })
   });
 

--- a/src/shared/services/firebase.js
+++ b/src/shared/services/firebase.js
@@ -88,6 +88,24 @@ window.adminTools = {
   },
 
   /**
+   * Test the lifecycle email pipeline (admin only). Sends the `testPing`
+   * email through the full send path: emailPrefs suppression check,
+   * emailLog stop-rules + audit record, Postmark stream routing.
+   *
+   * Usage from browser console:
+   *   await adminTools.testLifecycleEmail()                          // dry run to yourself, outbound
+   *   await adminTools.testLifecycleEmail({ stream: 'conversion' })  // dry run, broadcast stream
+   *   await adminTools.testLifecycleEmail({ dryRun: false })         // actually send
+   *   await adminTools.testLifecycleEmail({ uid: '...', dryRun: false })
+   */
+  testLifecycleEmail: async ({ uid, stream, dryRun = true } = {}) => {
+    const trigger = httpsCallable(functions, 'triggerLifecycleEmail');
+    const result = await trigger({ uid, stream, dryRun });
+    console.log(result.data);
+    return result.data;
+  },
+
+  /**
    * Audit user subscriptions vs claims (admin/PRO only)
    * Identifies discrepancies between Stripe subscriptions and Firebase PRO claims
    * @param {boolean} fixDiscrepancies - If true, automatically fix claim issues

--- a/test/core/email-stop-rules.test.js
+++ b/test/core/email-stop-rules.test.js
@@ -1,0 +1,226 @@
+/* global describe, it */
+
+import assert from 'assert';
+import stopRules from '../../public/functions/email/stop-rules.js';
+
+const { evaluateStopRules, toMillis, DAY_MS } = stopRules;
+
+const NOW = 1_800_000_000_000; // fixed clock for deterministic window checks
+
+// Builds an emailLog summary doc with one prior send of `emailId`.
+const summaryWithSend = (emailId, category, sentAtMs, dedupeKey = null) => ({
+  emails: {
+    [emailId]: {
+      lastSentAt: sentAtMs,
+      sentCount: 1,
+      ...(dedupeKey ? { dedupeKeys: { [dedupeKey]: sentAtMs } } : {})
+    }
+  },
+  categories: { [category]: { lastSentAt: sentAtMs } }
+});
+
+describe('email stop-rules', function () {
+  describe('#evaluateStopRules()', function () {
+    it('allows when there is no summary doc (first-ever send)', function () {
+      const verdict = evaluateStopRules({
+        emailId: 'welcome',
+        category: 'transactional',
+        rules: { onceEver: true },
+        summary: null,
+        nowMs: NOW
+      });
+      assert.deepStrictEqual(verdict, { allowed: true, reason: null });
+    });
+
+    it('allows with no rules at all', function () {
+      const verdict = evaluateStopRules({
+        emailId: 'testPing',
+        category: 'transactional',
+        summary: summaryWithSend('testPing', 'transactional', NOW - 1000),
+        nowMs: NOW
+      });
+      assert.strictEqual(verdict.allowed, true);
+    });
+
+    describe('onceEver', function () {
+      it('blocks a second send of the same emailId', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'welcome',
+          category: 'transactional',
+          rules: { onceEver: true },
+          summary: summaryWithSend(
+            'welcome',
+            'transactional',
+            NOW - 400 * DAY_MS
+          ),
+          nowMs: NOW
+        });
+        assert.deepStrictEqual(verdict, { allowed: false, reason: 'onceEver' });
+      });
+
+      it('does not block a different emailId', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'geoNotUsed',
+          category: 'lifecycle',
+          rules: { onceEver: true },
+          summary: summaryWithSend('welcome', 'transactional', NOW - DAY_MS),
+          nowMs: NOW
+        });
+        assert.strictEqual(verdict.allowed, true);
+      });
+    });
+
+    describe('notWithinDays', function () {
+      it('blocks inside the window', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'pricingNudge',
+          category: 'conversion',
+          rules: { notWithinDays: 30 },
+          summary: summaryWithSend(
+            'pricingNudge',
+            'conversion',
+            NOW - 29 * DAY_MS
+          ),
+          nowMs: NOW
+        });
+        assert.deepStrictEqual(verdict, {
+          allowed: false,
+          reason: 'notWithinDays'
+        });
+      });
+
+      it('allows once the window has elapsed', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'pricingNudge',
+          category: 'conversion',
+          rules: { notWithinDays: 30 },
+          summary: summaryWithSend(
+            'pricingNudge',
+            'conversion',
+            NOW - 31 * DAY_MS
+          ),
+          nowMs: NOW
+        });
+        assert.strictEqual(verdict.allowed, true);
+      });
+    });
+
+    describe('categoryNotWithinDays', function () {
+      it('blocks when a DIFFERENT email in the same category sent recently', function () {
+        // e.g. checkoutAbandoned72h suppressed because checkoutAbandoned1h
+        // went out 2 days ago (≤1 conversion email per user per 7d).
+        const verdict = evaluateStopRules({
+          emailId: 'checkoutAbandoned72h',
+          category: 'conversion',
+          rules: { categoryNotWithinDays: 7 },
+          summary: summaryWithSend(
+            'checkoutAbandoned1h',
+            'conversion',
+            NOW - 2 * DAY_MS
+          ),
+          nowMs: NOW
+        });
+        assert.deepStrictEqual(verdict, {
+          allowed: false,
+          reason: 'categoryNotWithinDays'
+        });
+      });
+
+      it('ignores sends in other categories', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'checkoutAbandoned1h',
+          category: 'conversion',
+          rules: { categoryNotWithinDays: 7 },
+          summary: summaryWithSend('geoNotUsed', 'lifecycle', NOW - DAY_MS),
+          nowMs: NOW
+        });
+        assert.strictEqual(verdict.allowed, true);
+      });
+    });
+
+    describe('dedupeKey', function () {
+      it('blocks a repeat of the same key (same invoice/session)', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'failedPayment',
+          category: 'transactional',
+          summary: summaryWithSend(
+            'failedPayment',
+            'transactional',
+            NOW - DAY_MS,
+            'in_123'
+          ),
+          dedupeKey: 'in_123',
+          nowMs: NOW
+        });
+        assert.deepStrictEqual(verdict, {
+          allowed: false,
+          reason: 'dedupeKey'
+        });
+      });
+
+      it('allows a new key for the same emailId', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'failedPayment',
+          category: 'transactional',
+          summary: summaryWithSend(
+            'failedPayment',
+            'transactional',
+            NOW - DAY_MS,
+            'in_123'
+          ),
+          dedupeKey: 'in_456',
+          nowMs: NOW
+        });
+        assert.strictEqual(verdict.allowed, true);
+      });
+    });
+
+    describe('stopIfPro', function () {
+      it('blocks when the caller resolved the user as Pro', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'geoNotUsed',
+          category: 'lifecycle',
+          rules: { stopIfPro: true },
+          summary: null,
+          isPro: true,
+          nowMs: NOW
+        });
+        assert.deepStrictEqual(verdict, { allowed: false, reason: 'pro' });
+      });
+
+      it('ignores isPro when the rule is not set', function () {
+        const verdict = evaluateStopRules({
+          emailId: 'postUpgradeWelcome',
+          category: 'transactional',
+          summary: null,
+          isPro: true,
+          nowMs: NOW
+        });
+        assert.strictEqual(verdict.allowed, true);
+      });
+    });
+
+    it('combines rules: first blocking rule wins (pro before onceEver)', function () {
+      const verdict = evaluateStopRules({
+        emailId: 'geoNotUsed',
+        category: 'lifecycle',
+        rules: { stopIfPro: true, onceEver: true },
+        summary: summaryWithSend('geoNotUsed', 'lifecycle', NOW - DAY_MS),
+        isPro: true,
+        nowMs: NOW
+      });
+      assert.strictEqual(verdict.reason, 'pro');
+    });
+  });
+
+  describe('#toMillis()', function () {
+    it('handles epoch ms, Date, Firestore Timestamp-like, and null', function () {
+      assert.strictEqual(toMillis(NOW), NOW);
+      assert.strictEqual(toMillis(new Date(NOW)), NOW);
+      assert.strictEqual(toMillis({ toMillis: () => NOW }), NOW);
+      assert.strictEqual(toMillis(null), null);
+      assert.strictEqual(toMillis(undefined), null);
+      assert.strictEqual(toMillis('not-a-time'), null);
+    });
+  });
+});

--- a/test/rules/email.rules.test.js
+++ b/test/rules/email.rules.test.js
@@ -1,0 +1,83 @@
+/**
+ * Firestore rules tests — emailLog + emailPrefs are cloud-functions-only.
+ *
+ * Run via `npm run test:rules` (wraps the firestore emulator via
+ * `firebase emulators:exec`). Not part of CI; run locally when touching
+ * public/firestore.rules.
+ *
+ * Coverage: neither the owner nor another user can read or write the
+ * lifecycle email collections (emailLog/{uid}, its sends subcollection,
+ * emailPrefs/{uid}). Only the Admin SDK (Cloud Functions) touches them.
+ */
+
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertFails
+} from '@firebase/rules-unit-testing';
+import { doc, setDoc, getDoc } from 'firebase/firestore';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const UID = 'user-abc';
+const OTHER_UID = 'user-xyz';
+
+let testEnv;
+
+describe('firestore.rules — emailLog + emailPrefs (cloud-only)', () => {
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: 'demo-3dstreet-rules',
+      firestore: {
+        rules: readFileSync(
+          resolve(__dirname, '../../public/firestore.rules'),
+          'utf8'
+        ),
+        host: '127.0.0.1',
+        port: 8080
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv?.cleanup();
+  });
+
+  const paths = (uid) => [
+    ['emailLog summary', ['emailLog', uid]],
+    ['emailLog send record', ['emailLog', uid, 'sends', 'send-1']],
+    ['emailPrefs', ['emailPrefs', uid]]
+  ];
+
+  it('denies the owner read and write on all email collections', async () => {
+    const db = testEnv.authenticatedContext(UID).firestore();
+    for (const [label, segments] of paths(UID)) {
+      const ref = doc(db, ...segments);
+      await assertFails(getDoc(ref), `${label}: owner read should fail`);
+      await assertFails(
+        setDoc(ref, { userId: UID }),
+        `${label}: owner write should fail`
+      );
+    }
+  });
+
+  it('denies another authenticated user read and write', async () => {
+    const db = testEnv.authenticatedContext(OTHER_UID).firestore();
+    for (const [label, segments] of paths(UID)) {
+      const ref = doc(db, ...segments);
+      await assertFails(getDoc(ref), `${label}: other-user read should fail`);
+      await assertFails(
+        setDoc(ref, { suppressed: true }),
+        `${label}: other-user write should fail`
+      );
+    }
+  });
+
+  it('denies unauthenticated access', async () => {
+    const db = testEnv.unauthenticatedContext().firestore();
+    for (const [label, segments] of paths(UID)) {
+      const ref = doc(db, ...segments);
+      await assertFails(getDoc(ref), `${label}: anon read should fail`);
+    }
+  });
+});

--- a/test/rules/lifecycle-email.emulator.test.js
+++ b/test/rules/lifecycle-email.emulator.test.js
@@ -1,0 +1,293 @@
+/**
+ * Emulator-backed tests for sendLifecycleEmail (the parts the pure stop-rule
+ * unit tests can't cover): the transactional claim + pending/sent/error audit
+ * records, rollback on Postmark failure (including the dedupeKey regression),
+ * emailPrefs suppression, broadcast unsubscribe footer, and concurrent-send
+ * idempotency.
+ *
+ * Runs under `npm run test:rules`, which boots the firestore + auth emulators
+ * via `firebase emulators:exec` (that sets FIRESTORE_EMULATOR_HOST /
+ * FIREBASE_AUTH_EMULATOR_HOST for this process). Postmark is stubbed at the
+ * global fetch level — no network.
+ *
+ * The module under test lives in public/functions (its own node_modules), so
+ * firebase-admin must be THE SAME instance the module sees — hence
+ * createRequire anchored there instead of top-level imports.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi
+} from 'vitest';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const functionsRequire = createRequire(
+  resolve(__dirname, '../../public/functions/index.js')
+);
+const admin = functionsRequire('firebase-admin');
+
+let sendLifecycleEmail;
+let db;
+
+// Minimal template; subject/body assertions key off these markers.
+const TEMPLATE = {
+  getSubject: (name) => `Test subject for ${name}`,
+  getHtmlBody: (name) =>
+    `<!DOCTYPE html><html><body><p>Hi ${name}</p></body></html>`,
+  getTextBody: (name) => `Hi ${name}`
+};
+
+const okFetch = () =>
+  vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ MessageID: 'pm-msg-1' })
+  }));
+
+const failFetch = () =>
+  vi.fn(async () => ({
+    ok: false,
+    status: 500,
+    text: async () => 'postmark 500'
+  }));
+
+let uidCounter = 0;
+const makeUser = async () => {
+  const uid = `lifecycle-test-${++uidCounter}`;
+  await admin.auth().createUser({
+    uid,
+    email: `${uid}@example.test`,
+    displayName: `Tester ${uidCounter}`
+  });
+  return uid;
+};
+
+const summaryDoc = async (uid) =>
+  (await db.collection('emailLog').doc(uid).get()).data();
+
+const sendRecords = async (uid) => {
+  const snap = await db
+    .collection('emailLog')
+    .doc(uid)
+    .collection('sends')
+    .get();
+  return snap.docs.map((d) => d.data());
+};
+
+describe('sendLifecycleEmail (emulator)', () => {
+  beforeAll(() => {
+    expect(process.env.FIRESTORE_EMULATOR_HOST).toBeTruthy();
+    expect(process.env.FIREBASE_AUTH_EMULATOR_HOST).toBeTruthy();
+    process.env.POSTMARK_API_KEY = 'test-server-token';
+    if (!admin.apps.length) {
+      admin.initializeApp({ projectId: 'demo-3dstreet-rules' });
+    }
+    db = admin.firestore();
+    ({ sendLifecycleEmail } = functionsRequire('./email/lifecycle-email.js'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllGlobals();
+    await Promise.all(admin.apps.map((app) => app.delete()));
+  });
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('happy path: sends, writes summary claim and a sent audit record', async () => {
+    const uid = await makeUser();
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await sendLifecycleEmail({
+      db,
+      uid,
+      emailId: 'welcome',
+      category: 'transactional',
+      stream: 'outbound',
+      template: TEMPLATE,
+      rules: { onceEver: true }
+    });
+
+    expect(result).toMatchObject({ action: 'sent', messageId: 'pm-msg-1' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const summary = await summaryDoc(uid);
+    expect(summary.emails.welcome.sentCount).toBe(1);
+    expect(summary.emails.welcome.lastSentAt).toBeTruthy();
+    expect(summary.categories.transactional.lastSentAt).toBeTruthy();
+
+    const sends = await sendRecords(uid);
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toMatchObject({
+      emailId: 'welcome',
+      stream: 'outbound',
+      status: 'sent',
+      messageId: 'pm-msg-1'
+    });
+  });
+
+  it('dry run evaluates but claims and sends nothing', async () => {
+    const uid = await makeUser();
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await sendLifecycleEmail({
+      db,
+      uid,
+      emailId: 'welcome',
+      category: 'transactional',
+      stream: 'outbound',
+      template: TEMPLATE,
+      rules: { onceEver: true },
+      dryRun: true
+    });
+
+    expect(result.action).toBe('would-send');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await summaryDoc(uid)).toBeUndefined();
+    expect(await sendRecords(uid)).toHaveLength(0);
+  });
+
+  it('broadcast: appends unsubscribe footer, routes to the stream, respects emailPrefs', async () => {
+    const uid = await makeUser();
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await sendLifecycleEmail({
+      db,
+      uid,
+      emailId: 'checkoutAbandoned1h',
+      category: 'conversion',
+      stream: 'conversion',
+      template: TEMPLATE,
+      dedupeKey: 'cs_1'
+    });
+    expect(first.action).toBe('sent');
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.MessageStream).toBe('conversion');
+    expect(payload.HtmlBody).toContain('{{{ pm:unsubscribe_url }}}');
+    expect(payload.TextBody).toContain('{{{ pm:unsubscribe_url }}}');
+    // Footer must land inside the document, not after </body>
+    expect(payload.HtmlBody.indexOf('pm:unsubscribe_url')).toBeLessThan(
+      payload.HtmlBody.indexOf('</body>')
+    );
+
+    // Simulate the Postmark Subscription Change webhook having recorded an
+    // opt-out for this stream; the next send must be skipped.
+    await db
+      .collection('emailPrefs')
+      .doc(uid)
+      .set({
+        userId: uid,
+        streams: { conversion: { suppressed: true } }
+      });
+    const second = await sendLifecycleEmail({
+      db,
+      uid,
+      emailId: 'checkoutAbandoned1h',
+      category: 'conversion',
+      stream: 'conversion',
+      template: TEMPLATE,
+      dedupeKey: 'cs_2'
+    });
+    expect(second).toMatchObject({ action: 'skipped', reason: 'unsubscribed' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back the claim on Postmark failure so a retry succeeds (dedupeKey regression)', async () => {
+    const uid = await makeUser();
+
+    // Prior successful send of the same emailId with a different dedupeKey —
+    // the case where a set+merge rollback would leave the new key behind.
+    vi.stubGlobal('fetch', okFetch());
+    const args = {
+      db,
+      uid,
+      emailId: 'failedPayment',
+      category: 'transactional',
+      stream: 'outbound',
+      template: TEMPLATE
+    };
+    expect(
+      (await sendLifecycleEmail({ ...args, dedupeKey: 'in_100' })).action
+    ).toBe('sent');
+    const before = await summaryDoc(uid);
+
+    // Postmark fails for the new invoice → claim must be fully rolled back.
+    vi.stubGlobal('fetch', failFetch());
+    const failed = await sendLifecycleEmail({ ...args, dedupeKey: 'in_200' });
+    expect(failed.action).toBe('error');
+
+    const after = await summaryDoc(uid);
+    expect(after.emails.failedPayment.sentCount).toBe(1);
+    expect(Object.keys(after.emails.failedPayment.dedupeKeys)).toEqual([
+      'in_100'
+    ]);
+    expect(after.emails.failedPayment.lastSentAt.toMillis()).toBe(
+      before.emails.failedPayment.lastSentAt.toMillis()
+    );
+
+    const sends = await sendRecords(uid);
+    expect(sends.map((s) => s.status).sort()).toEqual(['error', 'sent']);
+    expect(sends.find((s) => s.status === 'error').error).toContain('500');
+
+    // The whole point: the retry for in_200 must NOT be blocked.
+    vi.stubGlobal('fetch', okFetch());
+    const retried = await sendLifecycleEmail({ ...args, dedupeKey: 'in_200' });
+    expect(retried.action).toBe('sent');
+    const final = await summaryDoc(uid);
+    expect(Object.keys(final.emails.failedPayment.dedupeKeys).sort()).toEqual([
+      'in_100',
+      'in_200'
+    ]);
+  });
+
+  it('concurrent onceEver sends: exactly one email goes out', async () => {
+    const uid = await makeUser();
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const args = {
+      db,
+      uid,
+      emailId: 'geoNotUsed',
+      category: 'lifecycle',
+      stream: 'lifecycle',
+      template: TEMPLATE,
+      rules: { onceEver: true }
+    };
+    const results = await Promise.all([
+      sendLifecycleEmail({ ...args }),
+      sendLifecycleEmail({ ...args })
+    ]);
+
+    const actions = results.map((r) => r.action).sort();
+    expect(actions).toEqual(['sent', 'skipped']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((await summaryDoc(uid)).emails.geoNotUsed.sentCount).toBe(1);
+    expect(
+      (await sendRecords(uid)).filter((s) => s.status === 'sent')
+    ).toHaveLength(1);
+  });
+
+  it('unknown broadcast stream is rejected before any lookup', async () => {
+    const result = await sendLifecycleEmail({
+      db,
+      uid: 'irrelevant',
+      emailId: 'x',
+      category: 'x',
+      stream: 'not-a-stream',
+      template: TEMPLATE
+    });
+    expect(result.action).toBe('error');
+    expect(result.reason).toMatch(/unknown stream/);
+  });
+});

--- a/vitest.rules.config.js
+++ b/vitest.rules.config.js
@@ -1,9 +1,14 @@
 /**
- * Separate vitest config for Firestore rules tests.
+ * Separate vitest config for Firestore emulator tests (rules + the lifecycle
+ * email send service).
  *
  * Uses the `node` env (no jsdom / React mocks) and points at test/rules.
  * Invoked via `npm run test:rules`, which wraps this in
- * `firebase emulators:exec --only firestore` so the emulator is up.
+ * `firebase emulators:exec --only firestore,auth` so the emulators are up.
+ *
+ * fileParallelism is off because every test file shares the one emulator
+ * instance and the rules tests call clearFirestore() between cases — run in
+ * parallel they wipe each other's documents mid-test.
  */
 import { defineConfig } from 'vitest/config';
 
@@ -11,6 +16,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/rules/**/*.test.js'],
-    testTimeout: 15000
+    testTimeout: 15000,
+    fileParallelism: false
   }
 });


### PR DESCRIPTION
PR 1 of the email lifecycle P0 plan (`docs/email-lifecycle-p0-plan.md`, included in this PR). Ships the plumbing every P0 email will use; no user-facing emails are sent by this PR (templates and triggers land in PRs 2-4).

## What's here

**Send service** (`public/functions/email/lifecycle-email.js`)
- `sendLifecycleEmail({ db, uid, emailId, category, stream, template, data, rules, dedupeKey, dryRun })`
- Broadcast streams (`conversion`, `lifecycle`) check `emailPrefs/{uid}` suppression and get an `{{{ pm:unsubscribe_url }}}` footer; `outbound` stays transactional (no unsubscribe), matching the plan's routing rules.
- Stop-rules are evaluated and the send is claimed inside one Firestore transaction on the `emailLog/{uid}` summary doc, so a retried Stripe webhook can't double-send; a failed Postmark call rolls the claim back so sweeps can retry.
- Every attempt (sent or error) is recorded in `emailLog/{uid}/sends/{autoId}`.

**Stop-rules** (`public/functions/email/stop-rules.js`, pure, unit-tested)
`onceEver`, `notWithinDays`, `categoryNotWithinDays` (backs "≤1 conversion email per user per 7d"), `stopIfPro`, `dedupeKey` (once per invoice/checkout session).

**emailLog schema** (resolves open decision D3): one summary doc per uid holding per-email and per-category last-send state (single transactional read covers every rule, no queries) plus the `sends` audit subcollection. `notifyLog` is untouched; `tokenExhaustion` keeps working as-is.

**Postmark Subscription Change webhook** (`postmarkSubscriptionWebhook`): Basic-auth-gated (new secret `POSTMARK_WEBHOOK_AUTH`, fail-closed), matches recipient → Auth uid, mirrors per-stream opt-out state into `emailPrefs/{uid}`. Unknown recipients and non-SubscriptionChange payloads are acked and ignored.

**Admin test path**: `triggerLifecycleEmail` callable + `adminTools.testLifecycleEmail()` console helper sends a `testPing` email through the full pipeline (dry-run by default, stream selectable) so streams/unsubscribe/logging can be verified end to end after deploy.

**Rules**: `emailLog` (+ `sends`) and `emailPrefs` are cloud-functions-only, with emulator rules tests.

## Testing

- `npx mocha test/core/email-stop-rules.test.js` — 14 passing
- `npm run test:core` — 102 passing
- `npm run test:rules` — 16 passing (needs JDK 21; ran with brew openjdk@21)
- `node -e "require('./index.js')"` in `public/functions` loads clean; eslint + prettier clean

## After merge (manual, Postmark dashboard + secrets)

1. Create `conversion` and `lifecycle` broadcast streams (stream IDs must be exactly those strings).
2. `firebase functions:secrets:set POSTMARK_WEBHOOK_AUTH` (value `user:pass`) on dev, then prod.
3. Deploy, then add the Subscription Change webhook on both broadcast streams pointing at `https://user:pass@<region>-<project>.cloudfunctions.net/postmarkSubscriptionWebhook`.
4. Verify: `await adminTools.testLifecycleEmail({ stream: 'conversion', dryRun: false })` from an admin console on dev → check Postmark activity shows the right stream + unsubscribe link, then click unsubscribe and confirm `emailPrefs/{uid}` updates and a repeat send returns `skipped/unsubscribed`.
5. While in the dashboard: confirm DKIM status for 3dstreet.com (audit couldn't check with the server token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)