### PR TITLE
Inline title edit fast follows: read-only in hidden panel mode, fix edit input colors

### DIFF
--- a/src/editor/components/elements/SceneEditTitle/SceneEditTitle.component.jsx
+++ b/src/editor/components/elements/SceneEditTitle/SceneEditTitle.component.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import classNames from 'classnames';
 import styles from './SceneEditTitle.module.scss';
 import { useAuthContext } from '../../../contexts/index.js';
 import { updateSceneIdAndTitle } from '../../../api/scene';
@@ -9,6 +10,8 @@ import { Edit24Icon } from '@shared/icons';
 const SceneEditTitle = () => {
   const title = useStore((state) => state.sceneTitle);
   const saveScene = useStore((state) => state.saveScene);
+  // Hidden-panel mode shows the title for context only — no inline editing.
+  const editable = useStore((state) => state.panelsVisible);
   const { currentUser } = useAuthContext();
   const [editing, setEditing] = useState(false);
 
@@ -45,7 +48,7 @@ const SceneEditTitle = () => {
     }
   };
 
-  if (editing) {
+  if (editing && editable) {
     return (
       <div className={styles.wrapper}>
         <InlineEditInput
@@ -59,12 +62,17 @@ const SceneEditTitle = () => {
   }
 
   return (
-    <div className={styles.wrapper} onClick={() => setEditing(true)}>
+    <div
+      className={classNames(styles.wrapper, !editable && styles.static)}
+      onClick={editable ? () => setEditing(true) : undefined}
+    >
       <div className={styles.readOnly}>
         <p className={styles.title}>{displayTitle}</p>
-        <span className={styles.editIcon}>
-          <Edit24Icon />
-        </span>
+        {editable && (
+          <span className={styles.editIcon}>
+            <Edit24Icon />
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/editor/components/elements/SceneEditTitle/SceneEditTitle.module.scss
+++ b/src/editor/components/elements/SceneEditTitle/SceneEditTitle.module.scss
@@ -21,6 +21,15 @@
     }
   }
 
+  // Hidden-panel mode: title is display-only.
+  &.static {
+    cursor: default;
+
+    &:hover {
+      background: none;
+    }
+  }
+
   .readOnly {
     display: flex;
     align-items: center;
@@ -59,9 +68,11 @@
     width: min(400px, 50vw);
     font-size: 16px;
     font-weight: 500;
-    color: variables.$white;
-    background-color: variables.$black-300;
-    border: 1px solid variables.$blue-100;
+    // !important: the global `#aframeInspector input` rule (index.scss) outranks this
+    // module class and would otherwise gray out the text and flatten the border.
+    color: variables.$white !important;
+    background-color: variables.$black-300 !important;
+    border: 1px solid variables.$blue-100 !important;
     border-radius: 4px;
     padding: 0 4px;
     outline: none;


### PR DESCRIPTION
Closes #1816

Two fast follows on the inline scene title edit (#1808):

- **No editing in hidden-panel mode.** When panels are hidden, the title now renders display-only: no click-to-edit, no hover edit icon, default cursor. Gated on `panelsVisible` from the store so both render sites in SceneGraph get it.
- **Edit input colors.** The global `#aframeInspector input` rule (ID selector) outranked the CSS module class, so the input showed dark gray (`#888`) text with the flat black background and no border. The module's white text / dark background / blue border are now `!important` so they win while editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)