### PR TITLE
fix(generator): plan-scaled per-file cap for splat source video

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ The cloud URL lives in `gltf-model` / `src`. Firebase Storage download tokens al
 - `onAssetWritten` — Firestore trigger, maintains `users/{uid}/meta/usage.bytesUsed` via transaction. Only `size` (original) counts toward quota; `optimizedSourceSize` is excluded (platform cost).
 - `getUploadQuota` — callable, reads plan via `getAuth().getUser(uid)` (Admin SDK, always fresh custom claims). Returns `{ bytesUsed, planLimit, planName, allowed }`.
 
-**Plan limits (decimal):** FREE 100 MB · PRO 5 GB · MAX 25 GB (reserved; no users today). Per-file caps: GLB 50 MB · image 10 MB.
+**Plan limits (decimal):** total storage FREE 100 MB · PRO 5 GB · MAX 25 GB (reserved; no users today). Per-file caps are plan-scaled and type-agnostic (`MAX_FILE_BYTES_BY_PLAN` in `public/functions/asset-quota.js`, surfaced as `getUploadQuota().perFileLimit`): FREE 100 MB · PRO 1 GB · MAX 5 GB. Soft-enforced client-side + preflight; `storage.rules` holds a flat 5 GB hard ceiling.
 
 **Security rules:**
 

--- a/src/generator/splat.js
+++ b/src/generator/splat.js
@@ -101,10 +101,16 @@ const SPLAT_MODELS = {
 
 const DEFAULT_SPLAT_MODEL = 'sharp-ml';
 
-// Per-file ceiling for the uploaded source video (client-side guard; the
-// Storage rules backstop is far higher). Keep videos short — a 10–30s orbit is
-// plenty and keeps reconstruction time and cost reasonable.
-const VIDEO_MAX_BYTES = 200 * 1024 * 1024; // 200 MB
+// The source video is capped by the user's plan-scaled PER-FILE limit
+// (MAX_FILE_BYTES_BY_PLAN in public/functions/asset-quota.js — FREE 100 MB /
+// PRO 1 GB / MAX 5 GB, type-agnostic by design), fetched via getUploadQuota's
+// `perFileLimit`. Only the per-file gate applies: the video is transient
+// (deleted server-side when the job finishes, never a gallery asset), so the
+// total-storage quota is irrelevant here. This constant is the FALLBACK used
+// when the plan can't be resolved (signed out, callable unavailable); decimal
+// MB to match how plan limits are displayed. Storage rules hold the 5 GB hard
+// ceiling either way.
+const VIDEO_FALLBACK_MAX_BYTES = 200 * 1000 * 1000; // 200 MB
 
 const SplatTab = {
   elements: {},
@@ -476,19 +482,51 @@ const SplatTab = {
     this.elements.sourceUploadLabel.classList.remove('hidden');
   },
 
-  setSourceVideo(file) {
-    if (file.size > VIDEO_MAX_BYTES) {
-      FluxUI.showNotification(
-        `Video is too large (max ${Math.round(VIDEO_MAX_BYTES / (1024 * 1024))} MB). Trim it to a short orbit and try again.`,
-        'error'
-      );
-      this.clearSourceVideo();
-      return;
+  // Plan-scaled per-file cap check. Resolves to an error message when the
+  // file exceeds the user's per-file limit, else null. Falls back to the
+  // flat 200 MB guard when the plan can't be resolved.
+  async videoSizeError(file) {
+    const fallbackError =
+      file.size > VIDEO_FALLBACK_MAX_BYTES
+        ? `Video is too large (max ${Math.round(VIDEO_FALLBACK_MAX_BYTES / 1e6)} MB). Trim it to a short orbit and try again.`
+        : null;
+    if (!auth.currentUser) {
+      // Signed-out users can still stage a file; generateSplat re-checks
+      // against the real plan after sign-in.
+      return fallbackError;
     }
+    try {
+      const getUploadQuota = httpsCallable(functions, 'getUploadQuota');
+      const { data: quota } = await getUploadQuota({ proposedBytes: 0 });
+      const limit = Number(quota?.perFileLimit);
+      if (!limit) return fallbackError;
+      if (file.size <= limit) return null;
+      const limitMb = Math.round(limit / 1e6);
+      const fileMb = Math.round(file.size / 1e6);
+      return `This video is ${fileMb} MB; the ${quota.planName} plan allows ${limitMb} MB per file. Upgrade for larger uploads, or trim the video to a shorter orbit.`;
+    } catch (err) {
+      console.warn(
+        '[splat] per-file limit check unavailable, using fallback',
+        err
+      );
+      return fallbackError;
+    }
+  },
+
+  async setSourceVideo(file) {
+    // Show the selection immediately, then validate against the plan's
+    // per-file cap (callable round-trip) and roll back if it fails.
     this.sourceVideoFile = file;
     this.elements.videoSelectedName.textContent = file.name;
     this.elements.videoUploadLabel.classList.add('hidden');
     this.elements.videoSelected.classList.remove('hidden');
+
+    const error = await this.videoSizeError(file);
+    // Only roll back if this file is still the active selection.
+    if (error && this.sourceVideoFile === file) {
+      FluxUI.showNotification(error, 'error');
+      this.clearSourceVideo();
+    }
   },
 
   clearSourceVideo() {
@@ -633,11 +671,22 @@ const SplatTab = {
   async generateSplat() {
     if (!this.validate()) return;
 
+    const model = this.currentModel();
+
+    // Re-check the per-file cap at generate time: the file may have been
+    // staged while signed out, or the plan may have changed since selection.
+    if (model.inputKind === 'video') {
+      const sizeError = await this.videoSizeError(this.sourceVideoFile);
+      if (sizeError) {
+        FluxUI.showNotification(sizeError, 'error');
+        return;
+      }
+    }
+
     this.stopPolling();
     this.toggleLoading(true);
 
     try {
-      const model = this.currentModel();
       const generateReplicateSplat = httpsCallable(
         functions,
         'generateReplicateSplat'


### PR DESCRIPTION
## Problem

Uploading a 260 MB video to the Splat tab fails with a flat "max 200 MB" error. That limit is a leftover client constant (`VIDEO_MAX_BYTES`) from before the asset quota system existed; it never consults the plan, while the rest of the app enforces the plan-scaled per-file cap (`MAX_FILE_BYTES_BY_PLAN` in `public/functions/asset-quota.js`: FREE 100 MB / PRO 1 GB / MAX 5 GB, deliberately type-agnostic).

## Change

The Splat tab now uses the same authority as everything else: `getUploadQuota`'s `perFileLimit`.

- **File-select time:** the selection shows immediately, the callable validates in the background, and an over-limit file rolls back with a plan-aware message ("This video is 260 MB; the FREE plan allows 100 MB per file. Upgrade for larger uploads, or trim the video to a shorter orbit.").
- **Generate time:** re-checked before upload, covering files staged while signed out and plan changes since selection.
- **Per-file gate only, by design:** the source video is transient (the Cloud Function deletes it when the job finishes, and it never becomes a gallery asset / never counts toward `bytesUsed`), so the total-storage quota is intentionally not consulted.
- The flat 200 MB check survives only as a fallback when the plan can't be resolved (signed out, callable unavailable); `storage.rules`' 5 GB hard ceiling backstops everything.

Note this **tightens** the cap for FREE users (100 MB < the old flat 200 MB) and raises it for PRO (1 GB) / MAX (5 GB) — the plan system working as designed.

## Test plan

- [ ] FREE account: select a 150 MB video → rejected with the FREE/100 MB upgrade message
- [ ] PRO account: select a 260 MB video → accepted, generation proceeds
- [ ] Signed out: select a 260 MB video → staged (fallback allows ≤200 MB only); after sign-in as PRO, Generate proceeds
- [ ] Callable failure (offline/App Check): falls back to the 200 MB guard with the old message

🤖 Generated with [Claude Code](https://claude.com/claude-code)