### PR TITLE
Fix zoom-to-focus for batched models

### DIFF
--- a/src/editor/lib/EditorControls.js
+++ b/src/editor/lib/EditorControls.js
@@ -41,6 +41,7 @@ THREE.EditorControls = function (_object, domElement) {
   var focusWorldPos = new THREE.Vector3();
   var focusWorldQuat = new THREE.Quaternion();
   var focusWorldScale = new THREE.Vector3();
+  var batchBox = new THREE.Box3();
 
   this.isOrthographic = false;
   this.rotationEnabled = true;
@@ -74,6 +75,14 @@ THREE.EditorControls = function (_object, domElement) {
     );
 
     box.setFromObject(target);
+
+    // Batched entities have their mesh tree stripped at batch time, so setFromObject
+    // finds no geometry under them. batch-models stashes an entity-local AABB on the
+    // object3D (same fallback OrientedBoxHelper uses) — union it in world space.
+    if (target._batchLocalBbox) {
+      batchBox.copy(target._batchLocalBbox).applyMatrix4(target.matrixWorld);
+      box.union(batchBox);
+    }
 
     if (box.isEmpty() === false && !isNaN(box.min.x)) {
       box.getCenter(center);


### PR DESCRIPTION
Closes #1815

`EditorControls.focus` sizes the focus framing with `box.setFromObject(target)`, but batch-models strips a batched member's mesh tree at batch time, so the box came back empty and focus fell into the degenerate fallback (tiny 0.1 distance at a bogus center, which is what the issue screenshot shows).

batch-models already stashes an entity-local AABB on every member's object3D (`_batchLocalBbox`) exactly for consumers that can't read the stripped mesh tree; the selection/hover `OrientedBoxHelper` in viewport.js uses it. This applies the same fallback in `focus()`: transform the cached bbox by the entity's world matrix and union it into the focus box, so center, distance, and camera offset all compute from the real model bounds.

Unbatched entities are unaffected (`_batchLocalBbox` is absent, union is skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)