### PR TITLE
fix(export): auto-preview checkbox stays reachable after preview generates

### DIFF
--- a/src/editor/components/modals/ExportModal/ExportModal.component.jsx
+++ b/src/editor/components/modals/ExportModal/ExportModal.component.jsx
@@ -313,15 +313,33 @@ function ExportModal() {
 
   const renderPreview = () => {
     if (formatKey === 'glb') {
+      // Rendered in both the ready state (footer strip under the iframe) and
+      // the empty state — with auto-preview on, the iframe appears
+      // immediately, so the footer is the only place left to turn it off.
+      const autoPreviewCheckbox = (
+        <Checkbox
+          id="export-auto-glb-preview"
+          isChecked={autoGlbPreview}
+          onChange={setAutoGlbPreviewPersisted}
+          label={intl.formatMessage({
+            id: 'exportModal.autoPreviewLabel',
+            defaultMessage: 'Automatically generate 3D preview'
+          })}
+        />
+      );
+
       if (glbPreviewCurrent.status === 'ready') {
         return (
-          <iframe
-            className={styles.previewIframe}
-            title="GLB preview"
-            src={`/model-viewer.html?src=${encodeURIComponent(
-              glbPreviewCurrent.url
-            )}`}
-          />
+          <div className={styles.glbPreviewWrapper}>
+            <iframe
+              className={styles.previewIframe}
+              title="GLB preview"
+              src={`/model-viewer.html?src=${encodeURIComponent(
+                glbPreviewCurrent.url
+              )}`}
+            />
+            <div className={styles.previewFooter}>{autoPreviewCheckbox}</div>
+          </div>
         );
       }
       return (
@@ -357,17 +375,7 @@ function ExportModal() {
               </p>
             </>
           )}
-          <div className={styles.autoPreviewOption}>
-            <Checkbox
-              id="export-auto-glb-preview"
-              isChecked={autoGlbPreview}
-              onChange={setAutoGlbPreviewPersisted}
-              label={intl.formatMessage({
-                id: 'exportModal.autoPreviewLabel',
-                defaultMessage: 'Automatically generate 3D preview'
-              })}
-            />
-          </div>
+          <div className={styles.autoPreviewOption}>{autoPreviewCheckbox}</div>
         </div>
       );
     }

--- a/src/editor/components/modals/ExportModal/ExportModal.module.scss
+++ b/src/editor/components/modals/ExportModal/ExportModal.module.scss
@@ -158,6 +158,26 @@
   height: 100%;
 }
 
+// Iframe + footer column for the ready GLB preview.
+.glbPreviewWrapper {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+// Thin strip under the iframe hosting the auto-preview checkbox — with
+// auto-preview on, the iframe replaces the empty state instantly, so this is
+// the only place left to turn the setting back off.
+.previewFooter {
+  padding: 8px 16px;
+  font-size: 12px;
+  color: variables.$lightgray-700;
+  border-top: 1px solid variables.$darkgray-600;
+  background-color: variables.$darkgray-300;
+}
+
 .previewEmptyState {
   flex: 1;
   display: flex;


### PR DESCRIPTION
Follow-up to #1821. With auto-preview enabled, the generated preview's iframe replaced the empty state instantly, so the only control for the setting disappeared (no way to turn it back off). The ready state now renders a thin footer strip under the iframe with the same checkbox; turning it off keeps the already-generated preview.

Replaces #1830, which showed stale conflicts because the squash-merge of #1821 rewrote the branch history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)