### PR TITLE
Fix asset-card drop handling priority in AddLayerPanel

### DIFF
--- a/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
+++ b/src/editor/components/elements/AddLayerPanel/AddLayerPanel.component.jsx
@@ -354,6 +354,34 @@ const AddLayerPanel = () => {
     };
 
     const handleGlobalDrop = (e) => {
+      // Asset-card drop from the gallery panel: place the existing cloud
+      // asset at the picked point (no upload). This MUST be checked before the
+      // file-drop branch below: when a mesh/splat card carries a thumbnail it
+      // renders an <img>, and browsers synthesize that thumbnail into
+      // dataTransfer.files on drop. Checking files first would misread the
+      // model/splat drop as an image upload (the thumbnail), so the presence of
+      // our explicit asset-card MIME payload always wins.
+      const assetPayload = e.dataTransfer?.getData?.(ASSET_CARD_MIME);
+      if (assetPayload) {
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+          const asset = JSON.parse(assetPayload);
+          const position = pickPointOnGroundPlane({
+            x: e.clientX,
+            y: e.clientY,
+            canvas: AFRAME.scenes[0].canvas,
+            camera: AFRAME.INSPECTOR.camera
+          });
+          placeCloudAsset(asset, position);
+        } catch (err) {
+          console.warn('[AddLayerPanel] bad asset drag payload', err);
+        }
+        if (dropPlaneEl.current) fadeOutDropPlane();
+        removeDropCursor();
+        return;
+      }
+
       // File drop: upload + place.
       if (
         e.dataTransfer &&
@@ -400,28 +428,6 @@ const AddLayerPanel = () => {
         if (dropPlaneEl.current) fadeOutDropPlane();
         removeDropCursor();
         return;
-      }
-
-      // Asset-card drop from the gallery panel: place the existing cloud
-      // asset at the picked point (no upload).
-      const assetPayload = e.dataTransfer?.getData?.(ASSET_CARD_MIME);
-      if (assetPayload) {
-        e.preventDefault();
-        e.stopPropagation();
-        try {
-          const asset = JSON.parse(assetPayload);
-          const position = pickPointOnGroundPlane({
-            x: e.clientX,
-            y: e.clientY,
-            canvas: AFRAME.scenes[0].canvas,
-            camera: AFRAME.INSPECTOR.camera
-          });
-          placeCloudAsset(asset, position);
-        } catch (err) {
-          console.warn('[AddLayerPanel] bad asset drag payload', err);
-        }
-        if (dropPlaneEl.current) fadeOutDropPlane();
-        removeDropCursor();
       }
     };
 


### PR DESCRIPTION
## Summary
Reorders the drop-handler logic in `handleGlobalDrop` to check for asset-card MIME payload **before** checking for file drops. This fixes a bug where dragging mesh/splat cards with thumbnails would be misinterpreted as image uploads instead of asset placements.

## Problem
When a mesh or splat asset card carries a thumbnail image, browsers synthesize that thumbnail into `dataTransfer.files` on drop. The previous code checked `dataTransfer.files` first, causing the file-drop handler to incorrectly interpret the thumbnail as an image upload rather than recognizing the explicit asset-card MIME payload.

## Solution
- Moved the asset-card MIME check to the top of `handleGlobalDrop`, before the file-drop logic
- Added detailed comments explaining why this ordering is critical
- The explicit `ASSET_CARD_MIME` payload now always takes precedence, preventing the browser's synthesized thumbnail from triggering the wrong handler

## Changes
- Reordered conditional branches in `handleGlobalDrop` (lines 354–430)
- Asset-card drop handler now executes first with early return
- File-drop handler remains unchanged, now only executes if no asset payload is present

https://claude.ai/code/session_01H8fTevMgKTSAekGDDo4Q1a