### PR TITLE
Cloud asset processing pipeline — phase 1: image thumbnails + optimized WebP variants (#1643)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ The cloud URL lives in `gltf-model` / `src`. Firebase Storage download tokens al
 
 - `onAssetWritten` — Firestore trigger, maintains `users/{uid}/meta/usage.bytesUsed` via transaction. Only `size` (original) counts toward quota; `optimizedSourceSize` is excluded (platform cost).
 - `getUploadQuota` — callable, reads plan via `getAuth().getUser(uid)` (Admin SDK, always fresh custom claims). Returns `{ bytesUsed, planLimit, planName, allowed }`.
+- `processAssetOnWrite` + `reapAssetProcessing` — cloud asset-processing pipeline (thumbnails + optimized variants; phase 1 = images via sharp). Transactional lease on `leaseExpiresAt`, `processingState` state machine, scheduled reaper backstop. Variants are platform artifacts (never counted toward quota). Design + rollout ordering: `docs/asset-processing-pipeline.md`.
 
 **Plan limits (decimal):** total storage FREE 100 MB · PRO 5 GB · MAX 25 GB (reserved; no users today). Per-file caps are plan-scaled and type-agnostic (`MAX_FILE_BYTES_BY_PLAN` in `public/functions/asset-quota.js`, surfaced as `getUploadQuota().perFileLimit`): FREE 100 MB · PRO 1 GB · MAX 5 GB. Soft-enforced client-side + preflight; `storage.rules` holds a flat 5 GB hard ceiling.
 

--- a/docs/asset-processing-pipeline.md
+++ b/docs/asset-processing-pipeline.md
@@ -1,0 +1,120 @@
+# Cloud asset processing pipeline (thumbnails + optimized variants)
+
+Design + rollout plan for #1643, a fast-follow to #1639 (user asset upload).
+Post-upload, every gallery asset should end up with (a) a small, cheap
+**thumbnail** for grid cards, and (b) where it pays off, an **optimized
+display variant** served in place of the original.
+
+## Rollout ordering
+
+Phases are ordered so that each one reuses the machinery of the previous one.
+The key observation: every asset type's thumbnail problem reduces to *"produce
+a source image, then run it through the shared image-optimize pass"* — so the
+image pass ships first and everything else feeds it.
+
+| Phase | Asset type | Poster / thumbnail | Optimized variant | Status |
+| ----- | ---------- | ------------------ | ----------------- | ------ |
+| 1 | **Image** | sharp → 512px WebP thumb (replaces client canvas JPEG) | sharp → ≤2048px high-compression WebP, served via `optimizedSourceUrl` | this PR |
+| 2 | **Video** | server-side poster frame (ffmpeg) → phase-1 image pass | poster *is* the optimized image; video transcode explicitly out of scope | next |
+| 3 | **Mesh (GLB)** | client model-viewer capture already exists → normalize through phase-1 pass; server-side headless render only as backfill | heavy KTX2/Meshopt GLB optimize = separate Cloud Run track (rad-converter pattern), decoupled from this ordering | later |
+| 4 | **Splat** | client Spark capture at upload (same trick as GLB) → phase-1 pass; server render TBD | already shipped: RAD/LOD via `onSplatAssetCreated` → Cloud Run | later |
+
+Why this order:
+
+1. **Images first** — smallest job (sharp in a Cloud Function, seconds per
+   asset), and it's where the pipeline *scaffolding* lands: the
+   `processingState` field contract, the lease/claim transaction, and the
+   reaper. Every later phase is "new poster producer + existing pipeline".
+   Server-side is required, not a nicety: job-queue results (Veo/Kling videos,
+   SHARP splats) are saved to the gallery **server-side with no client
+   attached**, so a client-only approach can never cover them.
+2. **Video posters second** — videos currently have *no* thumbnail at all
+   (gallery cards embed the `<video>` element), so this is the biggest visible
+   win. Server-side ffmpeg first, because the primary video creation path is
+   the server-side job processor (closed-tab saves — the whole point of the
+   job queue). Client-side mediabunny remains an optional instant-feedback
+   fast path later; it can never be the only path.
+3. **Mesh posters third** — lowest urgency because a decent client capture
+   already exists (`captureThumbnail.js`); enrolling meshes is then just
+   adding `'mesh'` to the pipeline's handled types and re-running the phase-1
+   image pass over the captured thumb. Server-side mesh rendering (headless
+   model-viewer / puppeteer in Cloud Run) is the most infra-heavy poster
+   producer, so it waits until it's just backfill for missed client captures.
+   The *other* mesh item from #1643 — server-side high-compression GLB
+   optimization (KTX2, Draco/Meshopt at higher settings, swap
+   `optimizedSourcePath`) — is a separate Cloud Run track mirroring
+   rad-converter, and doesn't block or gate the poster phases.
+4. **Splats last** — the optimized variant already exists (RAD pipeline);
+   only the poster is missing, and rendering a splat needs either a client
+   Spark capture (cheap, do first) or a GPU-ish server render (TBD once
+   format choices stabilize).
+
+## Architecture
+
+Event-driven + reaper, not pure polling:
+
+```
+asset doc written (client upload OR server-side gallery save)
+  └─ processAssetOnWrite (Firestore trigger, asset-processing.js)
+       ├─ eligible + unclaimed? → transactional lease claim
+       ├─ process inline (phase 1: sharp — fast enough for a Function)
+       └─ write variants + processingState:'done' (or retry/failed)
+
+asset-processing reaper (scheduled, every 10 min)
+  ├─ expired leases (crashed/timed-out worker) → re-claim + re-process
+  ├─ pending retries whose backoff elapsed     → re-claim + re-process
+  └─ recent creations the trigger missed        → enroll + process
+```
+
+- **Locking**: Firestore transaction on `leaseExpiresAt`. `leaseExpiresAt`
+  doubles as a *not-before* time on `pending` retries, so one composite index
+  `(processingState, leaseExpiresAt)` serves the whole reaper query.
+- **Cloud Tasks / Cloud Run**: deliberately NOT used in phase 1 — sharp on an
+  image is seconds of work, inline in the trigger is simpler and has fewer
+  moving parts. Heavier work (GLB optimize, possibly ffmpeg) reuses the
+  proven Cloud Tasks → Cloud Run dispatch from `rad-dispatch.js` when its
+  phase lands.
+- **Idempotent by construction**: variant filenames are keyed on `assetId`
+  (`{assetId}-thumb.webp`, `{assetId}-optimized.webp`), so a duplicate run
+  overwrites the same objects and re-patches the same doc.
+
+## Asset doc field contract
+
+| Field | Meaning |
+| ----- | ------- |
+| `processingState` | `pending` \| `running` \| `done` \| `failed` (terminal) |
+| `processingAttempts` | attempt counter; `failed` once `MAX_ATTEMPTS` reached |
+| `leaseExpiresAt` | lease deadline while `running`; earliest-retry time while `pending`; cleared on terminal states |
+| `processingVersion` | pipeline version that produced the variants — bump `PROCESSING_VERSION` to make touched assets reprocess |
+| `processedAt` | server timestamp of last successful run |
+| `processingError` | last error message (retry/failed paths) |
+| `processingSkipped` | reason variants were intentionally not produced (e.g. `source_too_large`) — still `done` |
+| `thumbnailPath` / `thumbnailUrl` | generated thumbnail (all types eventually) |
+| `optimizedSourcePath` / `optimizedSourceUrl` / `optimizedSourceSize` | optimized display variant — same contract GLB client optimization already uses; `getServedUrl()` prefers it automatically |
+
+Legacy assets (created before the pipeline) are enrolled lazily: any doc
+touch (rename, re-save) fires the trigger and processes them. A bulk backfill
+can later be a `dryRun=false` mode on the admin manual trigger.
+
+## Quota accounting
+
+Unchanged rule, inherited automatically: `onAssetWritten` sums only `size`
+(the original upload). All generated variants are platform-derived artifacts —
+stored with `customMetadata.assetRole = 'thumbnail' | 'optimized'`, sizes kept
+in fields other than `size` — so they never count toward user quota.
+
+## Serving behavior change (phase 1)
+
+`getServedUrl()` (`optimizedSourceUrl ?? storageUrl`) previously only ever
+found `optimizedSourceUrl` on GLBs. Images now get one too (≤2048px WebP), so
+placed image entities and scene loads serve the optimized variant
+automatically. Downloads intentionally keep using `storageUrl` (the original)
+— see `downloadItem` in `useAssets.js`.
+
+## Open questions carried forward
+
+- Video posters: exact ffmpeg runtime (Function w/ ffmpeg-static vs Cloud
+  Run) — decide when phase 2 starts, based on memory profile of real uploads.
+- Mesh: rendered server-side preview (offscreen render) — only as backfill;
+  measure how often client capture actually fails before building it.
+- Splat poster: client Spark capture first; server render TBD.

--- a/public/firestore.indexes.json
+++ b/public/firestore.indexes.json
@@ -41,6 +41,34 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "assets",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "processingState",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "leaseExpiresAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assets",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "deleted",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/public/functions/asset-processing.js
+++ b/public/functions/asset-processing.js
@@ -1,0 +1,327 @@
+/**
+ * Cloud asset processing pipeline — phase 1: images (#1643).
+ *
+ * Post-upload, produce for every image asset:
+ *   - a small WebP thumbnail ({assetId}-thumb.webp, ≤512px) that replaces the
+ *     client's canvas JPEG on gallery cards, and
+ *   - an optimized display variant ({assetId}-optimized.webp, ≤2048px,
+ *     high-compression) written to the same optimizedSource* fields the GLB
+ *     client optimization uses — getServedUrl() picks it up automatically.
+ *
+ * Server-side is required, not a nicety: job-queue results are saved to the
+ * gallery server-side with no client attached, so a client-only pass can
+ * never cover them. Later phases (video posters, mesh posters, splat posters)
+ * add new "poster producers" that feed this same image pass — see
+ * docs/asset-processing-pipeline.md for the rollout ordering.
+ *
+ * Flow: the Firestore trigger claims the doc via a transactional lease
+ * (leaseExpiresAt) and processes inline — sharp on an image is seconds of
+ * work, so no Cloud Tasks indirection. Crashed/timed-out runs auto-release
+ * when the lease expires; the scheduled reaper
+ * (scheduled/asset-processing-reaper.js) re-takes them. leaseExpiresAt
+ * doubles as the not-before time on 'pending' retries so one composite index
+ * (processingState, leaseExpiresAt) serves the whole reaper query.
+ *
+ * Idempotent by construction: variant filenames are keyed on assetId, so a
+ * duplicate run (trigger racing the reaper) overwrites the same Storage
+ * objects and re-patches the same doc. Only the transaction claim decides
+ * who actually does the work.
+ *
+ * Quota: variants never count — onAssetWritten sums only `size`, and variant
+ * sizes live in other fields. Storage objects carry assetRole metadata
+ * ('thumbnail' / 'optimized') for byte-level audit scripts.
+ */
+
+const functions = require('firebase-functions/v1');
+const admin = require('firebase-admin');
+const crypto = require('crypto');
+
+// Bump to make already-'done' assets eligible again on their next doc touch
+// (or via a future backfill mode on the reaper's manual trigger).
+const PROCESSING_VERSION = 1;
+
+// Asset types the pipeline can currently produce variants for. Phase 2 adds
+// 'video' (poster frame → this same image pass), then 'mesh'/'splat' posters.
+// Types not listed are never enrolled — enrolling without a handler would
+// just make the reaper churn on permanently-pending docs.
+const HANDLED_TYPES = ['image'];
+
+const MAX_ATTEMPTS = 3;
+// Lease long enough to cover a slow download + sharp on a big image with the
+// function's own timeout (120s) as the real ceiling.
+const LEASE_MS = 4 * 60 * 1000;
+// Retry backoff between failed attempts (attempt n waits n × this).
+const RETRY_BACKOFF_MS = 5 * 60 * 1000;
+// Don't buffer arbitrarily large originals into memory (per-file plan caps
+// allow up to 1 GB+). Past this, skip variants — terminal, not an error.
+const MAX_SOURCE_BYTES = 80 * 1000 * 1000;
+
+const THUMB_MAX_PX = 512;
+const THUMB_WEBP_QUALITY = 75;
+const OPTIMIZED_MAX_PX = 2048;
+const OPTIMIZED_WEBP_QUALITY = 80;
+// Keep the optimized variant only when it meaningfully beats the original —
+// mirrors the client GLB optimizer's "not_smaller" skip.
+const OPTIMIZED_KEEP_RATIO = 0.9;
+
+function nowMs() {
+  return Date.now();
+}
+
+function tsMillis(ts) {
+  return ts && typeof ts.toMillis === 'function' ? ts.toMillis() : 0;
+}
+
+/**
+ * Whether this doc currently needs a processing run. Shared by the trigger,
+ * the claim transaction (re-checked inside), and the reaper, so all three
+ * agree on eligibility.
+ */
+function needsProcessing(data) {
+  if (!data || data.deleted) return false;
+  if (!HANDLED_TYPES.includes(data.type)) return false;
+  if (!data.storagePath) return false;
+
+  const state = data.processingState;
+  if (state === 'failed') return false; // terminal — manual intervention only
+  if (state === 'done') {
+    // Reprocess only when the pipeline version moved on.
+    return (Number(data.processingVersion) || 0) < PROCESSING_VERSION;
+  }
+  if (state === 'running' || state === 'pending') {
+    // running: lease still held → someone else is on it.
+    // pending: leaseExpiresAt is the earliest-retry time.
+    return tsMillis(data.leaseExpiresAt) <= nowMs();
+  }
+  // No processingState at all: never enrolled (new upload, or a legacy doc
+  // being lazily enrolled by any touch).
+  return true;
+}
+
+/**
+ * Transactionally claim the doc for processing. Returns the claimed doc data
+ * or null when someone else won the race (or the doc stopped being eligible).
+ */
+async function claimAsset(docRef) {
+  const db = admin.firestore();
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(docRef);
+    if (!snap.exists) return null;
+    const data = snap.data();
+    if (!needsProcessing(data)) return null;
+    tx.update(docRef, {
+      processingState: 'running',
+      processingAttempts: admin.firestore.FieldValue.increment(1),
+      leaseExpiresAt: admin.firestore.Timestamp.fromMillis(nowMs() + LEASE_MS)
+    });
+    return data;
+  });
+}
+
+/**
+ * Release a claim after a failed run: back off for another attempt, or mark
+ * terminally failed once attempts are exhausted.
+ */
+async function releaseFailed(docRef, err) {
+  const db = admin.firestore();
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(docRef);
+    if (!snap.exists) return;
+    const attempts = Number(snap.data().processingAttempts) || 1;
+    const message = String((err && err.message) || err).slice(0, 500);
+    if (attempts >= MAX_ATTEMPTS) {
+      tx.update(docRef, {
+        processingState: 'failed',
+        processingError: message,
+        leaseExpiresAt: admin.firestore.FieldValue.delete()
+      });
+    } else {
+      tx.update(docRef, {
+        processingState: 'pending',
+        processingError: message,
+        leaseExpiresAt: admin.firestore.Timestamp.fromMillis(
+          nowMs() + attempts * RETRY_BACKOFF_MS
+        )
+      });
+    }
+  });
+}
+
+function tokenUrl(bucketName, storagePath, token) {
+  return (
+    `https://firebasestorage.googleapis.com/v0/b/${bucketName}/o/` +
+    `${encodeURIComponent(storagePath)}?alt=media&token=${token}`
+  );
+}
+
+async function uploadVariant(bucket, storagePath, buffer, assetId, assetRole) {
+  const token = crypto.randomUUID();
+  await bucket.file(storagePath).save(buffer, {
+    resumable: false,
+    metadata: {
+      contentType: 'image/webp',
+      // Immutable content (keyed by assetId) — matches the client uploader.
+      cacheControl: 'public, max-age=31536000',
+      metadata: {
+        // Anonymous scene viewers load via this token, same as originals.
+        firebaseStorageDownloadTokens: token,
+        // Platform-derived artifact: audit scripts exclude from user quota.
+        assetRole,
+        assetId
+      }
+    }
+  });
+  return tokenUrl(bucket.name, storagePath, token);
+}
+
+/**
+ * Produce and store variants for an IMAGE asset. Returns the doc update to
+ * apply on success.
+ */
+async function processImage(docRef, data) {
+  // Lazy require: sharp's native binding is only paid for by this pipeline's
+  // invocations, not every function sharing this bundle's cold start.
+  const sharp = require('sharp');
+  const bucket = admin.storage().bucket();
+  const assetId = data.assetId || docRef.id;
+
+  const size = Number(data.size) || 0;
+  if (size > MAX_SOURCE_BYTES) {
+    return {
+      processingSkipped: 'source_too_large'
+    };
+  }
+
+  const [buffer] = await bucket.file(data.storagePath).download();
+
+  // .rotate() bakes EXIF orientation so variants render upright everywhere.
+  // failOn:'none' tolerates minor corruption instead of rejecting the file.
+  const base = sharp(buffer, { failOn: 'none' }).rotate();
+  const meta = await base.metadata();
+
+  // Variants live next to the original (users/{uid}/assets/images/...).
+  const folder = data.storagePath.slice(0, data.storagePath.lastIndexOf('/'));
+
+  const thumbBuffer = await base
+    .clone()
+    .resize({
+      width: THUMB_MAX_PX,
+      height: THUMB_MAX_PX,
+      fit: 'inside',
+      withoutEnlargement: true
+    })
+    .webp({ quality: THUMB_WEBP_QUALITY })
+    .toBuffer();
+  const thumbnailPath = `${folder}/${assetId}-thumb.webp`;
+  const thumbnailUrl = await uploadVariant(
+    bucket,
+    thumbnailPath,
+    thumbBuffer,
+    assetId,
+    'thumbnail'
+  );
+
+  const update = {
+    thumbnailPath,
+    thumbnailUrl,
+    // Backfill dimensions when the doc doesn't have them (server-side saves
+    // skip the client's <img> probe).
+    ...(!data.dimensions && meta.width && meta.height
+      ? { dimensions: { width: meta.width, height: meta.height } }
+      : {})
+  };
+
+  // Replace the client's canvas JPEG thumb file when we just superseded it.
+  // Best-effort — the monthly orphan cleanup is the backstop.
+  if (data.thumbnailPath && data.thumbnailPath !== thumbnailPath) {
+    await bucket
+      .file(data.thumbnailPath)
+      .delete()
+      .catch(() => {});
+  }
+
+  const optimizedBuffer = await base
+    .clone()
+    .resize({
+      width: OPTIMIZED_MAX_PX,
+      height: OPTIMIZED_MAX_PX,
+      fit: 'inside',
+      withoutEnlargement: true
+    })
+    .webp({ quality: OPTIMIZED_WEBP_QUALITY })
+    .toBuffer();
+
+  if (optimizedBuffer.length < buffer.length * OPTIMIZED_KEEP_RATIO) {
+    const optimizedSourcePath = `${folder}/${assetId}-optimized.webp`;
+    update.optimizedSourceUrl = await uploadVariant(
+      bucket,
+      optimizedSourcePath,
+      optimizedBuffer,
+      assetId,
+      'optimized'
+    );
+    update.optimizedSourcePath = optimizedSourcePath;
+    update.optimizedSourceSize = optimizedBuffer.length;
+  } else {
+    update.processingSkipped = 'optimized_not_smaller';
+  }
+
+  return update;
+}
+
+/**
+ * Claim + process + finalize one asset doc. Safe to call from both the
+ * trigger and the reaper; the claim transaction dedupes racing callers.
+ * Returns a short action string for logs/summaries.
+ */
+async function processAsset(docRef) {
+  const claimed = await claimAsset(docRef);
+  if (!claimed) return 'skipped';
+
+  try {
+    // Only 'image' today (HANDLED_TYPES gates enrollment); this becomes a
+    // per-type dispatch when video/mesh/splat posters land.
+    const update = await processImage(docRef, claimed);
+    await docRef.update({
+      ...update,
+      processingState: 'done',
+      processingVersion: PROCESSING_VERSION,
+      processedAt: admin.firestore.FieldValue.serverTimestamp(),
+      leaseExpiresAt: admin.firestore.FieldValue.delete(),
+      processingError: admin.firestore.FieldValue.delete()
+    });
+    return 'processed';
+  } catch (err) {
+    console.error(
+      `[asset-processing] failed for ${docRef.path}:`,
+      (err && err.message) || err
+    );
+    await releaseFailed(docRef, err);
+    return 'errored';
+  }
+}
+
+/**
+ * Firestore trigger: enroll + process eligible assets as they're written.
+ * Fires on every asset write (uploads, renames, our own status writes) —
+ * needsProcessing() makes the non-actionable ones cheap no-ops, including
+ * the writes this pipeline itself makes ('running' with live lease, 'done').
+ */
+const processAssetOnWrite = functions
+  .runWith({ memory: '1GB', timeoutSeconds: 120 })
+  .firestore.document('users/{userId}/assets/{assetId}')
+  .onWrite(async (change) => {
+    if (!change.after.exists) return null;
+    const after = change.after.data();
+    if (!needsProcessing(after)) return null;
+    await processAsset(change.after.ref);
+    return null;
+  });
+
+module.exports = {
+  processAssetOnWrite,
+  processAsset,
+  needsProcessing,
+  HANDLED_TYPES,
+  PROCESSING_VERSION
+};

--- a/public/functions/index.js
+++ b/public/functions/index.js
@@ -21,6 +21,8 @@ const { checkAssetUsageHealth, triggerCheckAssetUsageHealth } = require('./sched
 const { cleanupOrphanedStorage, triggerCleanupOrphanedStorage } = require('./scheduled/asset-orphan-cleanup.js');
 const { reconcileGenerationJobs, triggerReconcileGenerationJobs } = require('./scheduled/generation-job-reconcile.js');
 const { onSplatAssetCreated } = require('./rad-dispatch.js');
+const { processAssetOnWrite } = require('./asset-processing.js');
+const { reapAssetProcessing, triggerReapAssetProcessing } = require('./scheduled/asset-processing-reaper.js');
 const { generateEditorChat } = require('./ai-chat-proxy.js');
 
 // Re-export the getGeoidHeight function
@@ -88,6 +90,14 @@ exports.triggerReconcileGenerationJobs = triggerReconcileGenerationJobs;
 
 // --- RAD conversion (splat optimized variant) -----------------------------
 exports.onSplatAssetCreated = onSplatAssetCreated;
+
+// Asset processing pipeline — thumbnails + optimized variants (#1643).
+// Phase 1: images (sharp WebP thumb + optimized display variant). Firestore
+// trigger is the primary path; the reaper re-takes stuck/missed docs.
+// See docs/asset-processing-pipeline.md.
+exports.processAssetOnWrite = processAssetOnWrite;
+exports.reapAssetProcessing = reapAssetProcessing;
+exports.triggerReapAssetProcessing = triggerReapAssetProcessing;
 
 // Editor AI Assistant — server-side gate for the Vertex/Gemini chat. The client
 // no longer calls Firebase AI Logic directly (model selection was abusable); all

--- a/public/functions/package-lock.json
+++ b/public/functions/package-lock.json
@@ -13,6 +13,7 @@
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^7.0.0",
         "replicate": "^1.0.0",
+        "sharp": "^0.34.2",
         "stripe": "^22.2.1"
       },
       "devDependencies": {
@@ -594,10 +595,8 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1226,6 +1225,471 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3578,6 +4042,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -7467,6 +7940,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/public/functions/package.json
+++ b/public/functions/package.json
@@ -21,6 +21,7 @@
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^7.0.0",
     "replicate": "^1.0.0",
+    "sharp": "^0.34.2",
     "stripe": "^22.2.1"
   },
   "devDependencies": {

--- a/public/functions/scheduled/asset-processing-reaper.js
+++ b/public/functions/scheduled/asset-processing-reaper.js
@@ -1,0 +1,162 @@
+/**
+ * Asset-processing reaper — the backstop for asset-processing.js (#1643).
+ *
+ * The Firestore trigger is the primary path; this sweep only catches what it
+ * can't finish on its own:
+ *   - 'running' docs whose lease expired (worker crashed or timed out)
+ *   - 'pending' retries whose backoff window has elapsed
+ *   - recent creations the trigger never enrolled (dropped event)
+ *
+ * Both stuck-classes come from ONE composite index (processingState,
+ * leaseExpiresAt) because leaseExpiresAt doubles as the not-before time on
+ * 'pending' docs. Re-processing goes through the same transactional claim as
+ * the trigger (processAsset), so racing a live trigger is harmless.
+ *
+ * Two entry points:
+ *   - reapAssetProcessing        : pubsub schedule, every 10 min
+ *   - triggerReapAssetProcessing : admin-only callable, dryRun default
+ */
+
+const functions = require('firebase-functions/v1');
+const admin = require('firebase-admin');
+const { assertAppCheck } = require('../app-check.js');
+const { withJobHealth } = require('./job-health.js');
+const {
+  processAsset,
+  needsProcessing
+} = require('../asset-processing.js');
+
+const TEN_MIN_MS = 10 * 60 * 1000;
+
+// Cap per sweep so a pathological backlog can't blow the time budget; the
+// next tick picks up the remainder.
+const MAX_STUCK_PER_RUN = 50;
+
+// Missed-enrollment scan: only look at recent creations (the trigger delivers
+// at-least-once, so a genuinely dropped event is rare) — anything older is
+// legacy backlog, which enrolls lazily on its next doc touch instead.
+const MISSED_SCAN_LIMIT = 100;
+const MISSED_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+async function reap({ dryRun }) {
+  const db = admin.firestore();
+  const now = admin.firestore.Timestamp.now();
+
+  const summary = {
+    stuckScanned: 0,
+    missedScanned: 0,
+    processed: 0,
+    skipped: 0,
+    errored: 0,
+    samples: [],
+    dryRun
+  };
+
+  const handleDoc = async (docSnap, source) => {
+    const sample = { path: docSnap.ref.path, source };
+    if (dryRun) {
+      sample.action = 'would-process';
+      summary.processed++;
+    } else {
+      // processAsset re-checks eligibility inside its claim transaction, so a
+      // doc the live trigger already grabbed just counts as 'skipped'.
+      const action = await processAsset(docSnap.ref);
+      sample.action = action;
+      if (action === 'processed') summary.processed++;
+      else if (action === 'errored') summary.errored++;
+      else summary.skipped++;
+    }
+    if (summary.samples.length < 25) summary.samples.push(sample);
+  };
+
+  // 1) Expired leases + elapsed retry backoffs.
+  const stuckSnap = await db
+    .collectionGroup('assets')
+    .where('processingState', 'in', ['pending', 'running'])
+    .where('leaseExpiresAt', '<=', now)
+    .limit(MAX_STUCK_PER_RUN)
+    .get();
+  summary.stuckScanned = stuckSnap.size;
+  for (const docSnap of stuckSnap.docs) {
+    await handleDoc(docSnap, 'stuck');
+  }
+
+  // 2) Recent creations the trigger missed (no processingState at all).
+  const recentSnap = await db
+    .collectionGroup('assets')
+    .where('deleted', '==', false)
+    .orderBy('createdAt', 'desc')
+    .limit(MISSED_SCAN_LIMIT)
+    .get();
+  const cutoffMs = Date.now() - MISSED_MAX_AGE_MS;
+  for (const docSnap of recentSnap.docs) {
+    const data = docSnap.data();
+    const createdMs =
+      data.createdAt && data.createdAt.toMillis ? data.createdAt.toMillis() : 0;
+    if (createdMs && createdMs < cutoffMs) break; // ordered desc — all older
+    if (data.processingState) continue; // enrolled — bucket 1 owns it
+    if (!needsProcessing(data)) continue;
+    summary.missedScanned++;
+    await handleDoc(docSnap, 'missed');
+  }
+
+  return summary;
+}
+
+const reapAssetProcessing = functions
+  .runWith({
+    // Same profile as the trigger worker — the sweep runs the identical sharp
+    // pass, just over the backlog, one asset at a time.
+    memory: '1GB',
+    timeoutSeconds: 540
+  })
+  .pubsub.schedule('*/10 * * * *') // every 10 minutes
+  .timeZone('America/Los_Angeles')
+  .onRun(
+    withJobHealth(
+      'reapAssetProcessing',
+      {
+        schedule: '*/10 * * * *',
+        timeZone: 'America/Los_Angeles',
+        expectedIntervalMs: TEN_MIN_MS,
+        degradedKeys: ['errored']
+      },
+      async () => {
+        console.log('[asset-processing-reaper] starting sweep');
+        const summary = await reap({ dryRun: false });
+        console.log(
+          '[asset-processing-reaper] complete:',
+          JSON.stringify(summary)
+        );
+        return summary;
+      }
+    )
+  );
+
+const triggerReapAssetProcessing = functions
+  .runWith({ memory: '1GB', timeoutSeconds: 540 })
+  .https.onCall(async (data, context) => {
+    assertAppCheck(context);
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'unauthenticated',
+        'User must be authenticated.'
+      );
+    }
+    if (!context.auth.token.admin) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'Admin access required.'
+      );
+    }
+    const dryRun = data?.dryRun ?? true;
+    console.log(`[asset-processing-reaper] manual trigger (dryRun=${dryRun})`);
+    const summary = await reap({ dryRun });
+    console.log(
+      '[asset-processing-reaper] manual run complete:',
+      JSON.stringify(summary)
+    );
+    return summary;
+  });
+
+module.exports = { reapAssetProcessing, triggerReapAssetProcessing };

--- a/src/shared/assets/utils.js
+++ b/src/shared/assets/utils.js
@@ -58,10 +58,11 @@ export function is3dViewerType(type) {
 }
 
 /**
- * URL to use when loading or placing a GLB asset. Prefers the client-optimized
- * version (Draco + WebP) when available; falls back to the original source.
- * Safe to call on image/video assets too — they never have optimizedSourceUrl
- * so storageUrl is always returned.
+ * URL to use when loading or placing an asset. Prefers the optimized variant
+ * when available — for GLBs the client-optimized file (Draco + WebP), for
+ * images the server-generated display WebP (asset-processing pipeline,
+ * docs/asset-processing-pipeline.md) — falling back to the original source.
+ * Downloads must NOT use this: they keep item.storageUrl (the original).
  */
 export function getServedUrl(item) {
   return item?.optimizedSourceUrl ?? item?.storageUrl;


### PR DESCRIPTION
Phase 1 of #1643 (fast-follow to #1639): server-side asset processing that produces thumbnails + optimized variants, starting with images — and lands the pipeline scaffolding every later phase reuses.

## Rollout ordering (the discussion part)

Ordering follows the principle that **every asset type's thumbnail problem reduces to "produce a source image, then run it through a shared image-optimize pass"** — so the image pass ships first and everything else feeds it:

1. **Images (this PR)** — sharp → ≤512px WebP thumb (replaces the client canvas JPEG) + ≤2048px high-compression WebP display variant. Smallest job, and it's where the field contract / lease / reaper scaffolding lands. Server-side is *required*, not a nicety: job-queue results (Veo/Kling videos, SHARP splats) are saved to the gallery server-side with no client attached.
2. **Video posters** — biggest visible win (videos have no thumbnail today; gallery cards embed the `<video>` element). Recommend **server-side ffmpeg first**, because the primary video creation path is the server-side job processor (closed-tab saves — the whole point of the job queue); client-side mediabunny can only ever be an instant-feedback fast path, never the only path. Poster frame feeds the phase-1 image pass.
3. **Mesh posters** — lowest urgency: a decent client model-viewer capture already exists; enrolling meshes is mostly adding `'mesh'` to the pipeline's handled types. Server-side headless rendering waits until it's just backfill for missed captures. The *heavy* KTX2/Meshopt GLB optimization from the issue is a separate Cloud Run track (rad-converter pattern) — decoupled from the poster ordering.
4. **Splats** — the optimized variant already ships (RAD pipeline); only the poster is missing. Client Spark capture first (same trick as GLB), server render TBD.

Full write-up: `docs/asset-processing-pipeline.md`.

## What's in this PR

- **`public/functions/asset-processing.js`** — `processAssetOnWrite` Firestore trigger on `users/{uid}/assets/{assetId}`:
  - Transactional lease claim on `leaseExpiresAt` (crashed runs auto-release); `processingState` / `processingAttempts` / `processingVersion` per the issue's field contract.
  - sharp inline (no Cloud Tasks — images are seconds of work; heavy phases reuse the proven `rad-dispatch.js` Cloud Tasks → Cloud Run pattern instead).
  - Thumbnail written to `thumbnailPath`/`thumbnailUrl` (supersedes + deletes the client's canvas JPEG); optimized variant written to the existing `optimizedSource*` fields (kept only if ≥10% smaller), so `getServedUrl()` serves it with **zero client changes**. Downloads keep using `storageUrl` (verified: `downloadItem` doesn't call `getServedUrl`).
  - Variant filenames keyed on `assetId` → idempotent re-runs; Storage objects tagged `assetRole: 'thumbnail' | 'optimized'` with download tokens for anonymous viewers.
- **`public/functions/scheduled/asset-processing-reaper.js`** — every-10-min sweep + admin manual trigger (`dryRun` default): expired leases, due retries, and recent creations the trigger missed. `leaseExpiresAt` doubles as the pending-retry not-before time, so one composite index serves the whole query.
- **`public/firestore.indexes.json`** — two `COLLECTION_GROUP` composites on `assets`: `(processingState, leaseExpiresAt)` and `(deleted, createdAt)`.
- **Quota unchanged by construction** — `onAssetWritten` only sums `size`; variant sizes live in other fields.
- Docs: `docs/asset-processing-pipeline.md` (design + ordering), CLAUDE.md note, updated `getServedUrl()` comment (images can now carry `optimizedSourceUrl`).

## Behavior notes / review focus

- **Serving change**: placed image entities and scene loads now resolve to the ≤2048px WebP once processing runs (`getServedUrl` preference). If we want originals in scenes at full resolution, we can raise the cap or gate this — flagging for review.
- Legacy assets enroll lazily (any doc touch fires the trigger); a bulk backfill can later ride the admin manual trigger.
- Existing videos are deliberately **not** enrolled (`HANDLED_TYPES = ['image']`) — enrolling without a handler would just make the reaper churn.
- Per-source cap of 80 MB for processing (buffered into memory in a 1 GB function); larger originals mark `done` with `processingSkipped: 'source_too_large'`.

## Verification

- `eslint` clean on the new/changed function files.
- Module load + `needsProcessing` state-machine assertions + a live sharp resize→WebP round-trip exercised under Node 22.
- Not yet deployed/emulator-tested end-to-end — draft until we run it against dev-3dstreet.

Closes nothing yet — tracks #1643 (phase 1 of 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMCoexbXiwV6R7HeeBq81F

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMCoexbXiwV6R7HeeBq81F)_