### PR TITLE
fix(traffic-replay): persist manifest through scene save/load

### DIFF
--- a/scripts/tmd-replay/sample-waterleaf-busiest-hour.json
+++ b/scripts/tmd-replay/sample-waterleaf-busiest-hour.json
@@ -2,7 +2,7 @@
   "meta": {
     "schemaVersion": 1,
     "source": "tmdb-rvc-waterleaf-2025-10-11.sqlite",
-    "description": "Anonymized street-user replay manifest. Each agent carries only mode, direction, speed and duration; timestamps are relative to the window start. No identifiers, images, scores, or absolute per-user times.",
+    "description": "Anonymized street-user replay manifest. Each agent carries only mode, direction, speed and duration, and timestamps are relative to the window start. No identifiers, images, scores, or absolute per-user times.",
     "deployment": {
       "lat": 45.464152,
       "lon": -122.66961,

--- a/scripts/tmd-replay/sample-waterleaf-busiest-minute.json
+++ b/scripts/tmd-replay/sample-waterleaf-busiest-minute.json
@@ -2,7 +2,7 @@
   "meta": {
     "schemaVersion": 1,
     "source": "tmdb-rvc-waterleaf-2025-10-11.sqlite",
-    "description": "Anonymized street-user replay manifest. Each agent carries only mode, direction, speed and duration; timestamps are relative to the window start. No identifiers, images, scores, or absolute per-user times.",
+    "description": "Anonymized street-user replay manifest. Each agent carries only mode, direction, speed and duration, and timestamps are relative to the window start. No identifiers, images, scores, or absolute per-user times.",
     "deployment": {
       "lat": 45.464152,
       "lon": -122.66961,

--- a/scripts/tmd-replay/tmd-to-replay.mjs
+++ b/scripts/tmd-replay/tmd-to-replay.mjs
@@ -196,8 +196,8 @@ const manifest = {
     source: dbPath.split('/').pop(),
     description:
       'Anonymized street-user replay manifest. Each agent carries only mode, ' +
-      'direction, speed and duration; timestamps are relative to the window ' +
-      'start. No identifiers, images, scores, or absolute per-user times.',
+      'direction, speed and duration, and timestamps are relative to the ' +
+      'window start. No identifiers, images, scores, or absolute per-user times.',
     deployment,
     speedUnit: 'mph',
     window: {

--- a/src/aframe-components/play/manifest-codec.js
+++ b/src/aframe-components/play/manifest-codec.js
@@ -1,0 +1,85 @@
+/**
+ * manifest-codec
+ * ==============
+ *
+ * Encode/decode a Traffic Replay manifest for safe storage inside an A-Frame
+ * component string property (`street-traffic-replay="manifestData: ..."`).
+ *
+ * Why this exists: A-Frame serializes a multi-property component as a single
+ * `key: value; key: value` string and, on load, splits that whole string on
+ * `;` (and each declaration on the first `:`) BEFORE any per-property parsing
+ * runs. A raw JSON manifest whose string fields contain a `;` (the converter's
+ * own `meta.description` does) therefore gets silently truncated at the first
+ * `;` on reload, leaving invalid JSON and an empty replay. Base64 uses only
+ * `[A-Za-z0-9+/=]` — no `;` — so it round-trips through the serializer intact.
+ *
+ * `encodeManifest` writes a `b64:`-prefixed value; `decodeManifest` accepts
+ * that, a bare base64 blob, or a legacy raw-JSON value (backward compatible
+ * with any scene saved before this fix), returning the parsed object or null.
+ */
+
+const B64_PREFIX = 'b64:';
+
+function base64FromUtf8(str) {
+  const bytes = new TextEncoder().encode(str);
+  if (typeof btoa === 'function') {
+    // Chunk the byte->binary-string conversion so String.fromCharCode.apply
+    // can't overflow the call stack on large manifests.
+    let binary = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return btoa(binary);
+  }
+  return Buffer.from(bytes).toString('base64'); // node (tests)
+}
+
+function utf8FromBase64(b64) {
+  if (typeof atob === 'function') {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+  }
+  return Buffer.from(b64, 'base64').toString('utf8'); // node (tests)
+}
+
+/**
+ * @param {object|string} manifest - a manifest object, or its JSON string.
+ * @returns {string} a serializer-safe value for `manifestData`.
+ */
+export function encodeManifest(manifest) {
+  const json =
+    typeof manifest === 'string' ? manifest : JSON.stringify(manifest);
+  return B64_PREFIX + base64FromUtf8(json);
+}
+
+/**
+ * @param {string} value - the stored `manifestData` (b64-prefixed, bare
+ *   base64, or legacy raw JSON).
+ * @returns {object|null} the parsed manifest, or null if unusable.
+ */
+export function decodeManifest(value) {
+  if (typeof value !== 'string' || !value) return null;
+  const trimmed = value.trim();
+  let json;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    json = trimmed; // legacy raw-JSON value (pre-fix scenes)
+  } else {
+    try {
+      json = utf8FromBase64(
+        trimmed.startsWith(B64_PREFIX)
+          ? trimmed.slice(B64_PREFIX.length)
+          : trimmed
+      );
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}

--- a/src/aframe-components/play/manifest-codec.js
+++ b/src/aframe-components/play/manifest-codec.js
@@ -1,0 +1,88 @@
+/**
+ * manifest-codec
+ * ==============
+ *
+ * Encode/decode a Traffic Replay manifest for safe storage inside an A-Frame
+ * component string property (`street-traffic-replay="manifestData: ..."`).
+ *
+ * Why this exists: A-Frame serializes a multi-property component as a single
+ * `key: value; key: value` string and, on load, splits that whole string on
+ * `;` (and each declaration on the first `:`) BEFORE any per-property parsing
+ * runs. A raw JSON manifest whose string fields contain a `;` (the converter's
+ * own `meta.description` does) therefore gets silently truncated at the first
+ * `;` on reload, leaving invalid JSON and an empty replay. Base64 uses only
+ * `[A-Za-z0-9+/=]` — no `;` — so it round-trips through the serializer intact.
+ *
+ * `encodeManifest` writes a `b64:`-prefixed value; `decodeManifest` accepts
+ * that, a bare base64 blob, or a legacy raw-JSON value (backward compatible
+ * with any scene saved before this fix), returning the parsed object or null.
+ */
+
+const B64_PREFIX = 'b64:';
+
+// Prefer Node's Buffer when present (Node/tests): it is UTF-8 correct and
+// immune to whatever ambient `btoa`/`atob` a jsdom or A-Frame test shim may
+// install globally. Fall back to the standard browser `btoa`/`atob` path
+// (webpack does not polyfill Buffer, so this runs in the real app).
+const HAS_BUFFER =
+  typeof Buffer !== 'undefined' && typeof Buffer.from === 'function';
+
+function base64FromUtf8(str) {
+  if (HAS_BUFFER) return Buffer.from(str, 'utf8').toString('base64');
+  const bytes = new TextEncoder().encode(str);
+  // Chunk the byte->binary-string conversion so String.fromCharCode.apply
+  // can't overflow the call stack on large manifests.
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function utf8FromBase64(b64) {
+  if (HAS_BUFFER) return Buffer.from(b64, 'base64').toString('utf8');
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * @param {object|string} manifest - a manifest object, or its JSON string.
+ * @returns {string} a serializer-safe value for `manifestData`.
+ */
+export function encodeManifest(manifest) {
+  const json =
+    typeof manifest === 'string' ? manifest : JSON.stringify(manifest);
+  return B64_PREFIX + base64FromUtf8(json);
+}
+
+/**
+ * @param {string} value - the stored `manifestData` (b64-prefixed, bare
+ *   base64, or legacy raw JSON).
+ * @returns {object|null} the parsed manifest, or null if unusable.
+ */
+export function decodeManifest(value) {
+  if (typeof value !== 'string' || !value) return null;
+  const trimmed = value.trim();
+  let json;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    json = trimmed; // legacy raw-JSON value (pre-fix scenes)
+  } else {
+    try {
+      json = utf8FromBase64(
+        trimmed.startsWith(B64_PREFIX)
+          ? trimmed.slice(B64_PREFIX.length)
+          : trimmed
+      );
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}

--- a/src/aframe-components/play/replay-demo.js
+++ b/src/aframe-components/play/replay-demo.js
@@ -24,6 +24,8 @@
  * This is intentionally NOT the product UX — that's the "Traffic Replay" Add
  * Layer card. This is just a fast way to verify the engine end to end.
  */
+import { encodeManifest } from './manifest-codec.js';
+
 (function () {
   if (typeof window === 'undefined') return;
   const params = new URLSearchParams(window.location.search);
@@ -88,7 +90,7 @@
     const replayProps = { timeScale, loop: true, target: 'replay-demo-street' };
     if (sampleMod) {
       manifest = sampleMod.default || sampleMod;
-      replayProps.manifestData = JSON.stringify(manifest);
+      replayProps.manifestData = encodeManifest(manifest);
     } else {
       replayProps.manifestUrl = replay; // treat the param as a manifest URL
     }

--- a/src/aframe-components/play/street-traffic-replay.js
+++ b/src/aframe-components/play/street-traffic-replay.js
@@ -4,6 +4,7 @@ import {
   hideSegmentClones,
   releaseClones
 } from './clone-visibility.js';
+import { decodeManifest } from './manifest-codec.js';
 
 /**
  * street-traffic-replay
@@ -214,11 +215,12 @@ AFRAME.registerComponent('street-traffic-replay', {
 
   loadFromData: function () {
     if (this.data.manifestData) {
-      try {
-        this.setManifest(JSON.parse(this.data.manifestData));
-      } catch (err) {
-        console.error('[street-traffic-replay] bad manifestData JSON', err);
-      }
+      // manifestData is base64-encoded (see manifest-codec.js) so it survives
+      // A-Frame's `;`-delimited component serialization; decodeManifest also
+      // accepts legacy raw-JSON values from scenes saved before that fix.
+      const parsed = decodeManifest(this.data.manifestData);
+      if (parsed) this.setManifest(parsed);
+      else console.error('[street-traffic-replay] bad manifestData');
     } else if (this.data.manifestUrl) {
       fetch(this.data.manifestUrl)
         .then((r) => {

--- a/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
+++ b/src/editor/components/elements/AddLayerPanel/createLayerFunctions.js
@@ -1,6 +1,7 @@
 import { createUniqueId } from '../../../lib/entity.js';
 import * as defaultStreetObjects from './defaultStreets.js';
 import { VEHICLE_PRESETS } from '../../../../aframe-components/play/vehicle-presets.js';
+import { encodeManifest } from '../../../../aframe-components/play/manifest-codec.js';
 import { uploadAndPlaceAsset } from '../../../lib/asset-upload/uploadAndPlaceAsset.js';
 import {
   GLB_EXTS,
@@ -558,7 +559,7 @@ export function createReplayEntityFromManifest(manifest) {
     'data-layer-name': 'Traffic Replay',
     components: {
       'street-traffic-replay': {
-        manifestData: JSON.stringify(manifest),
+        manifestData: encodeManifest(manifest),
         timeScale: 1,
         loop: true
       }

--- a/src/editor/components/elements/StreetTrafficReplaySidebar.jsx
+++ b/src/editor/components/elements/StreetTrafficReplaySidebar.jsx
@@ -6,6 +6,10 @@ import Events from '../../lib/Events';
 import { Button, Dropdown } from '../elements';
 import { createUniqueId } from '../../lib/entity';
 import * as defaultStreetObjects from './AddLayerPanel/defaultStreets.js';
+import {
+  encodeManifest,
+  decodeManifest
+} from '../../../aframe-components/play/manifest-codec.js';
 
 const fieldLabels = defineMessages({
   timeScale: {
@@ -47,14 +51,7 @@ const StreetTrafficReplaySidebar = ({ entity }) => {
     return () => Events.off('entityupdate', onEntityUpdate);
   }, [entity]);
 
-  const manifest = useMemo(() => {
-    if (!manifestData) return null;
-    try {
-      return JSON.parse(manifestData);
-    } catch {
-      return null;
-    }
-  }, [manifestData]);
+  const manifest = useMemo(() => decodeManifest(manifestData), [manifestData]);
 
   if (!component || !component.schema || !component.data) return null;
 
@@ -97,7 +94,7 @@ const StreetTrafficReplaySidebar = ({ entity }) => {
         );
         return;
       }
-      setProp('manifestData', JSON.stringify(parsed));
+      setProp('manifestData', encodeManifest(parsed));
     };
     input.click();
   };

--- a/test/core/manifest-codec.test.js
+++ b/test/core/manifest-codec.test.js
@@ -1,0 +1,68 @@
+/* global describe, it */
+
+import assert from 'assert';
+import {
+  encodeManifest,
+  decodeManifest
+} from '../../src/aframe-components/play/manifest-codec.js';
+
+// A-Frame serializes a component as `key: value; key: value` and splits on
+// `;` / `:` on load, so a manifest stored raw gets truncated at the first `;`
+// in any string field. encodeManifest must produce a value that survives that.
+describe('manifest-codec', function () {
+  const manifest = {
+    meta: {
+      // The real converter emits a description containing a semicolon — the
+      // exact character that broke raw-JSON storage.
+      description: 'mode, direction, speed and duration; timestamps relative.',
+      countsByMode: { person: 2, bicycle: 1 }
+    },
+    agents: [
+      { t: 0, mode: 'person', dir: 'inbound', speed: 3, dur: 5 },
+      { t: 1.5, mode: 'bicycle', dir: 'outbound', speed: 10, dur: 8 }
+    ]
+  };
+
+  it('round-trips a manifest through encode/decode', function () {
+    const decoded = decodeManifest(encodeManifest(manifest));
+    assert.deepStrictEqual(decoded, manifest);
+  });
+
+  it('produces a value free of the A-Frame delimiters `;` and `:`', function () {
+    const encoded = encodeManifest(manifest);
+    // The `b64:` prefix carries the only colon; the payload after it must be
+    // delimiter-free so it survives component-string parsing.
+    const payload = encoded.replace(/^b64:/, '');
+    assert.ok(!payload.includes(';'), 'payload must not contain ";"');
+    assert.ok(!payload.includes(':'), 'payload must not contain ":"');
+  });
+
+  it('simulates the serializer split and recovers the full manifest', function () {
+    // Mimic `manifestData: <value>; target: x; timeScale: 1` being split on
+    // `;` then each declaration on its first `:` (what A-Frame does on load).
+    const flat = `manifestData: ${encodeManifest(manifest)}; target: s1; timeScale: 1`;
+    const decls = flat.split(';').map((d) => d.trim());
+    const bag = {};
+    for (const d of decls) {
+      const i = d.indexOf(':');
+      bag[d.slice(0, i).trim()] = d.slice(i + 1).trim();
+    }
+    assert.deepStrictEqual(decodeManifest(bag.manifestData), manifest);
+    assert.strictEqual(bag.target, 's1');
+  });
+
+  it('accepts legacy raw-JSON values (backward compatible)', function () {
+    assert.deepStrictEqual(decodeManifest(JSON.stringify(manifest)), manifest);
+  });
+
+  it('returns null for empty or unparseable input', function () {
+    assert.strictEqual(decodeManifest(''), null);
+    assert.strictEqual(decodeManifest(null), null);
+    assert.strictEqual(decodeManifest('not-base64-@@@'), null);
+  });
+
+  it('preserves non-ASCII characters', function () {
+    const m = { meta: { note: 'café — naïve — 日本語' }, agents: [] };
+    assert.deepStrictEqual(decodeManifest(encodeManifest(m)), m);
+  });
+});


### PR DESCRIPTION
A Traffic Replay layer stored its manifest in the street-traffic-replay component's `manifestData` property as raw JSON. A-Frame serializes a component as `key: value; key: value` and splits it on `;` (then each declaration on the first `:`) on load, BEFORE any per-property parsing. The converter's `meta.description` contains a `;`, so on reload the manifest was truncated at that `;`, JSON.parse failed, and the layer came back empty ("No manifest loaded") while the street's synthetic traffic played instead. This affected the Add Layer card and cloud save, not just the dev demo.

Fixes:
- Base64-encode manifestData via a shared manifest-codec so the stored value contains none of A-Frame's `;`/`:` delimiters. decodeManifest is backward compatible: it still reads legacy raw-JSON values, so scenes saved before this change keep loading.
- Wire encode/decode into the reader (street-traffic-replay) and the three writers (replay-demo, Add Layer card, sidebar import).
- Drop the semicolon from the converter's description and the two committed sample manifests so they round-trip even on unpatched clients.
- Add manifest-codec unit tests, including a simulation of A-Frame's serializer split.