### PR TITLE
fix: null-guard scene-id lookup and box-helper for detached objects

### DIFF
--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -52,7 +52,12 @@ class OrientedBoxHelper extends THREE.BoxHelper {
     // how Spark's SplatMesh handles matrix updates
     const isSplatEntity = this.object?.el?.hasAttribute('splat');
 
-    if (this.object !== undefined && !isSplatEntity) {
+    // this.object.parent is null when the tracked object has been detached from
+    // the scene graph (deleted/undo'd) while still hovered or selected; the
+    // parent-relative rezeroing below would then throw on matrixWorld.
+    const hasParent = this.object?.parent != null;
+
+    if (this.object !== undefined && hasParent && !isSplatEntity) {
       auxEuler.copy(this.object.rotation);
       auxLocalPosition.copy(this.object.position);
       this.object.rotation.set(0, 0, 0);
@@ -138,7 +143,7 @@ class OrientedBoxHelper extends THREE.BoxHelper {
     }
 
     // Restore rotations (skip for splat entities since we didn't modify them).
-    if (this.object !== undefined && !isSplatEntity) {
+    if (this.object !== undefined && hasParent && !isSplatEntity) {
       this.object.parent.matrixWorld.compose(
         auxPosition,
         auxQuaternion,

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -48,6 +48,11 @@ class OrientedBoxHelper extends THREE.BoxHelper {
     // It undoes the local entity rotation and then restores so box has the expected size.
     // We also undo the parent world rotation.
 
+    // tempBox3 is module-level and shared across all helper instances; reset it so
+    // that if we skip both bbox branches below (e.g. a detached object with no
+    // parent) we don't reuse the previous helper's box left over in it.
+    tempBox3.makeEmpty();
+
     // Skip the position/rotation zeroing for splat entities as it interferes with
     // how Spark's SplatMesh handles matrix updates
     const isSplatEntity = this.object?.el?.hasAttribute('splat');

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -40,8 +40,9 @@ function getCurrentSceneId() {
 STREET.utils.getCurrentSceneId = getCurrentSceneId;
 
 function getAuthorId() {
-  const authorId = AFRAME.scenes[0].getAttribute('metadata').authorId;
-  return authorId;
+  // Same guard as getCurrentSceneId: AFRAME.scenes[0] can be undefined during
+  // teardown/before attach, and this runs right after it in the beforeunload handler.
+  return AFRAME.scenes[0]?.getAttribute('metadata')?.authorId;
 }
 STREET.utils.getAuthorId = getAuthorId;
 

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -21,7 +21,10 @@ function getSceneUuidFromURLHash() {
 }
 
 function getCurrentSceneId() {
-  let currentSceneId = AFRAME.scenes[0].getAttribute('metadata').sceneId;
+  // AFRAME.scenes[0] can be undefined when this runs before the scene attaches
+  // or after it's torn down (e.g. the beforeunload handler on fast nav-away).
+  const scene = AFRAME.scenes[0];
+  let currentSceneId = scene?.getAttribute('metadata')?.sceneId;
   // console.log('currentSceneId from scene metadata', currentSceneId);
   const urlSceneId = getSceneUuidFromURLHash();
   // console.log('urlSceneId', urlSceneId);


### PR DESCRIPTION
Long-standing, zero-user-impact Sentry crashes — both present since **Sept 2025**, ~**1,300 lifetime events** combined — fixed with small null guards, plus two review follow-ups.

## 1. `getCurrentSceneId` / `getAuthorId` — `Cannot read properties of undefined (reading 'getAttribute')`
`AFRAME.scenes[0]` is `undefined` when the module-level `beforeunload` handler runs before the scene attaches or after teardown (fast nav-away; skewed to mobile Chrome). Optional-chain the scene + metadata lookup in **both** sibling accessors — the handler calls them on consecutive lines (`store.js:275–276`), so guarding only one would just move the crash one frame later with the same signature.
- Sentry: https://3dstreet.sentry.io/issues/6909703266/ (796 lifetime events)

## 2. `OrientedBoxHelper.update` — `Cannot read properties of null (reading 'matrixWorld')`
`this.object.parent` is `null` when the tracked object is detached from the scene graph (deleted/undo'd) while still hovered or selected, so the next raycaster tick throws. Guard both parent-relative rezeroing blocks with `hasParent`; an orphaned object has no meaningful bbox so skipping the update is correct.
- Also reset the module-level shared `tempBox3` with `makeEmpty()` at the top of `update()`, so when both bbox branches are skipped the `isEmpty()` check can't reuse another helper instance's stale box.
- Sentry: https://3dstreet.sentry.io/issues/6908493695/ (542 lifetime events)
- Distinct from the closed #1493 (that was `removeChild`-on-null in `street-generated-*` teardown).

## Risk
Low — pure null guards + a defensive box reset, no behavior change on the happy path. Lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)