### PR TITLE
test+docs(nav): characterise cursor-anchored LB pan (KD-38) + rotate sky-grab guard

### DIFF
--- a/src/editor/lib/nav-experimental/docs/02-key-decisions.md
+++ b/src/editor/lib/nav-experimental/docs/02-key-decisions.md
@@ -214,6 +214,43 @@ also *why* a single drag can wander the camera into a building (the
 recovery in KD-17 handles that), and why collision prevention can't rely
 on the gesture type being fixed.
 
+### KD-38 — LB pan is cursor-anchored, so its behaviour depends on cursor position
+
+LB pan (all three sub-modes — screen / truck / pedestal) is
+**cursor-anchored**: at mouse-down it grabs the world point under the
+cursor (`worldPointAt`) and keeps *that* point under the cursor for the
+whole drag. This is a deliberate change from legacy `EditorControls`,
+whose pan rate was cursor-*independent* (`max(minSpeedFactor,
+distToCentre) × panSpeed`). Because pan is derived from what sits under
+the cursor, two things follow — and both were the root of shipped
+regressions:
+
+- **Rate scales with the grabbed anchor's depth.** World-per-pixel is
+  proportional to how far the anchor is, so a shallow near-horizon grab
+  can latch a very distant anchor and "catapult" the camera — bounded by
+  the pan-anchor reach cap (`TH-81`).
+- **Pan needs a valid anchor *on the cursor ray*.** When the grab ray
+  misses all geometry (sky / void), `worldPointAt` returns a synthetic
+  Step-3 fallback that must lie on the **cursor ray** (`TH-21`), not the
+  camera's centre-forward — a centre-forward fallback injects the
+  cursor↔screen-centre offset into the first move and lurches the camera
+  (#1867). And an anchor grabbed ~0 m away (focusing an empty-bounding-box
+  entity parks the camera almost on it) makes the multiplicative dolly/pan
+  step degenerate, which is why zoom-out needs a floor (`TH-80`).
+
+**Asymmetry with rotate — a degenerate cursor position must be checked
+against *both* gestures.** Shift+LB rotation consumes the *same*
+`worldPointAt` anchor, but **branches on `source === 'fallback'`**: a sky
+grab orbits the screen-centre *ground* pivot (`_mapModePivot`'s
+`fallbackCentre`, on `y = 0`) and never touches the fallback point. So pan
+and rotate degenerate *differently* at the same cursor position — pan uses
+the fallback point, rotate discards it. Any change to degenerate-cursor
+handling (grab over sky, empty-bbox target, far-horizon grazing ray) must
+be verified for pan **and** rotate; a fix or test that exercises only one
+says nothing about the other. (This is the characterisation of the
+cursor-anchored-pan model that the original controls carried implicitly —
+see `06-changes-from-proposal.md`.)
+
 ### KD-29 — Map-orbit underground guard caps the input tilt, reversibly
 
 Because the orbit is decoupled (KD-03), the tilt clamp limits where you

--- a/src/editor/lib/nav-experimental/docs/04-glossary.md
+++ b/src/editor/lib/nav-experimental/docs/04-glossary.md
@@ -25,6 +25,13 @@ LB drag in Map mode (horizontal-plane translation); "truck/pedestal" = LB
 drag in Street mode (horizontal + vertical translation); "pan/tilt" =
 Shift+LB rotation.
 
+⚠ These LB-drag "pan" gestures are **cursor-anchored**, not
+cursor-independent screen slides: they grab the world point under the
+cursor and keep it there, so their rate and their handling of degenerate
+cursor positions (sky / void / empty-bbox) depend on the cursor — and pan
+degenerates *differently* from Shift+LB rotate at the same spot. See
+**KD-38** (`02-key-decisions.md`).
+
 ## Angles & heights
 
 **Tilt (as an angle).** ⚠ *Distinct from the "tilt" camera-move above.*

--- a/test/editor/lib/nav-experimental/ExperimentalControls.rotation.test.js
+++ b/test/editor/lib/nav-experimental/ExperimentalControls.rotation.test.js
@@ -78,3 +78,59 @@ describe('rotation — live-Shift truck↔rotate mid-drag switch (Tier 2)', () =
     expect(seq[seq.length - 1]).toBe(null); // gesture end
   });
 });
+
+describe('rotation — sky grab pivots on the ground centre, not the cursor-ray fallback (KD-38 asymmetry)', () => {
+  // The pan/rotate degenerate-cursor asymmetry: both gestures consume the same
+  // worldPointAt anchor, but on a sky grab (source==='fallback') PAN uses the
+  // fallback POINT directly (why it must lie on the cursor ray — #1867) while
+  // ROTATE branches on source and orbits the screen-centre GROUND pivot,
+  // ignoring the fallback point entirely. A degenerate-cursor test that
+  // exercises only one gesture says nothing about the other, so this guards
+  // the rotate side (LB pan's sky path is covered in ExperimentalControls.lbPan).
+  it('Shift+LB over sky orbits fallbackCentre (y≈0), never the cursor-ray fallback point', () => {
+    const scene = H.groundPlaneScene({ y: 0 });
+    // Map mode (tilt 38° > T=25) but with a wide 90° FOV so the TOP of the
+    // viewport looks ABOVE the horizon (sky) while the screen centre still
+    // meets the ground — so worldPointAt's centre pivot is a real ground point
+    // and the top-of-screen cursor grab misses everything → Step-3 fallback.
+    const cam = H.makePerspectiveCam({ pos: [0, 40, 51], lookAt: [0, 0, 0], fov: 90 });
+    const dom = H.makeDomElement(); // 1280x720 at (37,19) → centre client (677,379)
+    const c = H.makeControls({ camera: cam, dom, scene, streetLevel: true });
+    expect(H.tilt(cam)).toBeGreaterThan(25); // Map regime → orbit
+    expect(H.tilt(cam)).toBeLessThan(45); // shallow enough that the top is sky
+
+    // Cursor high in the viewport (client y=40, well above the horizon line):
+    // its ray points above horizontal → misses all geometry → fallback.
+    const SKY = { clientX: 677, clientY: 40 };
+    const anchor = c._cursorAnchor.worldPointAt(SKY.clientX, SKY.clientY);
+    expect(anchor.source).toBe('fallback'); // genuinely a sky grab
+    // The fallback POINT sits UP on the cursor ray, above the ground — exactly
+    // the point rotate must NOT pivot on (this is what pan uses, deliberately).
+    expect(anchor.y).toBeGreaterThan(1);
+
+    H.mouseDown(c, {
+      clientX: SKY.clientX,
+      clientY: SKY.clientY,
+      button: 0,
+      shiftKey: true
+    });
+    const pivot = c._latch.get('center').clone();
+
+    // Regression guard: rotate orbits the screen-centre GROUND pivot
+    // (_mapModePivot's fallbackCentre, y≈0), NOT the cursor-ray fallback point
+    // (anchor.y>1). If a refactor made rotate consume the fallback point, pivot.y
+    // would jump to ~anchor.y and this reds.
+    expect(pivot.y).toBeLessThan(0.5);
+    expect(Math.abs(pivot.y - anchor.y)).toBeGreaterThan(0.5);
+
+    // And the orbit still produces motion — a dead gesture is also lurch-free,
+    // so assert it actually rotates the camera about the ground pivot.
+    const before = H.pose(cam);
+    for (let i = 0; i < 8; i++) {
+      H.mouseMove(c, { clientX: SKY.clientX + i * 8, clientY: SKY.clientY });
+    }
+    H.mouseUp(c);
+    expect(Number.isFinite(cam.position.x)).toBe(true);
+    expect(cam.position.distanceTo(before.pos)).toBeGreaterThan(1e-3);
+  });
+});


### PR DESCRIPTION
Follow-up to the recent navigation regression fixes (#1855 / #1859 / #1868). No runtime change — docs + one test only.

## Why

Tracing #1867 (sky-grab pan lurch) back, the root is that **LB pan is cursor-anchored**: it grabs the world point under the cursor at mouse-down and keeps that point under the cursor for the whole drag (unlike legacy `EditorControls`, whose pan rate was cursor-independent). That model was carried over from the original controls but was never written down as a decision — so its consequences (rate scales with anchor depth; a sky grab needs a synthetic anchor **on the cursor ray**; a near-zero-distance anchor degenerates) only surfaced as the #1867 / TH-80 / TH-81 fixes. This PR states the model explicitly and closes a test-coverage gap on the rotate side.

## Changes

- **`docs/02-key-decisions.md` — new KD-38.** Characterises cursor-anchored LB pan and, crucially, the **pan-vs-rotate asymmetry**: on a `source === 'fallback'` (sky) grab, pan uses the fallback *point* (why it must lie on the cursor ray, #1867), while Shift+LB rotate **branches on `source`** and orbits the screen-centre *ground* pivot (`_mapModePivot`'s `fallbackCentre`), ignoring the point. So the two gestures degenerate differently at the same cursor position — a degenerate-cursor change must be checked against both.
- **`docs/04-glossary.md`** — a note on the LB "pan" terms flagging the cursor-anchored dependence, pointing to KD-38.
- **`test/.../ExperimentalControls.rotation.test.js`** — a regression guard for the **rotate** side of the sky grab: Shift+LB over sky orbits `fallbackCentre` (y ≈ 0), never the cursor-ray fallback point (y > 1). The pan side is already covered by the `ExperimentalControls.lbPan` sky-grab tests (#1867); this guards the branch that keeps rotate immune to the same fault.

## Testing

- `ExperimentalControls.rotation.test.js`: 3/3 green (2 existing + the new guard).
- Break-it check: forcing rotate to consume the fallback point makes the new test red (`pivot.y` 42.7 vs the `< 0.5` assertion), confirming the guard bites.
- No `src` changes, so lint is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
