### PR TITLE
layer panel: pull Driveable Taxi, move Traffic Replay to Custom

### DIFF
--- a/src/editor/components/elements/AddLayerPanel/layersData.js
+++ b/src/editor/components/elements/AddLayerPanel/layersData.js
@@ -30,11 +30,6 @@ export const streetLayersData = [
     icon: 'ui_assets/cards/icons/streetmix24.png',
     handlerFunction: createFunctions.createManagedStreetFromStreetmixURLPrompt
   }),
-  card(m.trafficReplayName, m.trafficReplayDesc, {
-    img: '',
-    icon: 'ui_assets/cards/icons/3dst24.png',
-    handlerFunction: createFunctions.createTrafficReplay
-  }),
   card(m.managedStreet4024Name, m.managedStreet4024Desc, {
     img: 'ui_assets/cards/street-preset-40-24.jpg',
     icon: 'ui_assets/cards/icons/3dst24.png',
@@ -139,17 +134,20 @@ export const customLayersData = [
     icon: '',
     handlerFunction: createFunctions.createDriveableDeliveryRobot
   }),
-  card(m.driveableTaxiName, m.driveableTaxiDesc, {
-    img: '',
-    requiresPro: false,
-    icon: '',
-    handlerFunction: createFunctions.createDriveableTaxi
-  }),
+  // Driveable Taxi card intentionally not surfaced yet (model/handling
+  // not ready) — the 'taxi' preset, createDriveableTaxi handler, and
+  // i18n messages all exist, so restoring it is one card() entry here.
   card(m.raceTargetName, m.raceTargetDesc, {
     img: '',
     requiresPro: false,
     icon: '',
     handlerFunction: createFunctions.createRaceTarget
+  }),
+  card(m.trafficReplayName, m.trafficReplayDesc, {
+    img: '',
+    requiresPro: false,
+    icon: 'ui_assets/cards/icons/3dst24.png',
+    handlerFunction: createFunctions.createTrafficReplay
   }),
   card(m.uploadSplatName, m.uploadSplatDesc, {
     img: '',


### PR DESCRIPTION
## What

Two Add Layer panel adjustments:

- **Remove the Driveable Taxi card** — the taxi driveable isn't ready to ship. Only the card entry is removed: the `taxi` vehicle preset, `createDriveableTaxi` handler, and i18n messages stay in place, so existing scenes that already contain a taxi still load and drive, and restoring the card later is a one-entry change (noted in a code comment).
- **Move Traffic Replay from the Streets group to Custom**, next to the other play-mode layers (driveable vehicles, Race Target).

## Test plan

- [x] Add Layer panel → Streets: no Traffic Replay card, street presets unchanged
- [x] Add Layer panel → Custom: Traffic Replay appears after Race Target; no Driveable Taxi card
- [ ] Adding Traffic Replay from its new home still creates the layer with the demo manifest
- [ ] A saved scene containing a previously-added Driveable Taxi still loads and drives

🤖 Generated with [Claude Code](https://claude.com/claude-code)