### PR TITLE
Fix GeoModal ignoring typed address when no autocomplete suggestion is selected

### DIFF
--- a/src/editor/components/modals/GeoModal/GeoModal.component.jsx
+++ b/src/editor/components/modals/GeoModal/GeoModal.component.jsx
@@ -177,7 +177,10 @@ const GeoModal = () => {
   const setMarkerPositionAndElevation = useCallback((lat, lng) => {
     if (!isNaN(lat) && !isNaN(lng)) {
       // A user-driven pick (map click, search, manual coords) — provenance
-      // becomes 'manual' on save.
+      // becomes 'manual' on save. It also supersedes any typed-but-unresolved
+      // search text: the last explicit location choice wins, so a map click
+      // after an abandoned search commits the click, not the stale text.
+      pendingSearchQueryRef.current = '';
       userChangedLocationRef.current = true;
       setMarkerPosition({
         lat: roundCoord(lat),

--- a/src/editor/components/modals/GeoModal/GeoModal.component.jsx
+++ b/src/editor/components/modals/GeoModal/GeoModal.component.jsx
@@ -206,10 +206,12 @@ const GeoModal = () => {
   }, []);
 
   // Resolve a free-typed search string to coordinates. Returns
-  // { lat, lng } or null when nothing matched / the API is unavailable.
+  // { status: 'ok', lat, lng }, { status: 'notFound' } when the text didn't
+  // match anything, or { status: 'unavailable' } when the Geocoder itself
+  // is missing or failing (API not loaded, quota, network).
   const geocodeSearchQuery = useCallback(async (query) => {
     if (!window.google?.maps?.Geocoder) {
-      return null;
+      return { status: 'unavailable' };
     }
     if (!geocoderRef.current) {
       geocoderRef.current = new window.google.maps.Geocoder();
@@ -217,10 +219,15 @@ const GeoModal = () => {
     try {
       const { results } = await geocoderRef.current.geocode({ address: query });
       const location = results?.[0]?.geometry?.location;
-      return location ? { lat: location.lat(), lng: location.lng() } : null;
+      return location
+        ? { status: 'ok', lat: location.lat(), lng: location.lng() }
+        : { status: 'notFound' };
     } catch (error) {
-      // The Geocoder rejects on ZERO_RESULTS and friends — treat as not found.
-      return null;
+      // The Geocoder rejects on any non-OK status; only ZERO_RESULTS means
+      // the query itself found nothing.
+      return error?.code === 'ZERO_RESULTS'
+        ? { status: 'notFound' }
+        : { status: 'unavailable' };
     }
   }, []);
 
@@ -243,7 +250,7 @@ const GeoModal = () => {
           return;
         }
         const geocoded = await geocodeSearchQuery(query);
-        if (geocoded) {
+        if (geocoded.status === 'ok') {
           pendingSearchQueryRef.current = '';
           setMarkerPositionAndElevation(geocoded.lat, geocoded.lng);
         }
@@ -286,7 +293,7 @@ const GeoModal = () => {
     const pendingQuery = pendingSearchQueryRef.current.trim();
     if (pendingQuery && !wasOpenedFromGeojson) {
       const geocoded = await geocodeSearchQuery(pendingQuery);
-      if (geocoded) {
+      if (geocoded.status === 'ok') {
         pendingSearchQueryRef.current = '';
         userChangedLocationRef.current = true;
         latitude = roundCoord(geocoded.lat);
@@ -294,15 +301,28 @@ const GeoModal = () => {
         setMarkerPosition({ lat: latitude, lng: longitude });
       } else {
         setIsWorking(false);
+        posthog.capture('geo_location_search_failed', {
+          query: pendingQuery,
+          reason: geocoded.status,
+          is_pro_user: currentUser?.isPro || false,
+          tokens_available: tokenProfile?.geoToken || 0,
+          scene_id: STREET.utils.getCurrentSceneId()
+        });
         STREET.notify.errorMessage(
-          intl.formatMessage(
-            {
-              id: 'geoModal.locationSearchNotFound',
-              defaultMessage:
-                'Could not find "{query}". Please select a suggestion from the search dropdown or click the map to set the location.'
-            },
-            { query: pendingQuery }
-          )
+          geocoded.status === 'unavailable'
+            ? intl.formatMessage({
+                id: 'geoModal.locationSearchUnavailable',
+                defaultMessage:
+                  'Location search is temporarily unavailable. Please click the map or enter coordinates directly to set the location.'
+              })
+            : intl.formatMessage(
+                {
+                  id: 'geoModal.locationSearchNotFound',
+                  defaultMessage:
+                    'Could not find "{query}". Please select a suggestion from the search dropdown or click the map to set the location.'
+                },
+                { query: pendingQuery }
+              )
         );
         return;
       }

--- a/src/editor/components/modals/GeoModal/GeoModal.component.jsx
+++ b/src/editor/components/modals/GeoModal/GeoModal.component.jsx
@@ -72,6 +72,13 @@ const GeoModal = () => {
   // existing location. Drives provenance: a deliberate change stamps source
   // 'manual', while just activating the prefilled location keeps its origin.
   const userChangedLocationRef = useRef(false);
+  // Search text typed since the last applied autocomplete/geocode result.
+  // Google Places Autocomplete only yields coordinates when a suggestion is
+  // explicitly selected — typing an address and clicking Set Location without
+  // selecting one would otherwise commit stale marker coordinates (#1897).
+  // Non-empty means the marker does NOT yet reflect the typed text.
+  const pendingSearchQueryRef = useRef('');
+  const geocoderRef = useRef(null);
   const returnToPreviousModal = useStore(
     (state) => state.returnToPreviousModal
   );
@@ -111,6 +118,7 @@ const GeoModal = () => {
       // Fresh open: nothing the user touched yet, so the prefill below isn't a
       // "change". Marker interactions flip this back to true.
       userChangedLocationRef.current = false;
+      pendingSearchQueryRef.current = '';
       // Check if we have GeoJSON import data first (takes priority)
       if (geojsonImportData && geojsonImportData.lat && geojsonImportData.lon) {
         const lat = roundCoord(geojsonImportData.lat);
@@ -194,19 +202,53 @@ const GeoModal = () => {
     setAutocomplete(autocompleteInstance);
   }, []);
 
-  const onPlaceChanged = useCallback(() => {
+  // Resolve a free-typed search string to coordinates. Returns
+  // { lat, lng } or null when nothing matched / the API is unavailable.
+  const geocodeSearchQuery = useCallback(async (query) => {
+    if (!window.google?.maps?.Geocoder) {
+      return null;
+    }
+    if (!geocoderRef.current) {
+      geocoderRef.current = new window.google.maps.Geocoder();
+    }
+    try {
+      const { results } = await geocoderRef.current.geocode({ address: query });
+      const location = results?.[0]?.geometry?.location;
+      return location ? { lat: location.lat(), lng: location.lng() } : null;
+    } catch (error) {
+      // The Geocoder rejects on ZERO_RESULTS and friends — treat as not found.
+      return null;
+    }
+  }, []);
+
+  const onPlaceChanged = useCallback(async () => {
     if (autocomplete !== null) {
       const place = autocomplete.getPlace();
       if (place && place.geometry) {
+        // A suggestion was explicitly selected — coordinates come with it.
+        pendingSearchQueryRef.current = '';
         setMarkerPositionAndElevation(
           place.geometry.location.lat(),
           place.geometry.location.lng()
         );
+      } else {
+        // Enter pressed without selecting a suggestion: the place only
+        // carries the raw text, no geometry. Geocode it so typed addresses
+        // still move the marker (#1897).
+        const query = (place?.name || pendingSearchQueryRef.current).trim();
+        if (!query) {
+          return;
+        }
+        const geocoded = await geocodeSearchQuery(query);
+        if (geocoded) {
+          pendingSearchQueryRef.current = '';
+          setMarkerPositionAndElevation(geocoded.lat, geocoded.lng);
+        }
       }
     } else {
       console.log('Autocomplete is not loaded yet!');
     }
-  }, [autocomplete]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [autocomplete, geocodeSearchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onCloseCheck = (evt) => {
     // do not close geoModal when clicking on a list with suggestions for
@@ -231,8 +273,37 @@ const GeoModal = () => {
     }
 
     setIsWorking(true);
-    const latitude = markerPosition.lat;
-    const longitude = markerPosition.lng;
+    let latitude = markerPosition.lat;
+    let longitude = markerPosition.lng;
+
+    // The user may have typed an address without selecting an autocomplete
+    // suggestion, in which case the marker still holds stale coordinates.
+    // Resolve the typed text now so Set Location commits what they typed
+    // instead of silently using the previous location (#1897).
+    const pendingQuery = pendingSearchQueryRef.current.trim();
+    if (pendingQuery && !wasOpenedFromGeojson) {
+      const geocoded = await geocodeSearchQuery(pendingQuery);
+      if (geocoded) {
+        pendingSearchQueryRef.current = '';
+        userChangedLocationRef.current = true;
+        latitude = roundCoord(geocoded.lat);
+        longitude = roundCoord(geocoded.lng);
+        setMarkerPosition({ lat: latitude, lng: longitude });
+      } else {
+        setIsWorking(false);
+        STREET.notify.errorMessage(
+          intl.formatMessage(
+            {
+              id: 'geoModal.locationSearchNotFound',
+              defaultMessage:
+                'Could not find "{query}". Please select a suggestion from the search dropdown or click the map to set the location.'
+            },
+            { query: pendingQuery }
+          )
+        );
+        return;
+      }
+    }
 
     // Track geo location setting attempt
     posthog.capture('geo_location_set_attempt', {
@@ -399,7 +470,13 @@ const GeoModal = () => {
                     defaultMessage: 'Search for a location'
                   })
                 }
-                onChange={(value) => {}}
+                onChange={(value) => {
+                  // Track typed text so Set Location can geocode it if no
+                  // autocomplete suggestion gets selected. Selecting a
+                  // suggestion sets the input programmatically (no onChange)
+                  // and clears this in onPlaceChanged.
+                  pendingSearchQueryRef.current = value;
+                }}
               />
             </Autocomplete>
           )}

--- a/src/editor/i18n/locales/.translation-manifest.json
+++ b/src/editor/i18n/locales/.translation-manifest.json
@@ -748,7 +748,8 @@
     "trafficReplay.hiddenModesBody": "The linked street has vehicles hidden, so these recorded modes will not appear during play: {modes}.",
     "trafficReplay.hiddenModesHeading": "⚠️ Some modes will be hidden",
     "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street",
-    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
+    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location.",
+    "geoModal.locationSearchUnavailable": "Location search is temporarily unavailable. Please click the map or enter coordinates directly to set the location."
   },
   "fr": {
     "actionBar.handTool": "Hand Tool (h) - pan and rotate the view without selecting objects",
@@ -1499,7 +1500,8 @@
     "trafficReplay.hiddenModesBody": "The linked street has vehicles hidden, so these recorded modes will not appear during play: {modes}.",
     "trafficReplay.hiddenModesHeading": "⚠️ Some modes will be hidden",
     "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street",
-    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
+    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location.",
+    "geoModal.locationSearchUnavailable": "Location search is temporarily unavailable. Please click the map or enter coordinates directly to set the location."
   },
   "pt-BR": {
     "actionBar.handTool": "Hand Tool (h) - pan and rotate the view without selecting objects",
@@ -2250,6 +2252,7 @@
     "trafficReplay.hiddenModesBody": "The linked street has vehicles hidden, so these recorded modes will not appear during play: {modes}.",
     "trafficReplay.hiddenModesHeading": "⚠️ Some modes will be hidden",
     "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street",
-    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
+    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location.",
+    "geoModal.locationSearchUnavailable": "Location search is temporarily unavailable. Please click the map or enter coordinates directly to set the location."
   }
 }

--- a/src/editor/i18n/locales/.translation-manifest.json
+++ b/src/editor/i18n/locales/.translation-manifest.json
@@ -747,7 +747,8 @@
     "geoSidebar.opacityFlattening": "Opacity & Flattening",
     "trafficReplay.hiddenModesBody": "The linked street has vehicles hidden, so these recorded modes will not appear during play: {modes}.",
     "trafficReplay.hiddenModesHeading": "⚠️ Some modes will be hidden",
-    "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street"
+    "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street",
+    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
   },
   "fr": {
     "actionBar.handTool": "Hand Tool (h) - pan and rotate the view without selecting objects",
@@ -1497,7 +1498,8 @@
     "geoSidebar.opacityFlattening": "Opacity & Flattening",
     "trafficReplay.hiddenModesBody": "The linked street has vehicles hidden, so these recorded modes will not appear during play: {modes}.",
     "trafficReplay.hiddenModesHeading": "⚠️ Some modes will be hidden",
-    "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street"
+    "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street",
+    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
   },
   "pt-BR": {
     "actionBar.handTool": "Hand Tool (h) - pan and rotate the view without selecting objects",
@@ -2247,6 +2249,7 @@
     "geoSidebar.opacityFlattening": "Opacity & Flattening",
     "trafficReplay.hiddenModesBody": "The linked street has vehicles hidden, so these recorded modes will not appear during play: {modes}.",
     "trafficReplay.hiddenModesHeading": "⚠️ Some modes will be hidden",
-    "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street"
+    "trafficReplay.showVehiclesOnStreet": "Show vehicles on linked street",
+    "geoModal.locationSearchNotFound": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
   }
 }

--- a/src/editor/i18n/locales/en.json
+++ b/src/editor/i18n/locales/en.json
@@ -1160,6 +1160,9 @@
   "geoModal.locationLabel": {
     "defaultMessage": "Location:"
   },
+  "geoModal.locationSearchNotFound": {
+    "defaultMessage": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
+  },
   "geoModal.locationSetSuccess": {
     "defaultMessage": "Location Set Successfully!"
   },

--- a/src/editor/i18n/locales/en.json
+++ b/src/editor/i18n/locales/en.json
@@ -1163,6 +1163,9 @@
   "geoModal.locationSearchNotFound": {
     "defaultMessage": "Could not find \"{query}\". Please select a suggestion from the search dropdown or click the map to set the location."
   },
+  "geoModal.locationSearchUnavailable": {
+    "defaultMessage": "Location search is temporarily unavailable. Please click the map or enter coordinates directly to set the location."
+  },
   "geoModal.locationSetSuccess": {
     "defaultMessage": "Location Set Successfully!"
   },

--- a/src/editor/i18n/locales/es.json
+++ b/src/editor/i18n/locales/es.json
@@ -386,6 +386,7 @@
   "geoModal.geospatialTips": "Consejos geoespaciales",
   "geoModal.latLong": "Lat, Long",
   "geoModal.locationLabel": "Ubicación:",
+  "geoModal.locationSearchNotFound": "No se pudo encontrar \"{query}\". Selecciona una sugerencia de la lista de búsqueda o haz clic en el mapa para establecer la ubicación.",
   "geoModal.locationSetSuccess": "¡Ubicación establecida correctamente!",
   "geoModal.nearestIntersectionLabel": "Intersección más cercana:",
   "geoModal.none": "Ninguna",

--- a/src/editor/i18n/locales/es.json
+++ b/src/editor/i18n/locales/es.json
@@ -387,6 +387,7 @@
   "geoModal.latLong": "Lat, Long",
   "geoModal.locationLabel": "Ubicación:",
   "geoModal.locationSearchNotFound": "No se pudo encontrar \"{query}\". Selecciona una sugerencia de la lista de búsqueda o haz clic en el mapa para establecer la ubicación.",
+  "geoModal.locationSearchUnavailable": "La búsqueda de ubicaciones no está disponible temporalmente. Haz clic en el mapa o introduce las coordenadas directamente para establecer la ubicación.",
   "geoModal.locationSetSuccess": "¡Ubicación establecida correctamente!",
   "geoModal.nearestIntersectionLabel": "Intersección más cercana:",
   "geoModal.none": "Ninguna",

--- a/src/editor/i18n/locales/fr.json
+++ b/src/editor/i18n/locales/fr.json
@@ -387,6 +387,7 @@
   "geoModal.latLong": "Lat, Long",
   "geoModal.locationLabel": "Emplacement :",
   "geoModal.locationSearchNotFound": "Impossible de trouver « {query} ». Veuillez sélectionner une suggestion dans la liste de recherche ou cliquer sur la carte pour définir l'emplacement.",
+  "geoModal.locationSearchUnavailable": "La recherche de lieu est temporairement indisponible. Veuillez cliquer sur la carte ou saisir directement les coordonnées pour définir l'emplacement.",
   "geoModal.locationSetSuccess": "Emplacement défini avec succès !",
   "geoModal.nearestIntersectionLabel": "Intersection la plus proche :",
   "geoModal.none": "Aucun",

--- a/src/editor/i18n/locales/fr.json
+++ b/src/editor/i18n/locales/fr.json
@@ -386,6 +386,7 @@
   "geoModal.geospatialTips": "Conseils géospatiaux",
   "geoModal.latLong": "Lat, Long",
   "geoModal.locationLabel": "Emplacement :",
+  "geoModal.locationSearchNotFound": "Impossible de trouver « {query} ». Veuillez sélectionner une suggestion dans la liste de recherche ou cliquer sur la carte pour définir l'emplacement.",
   "geoModal.locationSetSuccess": "Emplacement défini avec succès !",
   "geoModal.nearestIntersectionLabel": "Intersection la plus proche :",
   "geoModal.none": "Aucun",

--- a/src/editor/i18n/locales/pt-BR.json
+++ b/src/editor/i18n/locales/pt-BR.json
@@ -387,6 +387,7 @@
   "geoModal.latLong": "Lat, Long",
   "geoModal.locationLabel": "Localização:",
   "geoModal.locationSearchNotFound": "Não foi possível encontrar \"{query}\". Selecione uma sugestão da lista de busca ou clique no mapa para definir a localização.",
+  "geoModal.locationSearchUnavailable": "A busca de localização está temporariamente indisponível. Clique no mapa ou insira as coordenadas diretamente para definir a localização.",
   "geoModal.locationSetSuccess": "Localização Definida com Sucesso!",
   "geoModal.nearestIntersectionLabel": "Cruzamento Mais Próximo:",
   "geoModal.none": "Nenhum",

--- a/src/editor/i18n/locales/pt-BR.json
+++ b/src/editor/i18n/locales/pt-BR.json
@@ -386,6 +386,7 @@
   "geoModal.geospatialTips": "Dicas Geoespaciais",
   "geoModal.latLong": "Lat, Long",
   "geoModal.locationLabel": "Localização:",
+  "geoModal.locationSearchNotFound": "Não foi possível encontrar \"{query}\". Selecione uma sugestão da lista de busca ou clique no mapa para definir a localização.",
   "geoModal.locationSetSuccess": "Localização Definida com Sucesso!",
   "geoModal.nearestIntersectionLabel": "Cruzamento Mais Próximo:",
   "geoModal.none": "Nenhum",


### PR DESCRIPTION
Fixes #1897

## Root cause

In `GeoModal.component.jsx`, typing into the location search field never updated the lat/long state:

- The search `Input`'s `onChange` handler was a no-op (`onChange={(value) => {}}`), so typed text was discarded.
- Coordinates were only set inside `onPlaceChanged`, and only when `autocomplete.getPlace()` returned a place **with geometry** — which Google Places Autocomplete only provides when the user explicitly clicks/selects a suggestion from the dropdown. Pressing Enter without selecting a suggestion returns a place with just the raw text and no geometry, so the handler silently did nothing.
- "Set Location" then committed whatever stale `markerPosition` was in state: the default San Francisco coordinates on first use, or the last-resolved location on later attempts. There was no error or feedback, so the mismatch was only discovered after the ~5–10 s tile load.

This also explains the confusing "goes to a different street than I typed" retry behavior: the committed coordinates came from a previous resolution, not the current text. Note the typed text also *appears* remembered between opens — the modal stays mounted and the uncontrolled input keeps its DOM value, and after a successful commit the reverse-geocoded `locationString` of the committed point shows as the input's placeholder. Neither ever fed back into lat/lng.

## Fix

- Track typed search text in a `pendingSearchQueryRef` (non-empty means the marker does **not** yet reflect the typed text). Selecting a suggestion, successfully geocoding the text, or explicitly picking a location another way (map click, manual coordinates) clears it — the last explicit location choice always wins.
- **Enter without selecting a suggestion:** `onPlaceChanged` now geocodes the typed text via `google.maps.Geocoder` and moves the marker, so the user gets immediate map feedback.
- **Set Location with unresolved typed text:** `onSaveHandler` geocodes the pending query first and commits those coordinates (stamping `manual` provenance). If geocoding finds nothing, it shows an error notification and keeps the modal open instead of silently committing stale coordinates. This also closes the in-flight-geocode race — the save path always resolves the current text before committing.
- The map-click and manual lat/long entry paths are unchanged (they already worked).
- New i18n message `geoModal.locationSearchNotFound` extracted to `en.json`, with hand-written es / pt-BR / fr translations and manifest entries (`npm run i18n:check` passes).

## Manual test plan (~10 min)

Setup: `npm start` → http://localhost:3333, open any scene, sign in with an account that is Pro or has geo tokens. Open **Geospatial → Change/Set Location** to reach the GeoModal. Keep the browser devtools console open to spot errors.

1. **Type + Set Location, no suggestion click (the #1897 repro, ~3 min).** Type a full address into the search field (e.g. `Washington Street and Scott Street, Chualar, CA`). Do **not** click any autocomplete suggestion and do **not** press Enter. Click **Set Location**.
   - ✅ Expected: scene loads at the typed address; success overlay's Location string matches it.
   - ❌ Before this fix: scene loads default San Francisco / previous location.
2. **Enter key, no suggestion click (~1 min).** Reopen the modal, type a different address, press **Enter** without clicking a suggestion.
   - ✅ Expected: map preview pans and the red marker + lat/long field update to the typed address *before* you click Set Location.
3. **Gibberish query fails loudly (~1 min).** Reopen the modal, type something unresolvable (e.g. `zzzqqqxxx nowhere`), click **Set Location**.
   - ✅ Expected: error notification "Could not find …", modal stays open, no location commit, **no geo token consumed**.
4. **Regression — suggestion click still works (~1 min).** Type an address and click one of the dropdown suggestions, then **Set Location**.
   - ✅ Expected: marker jumps on selection; commit goes to the selected place.
5. **Regression — map click and manual coords still work (~2 min).** Click a spot on the map preview → marker and lat/long update → Set Location commits it. Then paste coordinates directly into the Lat, Long field (e.g. `36.570, -121.516`) and Set Location.
   - ✅ Expected: both commit the shown coordinates, as before.
6. **Typed text then map click — last choice wins (~1 min).** Type an address (no suggestion click), then click a *different* spot on the map, then **Set Location**.
   - ✅ Expected: the scene commits the **map-clicked** point, not the abandoned typed text. This mirrors the workaround flow from the original report (failed search, then map click) — the click must not be overridden.

Optional if time remains: repeat step 1 in a fresh reload with a scene that already has a saved location, confirming the placeholder text (previous location string) alone doesn't get committed as a search.

## Automated testing

- `npm run test:core` (Mocha) — pass
- `npm run test:modern` (Vitest, 756 tests) — pass
- `npm run test:components` (browser component tests, 50 tests) — pass
- ESLint + Prettier clean on changed files

## Notes

- The GeoModal redesign planned in #1677 should carry this behavior forward: never commit coordinates that don't reflect the current search text, and fail loudly when the text can't be resolved.
- Possible follow-up (out of scope here): show where the typed text resolved to *before* committing, since each failed attempt costs a long tile-load feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkao1vfgcZtbhEcqBQqbww