### PR TITLE
Add gizmo prototype lab with experimental transform controls

### DIFF
--- a/docs/gizmo-prototypes.md
+++ b/docs/gizmo-prototypes.md
@@ -1,0 +1,72 @@
+# Gizmo Prototype Lab
+
+Experimental, switchable gizmo behaviors for the editor viewport, exploring
+the ideas in #1674, #1446, #1096, #1218, and #1806 side by side instead of
+betting on one "perfect" gizmo up front.
+
+## Switching prototypes
+
+**View → Gizmo Prototypes (Lab)** in the editor menu. The choice is a
+persisted local preference (`store.gizmoPrototype`, localStorage-backed) and
+takes effect immediately on the current selection — no reload. Default is
+`legacy`, which is the stock behavior, byte-for-byte.
+
+| Prototype                             | What changes                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Legacy (current gizmo)**            | Standard three.js TransformControls, unchanged.                                                                                                                                                                                                                                                                                                         |
+| **Simplified Move + Rotate** (#1674)  | One combined gizmo for every entity: drag the purple disc/arrows to move along the ground plane (Y preserved), drag the blue ring to rotate around Y. Thick tube geometry instead of 1px lines. Hold **Shift** to snap (0.5 m grid / 15°).                                                                                                              |
+| **Simplified + Ground Clamp** (#1446) | Same gizmo, but horizontal drags raycast down and re-seat the object on whatever surface is under the drag point (streets, shapes, 3D tiles), using the object's bounding-box bottom so it sits _on_ — not _in_ — the ground.                                                                                                                           |
+| **Street Endpoint Nodes** (#1096)     | Selecting a **managed street** shows a draggable circle at each end of the street. Dragging a circle keeps the other end fixed and rewrites the street's position, Y rotation, and `managed-street.length` so the two circles always define the street's ends. One undo step per drag (MultiCommand). Other entities fall back to the Simplified gizmo. |
+| **Segment Width Handles** (#1218)     | Selecting a **street segment** shows a bar along each long edge; dragging a bar changes `street-segment.width` live, with the normal managed-street re-layout cascade running during the drag. Shift snaps to 0.5 m. Other entities fall back to the Simplified gizmo.                                                                                  |
+
+In **every non-legacy prototype**, selecting a street-segment suppresses the
+move/rotate gizmo entirely (#1806) — `street-align` owns segment transforms,
+so an editable gizmo there silently loses its edits. The selection highlight
+still shows; width/type editing stays in the sidebar (plus the width handles
+prototype above).
+
+Managed streets only: none of the street-specific gizmos attach to legacy
+`street` + `streetmix-loader` scenes.
+
+## Architecture
+
+```
+src/editor/lib/gizmos/
+├── constants.js              # prototype registry (ids, labels) — menu + routing share it
+├── GizmoPointerControls.js   # shared base: pointer plumbing, raycasting, event dispatch
+├── SimpleTransformControls.js# move-on-ground + Y-rotate (+ optional ground clamp)
+├── StreetNodeControls.js     # managed-street endpoint circles
+└── SegmentWidthControls.js   # street-segment edge bars
+```
+
+- All controls follow the `MeasureLineControls` pattern: a `THREE.Object3D`
+  added to `inspector.sceneHelpers`, running its own raycaster against its
+  picker meshes, dispatching TransformControls-compatible events
+  (`mouseDown` / `objectChange` / `mouseUp`) that `viewport.js` wires to
+  camera-control locking and undoable `entityupdate` commands.
+- `attachControlsForSelection()` in `viewport.js` is the single routing
+  table: selection changes, transform-mode changes, and prototype switches
+  all funnel through it.
+- The simplified gizmo reuses the pre-drag snapshot + coalescing
+  `entityupdate` path the stock gizmo uses, so undo behaves identically.
+  The street gizmos mutate attributes live during the drag (so the street's
+  re-layout cascade runs) and commit one undo step on mouse-up via
+  `commitDrag` → `entityupdate`/`multi`.
+- Scale mode (`l` key) always attaches the stock TransformControls — the
+  advanced escape hatch under every prototype.
+- New gizmo objects are named with the `gizmoPrototype` prefix, which is on
+  the nav-experimental cursor-anchor exclusion list.
+
+## Known prototype limitations (by design, for now)
+
+- #1674's "advanced translate/rotate as a toolbar submenu" is approximated
+  by the lab switcher itself (+ scale mode escape hatch); no ActionBar
+  submenu yet.
+- Segment width drag with `street-align` width `center` grows the segment
+  symmetrically, so the dragged edge moves at ~half cursor speed; anchoring
+  the opposite edge would need a coordinated street-position change.
+- Endpoint node drags throttle `managed-street.length` writes to 10 Hz
+  during the drag (the length cascade re-lays-out every segment); the final
+  value always lands on mouse-up.
+- #1806's sidebar half (read-only position/rotation rows for segments) is
+  not part of this branch.

--- a/src/editor/components/scenegraph/AppMenu.jsx
+++ b/src/editor/components/scenegraph/AppMenu.jsx
@@ -37,6 +37,7 @@ import {
   COMPASS_NORTH_TOLERANCE_DEGREES
 } from '@/editor/lib/nav-experimental/index.js';
 import { captureNavDiscovery } from '@/editor/lib/navAnalytics.js';
+import { GIZMO_PROTOTYPES } from '@/editor/lib/gizmos/constants.js';
 
 // Keyboard hints shown in the Edit menu's right slot.
 const isMac = getOS() === 'macos';
@@ -97,7 +98,9 @@ const AppMenu = ({ currentUser }) => {
     setGeojsonImportData,
     setRightPanelTab,
     locale,
-    setLocale
+    setLocale,
+    gizmoPrototype,
+    setGizmoPrototype
   } = useStore();
   const [undoDisabled, setUndoDisabled] = useState(
     !AFRAME.INSPECTOR?.history || AFRAME.INSPECTOR.history.undos.length === 0
@@ -742,6 +745,47 @@ const AppMenu = ({ currentUser }) => {
                         defaultMessage="Experimental"
                       />
                     </Menubar.RadioItem>
+                  </Menubar.RadioGroup>
+                </Menubar.SubContent>
+              </Menubar.Portal>
+            </Menubar.Sub>
+            <Menubar.Sub>
+              <Menubar.SubTrigger className="MenubarItem">
+                <FormattedMessage
+                  id="appMenu.view.gizmoPrototypes"
+                  defaultMessage="Gizmo Prototypes (Lab)"
+                />
+                <div className="RightSlot">
+                  <AwesomeIcon icon={faChevronRight} size={12} />
+                </div>
+              </Menubar.SubTrigger>
+              <Menubar.Portal>
+                <Menubar.SubContent className="MenubarContent">
+                  <Menubar.RadioGroup
+                    value={gizmoPrototype}
+                    onValueChange={(prototype) => {
+                      if (prototype === gizmoPrototype) return;
+                      posthog.capture('gizmo_prototype_changed', {
+                        prototype
+                      });
+                      // Takes effect immediately — viewport.js re-routes the
+                      // attached controls on this store change, no reload.
+                      setGizmoPrototype(prototype);
+                    }}
+                  >
+                    {GIZMO_PROTOTYPES.map((proto) => (
+                      <Menubar.RadioItem
+                        key={proto.id}
+                        className="MenubarRadioItem"
+                        value={proto.id}
+                        title={proto.description}
+                      >
+                        <Menubar.ItemIndicator className="MenubarItemIndicator">
+                          <AwesomeIcon icon={faCircle} size={8} />
+                        </Menubar.ItemIndicator>
+                        {proto.label}
+                      </Menubar.RadioItem>
+                    ))}
                   </Menubar.RadioGroup>
                 </Menubar.SubContent>
               </Menubar.Portal>

--- a/src/editor/lib/gizmos/GizmoPointerControls.js
+++ b/src/editor/lib/gizmos/GizmoPointerControls.js
@@ -1,0 +1,176 @@
+/**
+ * GizmoPointerControls — shared pointer plumbing for the custom gizmo
+ * prototypes (see constants.js). Modeled on MeasureLineControls: an
+ * Object3D added to inspector.sceneHelpers that runs its own raycaster
+ * against its picker meshes and dispatches TransformControls-compatible
+ * events ('mouseDown', 'mouseUp', 'objectChange', 'change') so viewport.js
+ * can wire camera-control locking and undoable entityupdate commands the
+ * same way it does for the stock controls.
+ *
+ * Subclasses implement:
+ *   getPickers()            -> array of meshes to hit-test (name = axis id)
+ *   highlight(axis)         -> hover feedback
+ *   startDrag(axis, event)  -> return false to cancel the drag
+ *   moveDrag(event)
+ *   endDrag(event)          -> optional
+ */
+
+const raycasterLine = { threshold: 0.5 };
+
+class GizmoPointerControls extends THREE.Object3D {
+  constructor(camera, domElement, name) {
+    super();
+
+    this.name = name;
+    this.camera = camera;
+    this.domElement = domElement !== undefined ? domElement : document;
+
+    this.object = undefined; // subclass-defined attach target
+    this.visible = false;
+    this.enabled = true;
+    this.axis = null;
+    this.isDragging = false;
+
+    this.raycaster = new THREE.Raycaster();
+    this.raycaster.params.Line = raycasterLine;
+    this.mouse = new THREE.Vector2();
+    this.tempVec = new THREE.Vector3();
+
+    this.changeEvent = { type: 'change' };
+    this.mouseDownEvent = { type: 'mouseDown' };
+    this.mouseUpEvent = { type: 'mouseUp' };
+    this.objectChangeEvent = { type: 'objectChange' };
+
+    this.onPointerHover = this.onPointerHover.bind(this);
+    this.onPointerDown = this.onPointerDown.bind(this);
+    this.onPointerMove = this.onPointerMove.bind(this);
+    this.onPointerUp = this.onPointerUp.bind(this);
+
+    this.activate();
+  }
+
+  activate() {
+    this.domElement.addEventListener('mousemove', this.onPointerHover, false);
+    this.domElement.addEventListener('mousedown', this.onPointerDown, false);
+    this.domElement.addEventListener('mousemove', this.onPointerMove, false);
+    this.domElement.addEventListener('mouseup', this.onPointerUp, false);
+    this.domElement.addEventListener('mouseleave', this.onPointerUp, false);
+
+    this.domElement.addEventListener('touchmove', this.onPointerHover, false);
+    this.domElement.addEventListener('touchstart', this.onPointerDown, false);
+    this.domElement.addEventListener('touchmove', this.onPointerMove, false);
+    this.domElement.addEventListener('touchend', this.onPointerUp, false);
+    this.domElement.addEventListener('touchcancel', this.onPointerUp, false);
+  }
+
+  dispose() {
+    this.domElement.removeEventListener('mousemove', this.onPointerHover);
+    this.domElement.removeEventListener('mousedown', this.onPointerDown);
+    this.domElement.removeEventListener('mousemove', this.onPointerMove);
+    this.domElement.removeEventListener('mouseup', this.onPointerUp);
+    this.domElement.removeEventListener('mouseleave', this.onPointerUp);
+
+    this.domElement.removeEventListener('touchmove', this.onPointerHover);
+    this.domElement.removeEventListener('touchstart', this.onPointerDown);
+    this.domElement.removeEventListener('touchmove', this.onPointerMove);
+    this.domElement.removeEventListener('touchend', this.onPointerUp);
+    this.domElement.removeEventListener('touchcancel', this.onPointerUp);
+  }
+
+  updateMouse(event) {
+    const pointer = event.changedTouches ? event.changedTouches[0] : event;
+    const rect = this.domElement.getBoundingClientRect();
+    this.mouse.x = ((pointer.clientX - rect.left) / rect.width) * 2 - 1;
+    this.mouse.y = -((pointer.clientY - rect.top) / rect.height) * 2 + 1;
+    this.raycaster.setFromCamera(this.mouse, this.camera);
+  }
+
+  /** Intersect the current pointer ray with a THREE.Plane. */
+  intersectPlane(plane, out) {
+    return this.raycaster.ray.intersectPlane(plane, out);
+  }
+
+  onPointerHover(event) {
+    if (!this.object || !this.visible || !this.enabled || this.isDragging) {
+      return;
+    }
+    this.updateMouse(event);
+    const intersects = this.raycaster.intersectObjects(this.getPickers(), true);
+
+    let axis = null;
+    if (intersects.length > 0) {
+      // Pickers may be groups; the axis id lives on the named ancestor.
+      let node = intersects[0].object;
+      while (node && !node.userData.gizmoAxis) node = node.parent;
+      axis = node ? node.userData.gizmoAxis : intersects[0].object.name;
+      event.preventDefault();
+      this.domElement.style.cursor = 'pointer';
+    } else if (this.axis) {
+      this.domElement.style.cursor = null;
+    }
+
+    if (this.axis !== axis) {
+      this.axis = axis;
+      this.highlight(axis);
+      this.dispatchEvent(this.changeEvent);
+    }
+  }
+
+  onPointerDown(event) {
+    if (!this.object || !this.visible || !this.enabled || this.isDragging) {
+      return;
+    }
+    const pointer = event.changedTouches ? event.changedTouches[0] : event;
+    if (pointer.button !== 0 && pointer.button !== undefined) return;
+    if (!this.axis) return;
+
+    this.updateMouse(event);
+    if (this.startDrag(this.axis, event) === false) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = true;
+    this.dispatchEvent(this.mouseDownEvent);
+  }
+
+  onPointerMove(event) {
+    if (!this.object || !this.isDragging) return;
+    event.preventDefault();
+    event.stopPropagation();
+    this.updateMouse(event);
+    this.moveDrag(event);
+  }
+
+  onPointerUp(event) {
+    if (!this.isDragging) return;
+    this.isDragging = false;
+    this.endDrag(event);
+    this.dispatchEvent(this.mouseUpEvent);
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if ('TouchEvent' in window && event instanceof TouchEvent) {
+      this.axis = null;
+      this.highlight(null);
+    } else {
+      this.onPointerHover(event);
+    }
+    this.dispatchEvent(this.changeEvent);
+  }
+
+  // --- subclass hooks -------------------------------------------------
+  getPickers() {
+    return [];
+  }
+
+  highlight(axis) {}
+
+  startDrag(axis, event) {}
+
+  moveDrag(event) {}
+
+  endDrag(event) {}
+}
+
+export { GizmoPointerControls };

--- a/src/editor/lib/gizmos/SegmentWidthControls.js
+++ b/src/editor/lib/gizmos/SegmentWidthControls.js
@@ -1,0 +1,174 @@
+import { GizmoPointerControls } from './GizmoPointerControls';
+
+/**
+ * SegmentWidthControls — "Segment Width Handles" prototype (#1218).
+ *
+ * A selected street-segment (inside a managed street) shows a vertical bar
+ * along each long edge. Dragging a bar left/right changes
+ * street-segment.width in place; the managed street's normal re-layout
+ * cascade (street-align, street-ground, street-label) runs live during the
+ * drag.
+ *
+ * The drag is measured in the *street's* local X frame, which is stable
+ * while segments shuffle around during re-layout — no feedback loop between
+ * handle position and pointer delta.
+ *
+ * Note on feel: with street-align width 'center', widening a segment grows
+ * it symmetrically around the street center, so the dragged edge moves at
+ * about half cursor speed. Anchoring the opposite edge would need a
+ * coordinated street-position change — out of scope for this prototype.
+ */
+
+const MIN_WIDTH = 0.3;
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
+
+class SegmentWidthControls extends GizmoPointerControls {
+  constructor(camera, domElement) {
+    super(camera, domElement, 'gizmoPrototypeSegmentWidth');
+
+    this.el = undefined; // the street-segment entity
+    this.streetObject = null; // parent managed-street object3D
+
+    this.dragPlane = new THREE.Plane();
+    this.dragLocal = new THREE.Vector3();
+    this.dragStartPointerX = 0;
+    this.dragStartWidth = 0;
+    this.dragSign = 1;
+
+    this.buildHandles();
+  }
+
+  buildHandles() {
+    this.idleMaterial = new THREE.MeshBasicMaterial({
+      color: 0x1faaf2,
+      transparent: true,
+      opacity: 0.65,
+      depthTest: false
+    });
+    this.hoverMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffd633,
+      transparent: false,
+      depthTest: false
+    });
+
+    // Unit-depth bar; z is scaled per-frame to a fraction of segment length.
+    const barGeom = new THREE.BoxGeometry(0.18, 0.5, 1);
+
+    this.handles = {};
+    ['left', 'right'].forEach((key) => {
+      const bar = new THREE.Mesh(barGeom, this.idleMaterial);
+      bar.name = 'gizmoPrototypeSegmentWidth-' + key;
+      bar.userData.gizmoAxis = key;
+      bar.renderOrder = 100;
+      this.handles[key] = bar;
+      this.add(bar);
+    });
+  }
+
+  getPickers() {
+    return [this.handles.left, this.handles.right];
+  }
+
+  highlight(axis) {
+    ['left', 'right'].forEach((key) => {
+      this.handles[key].material =
+        key === axis ? this.hoverMaterial : this.idleMaterial;
+    });
+  }
+
+  attach(el) {
+    if (!el || !el.components || !el.components['street-segment']) return this;
+    const streetEl = el.parentElement;
+    if (!streetEl || !streetEl.components?.['managed-street']) return this;
+    this.el = el;
+    this.object = el.object3D;
+    this.streetObject = streetEl.object3D;
+    this.visible = true;
+    return this;
+  }
+
+  detach() {
+    this.el = undefined;
+    this.object = undefined;
+    this.streetObject = null;
+    this.visible = false;
+    this.axis = null;
+    return this;
+  }
+
+  getSegmentData() {
+    return this.el?.components['street-segment']?.data;
+  }
+
+  updateMatrixWorld(force) {
+    if (this.el && this.object) {
+      const data = this.getSegmentData();
+      if (data) {
+        this.object.updateWorldMatrix(true, false);
+        const halfWidth = (data.width || 0) / 2;
+        const barLen = Math.min(8, Math.max(2, (data.length || 0) * 0.5));
+        ['left', 'right'].forEach((key) => {
+          const handle = this.handles[key];
+          const sign = key === 'right' ? 1 : -1;
+          handle.position.set(sign * halfWidth, 0.3, 0);
+          this.object.localToWorld(handle.position);
+          this.object.getWorldQuaternion(handle.quaternion);
+          const dist = handle.position.distanceTo(this.camera.position);
+          const s = THREE.MathUtils.clamp(dist * 0.02, 1, 5);
+          handle.scale.set(s, s, barLen);
+        });
+      }
+    }
+    super.updateMatrixWorld(force);
+  }
+
+  startDrag(axis, event) {
+    const handle = this.handles[axis];
+    this.dragPlane.set(Y_AXIS, -handle.position.y);
+    if (!this.intersectPlane(this.dragPlane, this.tempVec)) return false;
+
+    this.dragLocal.copy(this.tempVec);
+    this.streetObject.worldToLocal(this.dragLocal);
+    this.dragStartPointerX = this.dragLocal.x;
+    this.dragStartWidth = this.getSegmentData()?.width || 0;
+    this.dragSign = axis === 'right' ? 1 : -1;
+  }
+
+  moveDrag(event) {
+    if (!this.intersectPlane(this.dragPlane, this.tempVec)) return;
+    this.dragLocal.copy(this.tempVec);
+    this.streetObject.worldToLocal(this.dragLocal);
+
+    const delta = (this.dragLocal.x - this.dragStartPointerX) * this.dragSign;
+    let newWidth = this.dragStartWidth + delta;
+    if (event.shiftKey) {
+      newWidth = Math.round(newWidth * 2) / 2; // 0.5m snap
+    }
+    newWidth = Math.max(MIN_WIDTH, parseFloat(newWidth.toFixed(2)));
+    if (newWidth === this.getSegmentData()?.width) return;
+
+    this.el.setAttribute('street-segment', 'width', newWidth);
+    this.dispatchEvent(this.changeEvent);
+    this.dispatchEvent(this.objectChangeEvent);
+  }
+
+  endDrag(event) {
+    if (!this.el) return;
+    const finalWidth = this.getSegmentData()?.width;
+    if (finalWidth === undefined || finalWidth === this.dragStartWidth) return;
+    this.dispatchEvent({
+      type: 'commitDrag',
+      entity: this.el,
+      changes: [
+        {
+          component: 'street-segment',
+          property: 'width',
+          value: finalWidth,
+          oldValue: this.dragStartWidth
+        }
+      ]
+    });
+  }
+}
+
+export { SegmentWidthControls };

--- a/src/editor/lib/gizmos/SimpleTransformControls.js
+++ b/src/editor/lib/gizmos/SimpleTransformControls.js
@@ -1,0 +1,315 @@
+import { GizmoPointerControls } from './GizmoPointerControls';
+
+/**
+ * SimpleTransformControls — the "Simplified Move + Rotate" prototype
+ * (#1674) with an optional ground-clamp behavior (#1446).
+ *
+ * One combined gizmo, no modes:
+ *   - a translucent disc with four arrows: drag to move along the ground
+ *     plane (XZ, Y preserved — or clamped to the surface below when
+ *     `clampToGround` is set)
+ *   - a thick ring around it: drag to rotate around Y
+ *
+ * Hold Shift while dragging to snap (0.5m translation grid, 15° rotation).
+ *
+ * Attach/detach mirror TransformControls (attach takes an Object3D with an
+ * `.el`), and 'mouseDown'/'objectChange'/'mouseUp' events fire the same way
+ * so viewport.js reuses its pre-drag-snapshot + entityupdate wiring.
+ */
+
+const TRANSLATE_SNAP = 0.5; // meters
+const ROTATE_SNAP = THREE.MathUtils.degToRad(15);
+
+const COLOR_MOVE = 0x8b5cf6; // purple
+const COLOR_ROTATE = 0x1faaf2; // 3DStreet selection blue
+const COLOR_HOVER = 0xffd633; // yellow
+
+function roundVec3(v) {
+  v.set(
+    parseFloat(v.x.toFixed(3)),
+    parseFloat(v.y.toFixed(3)),
+    parseFloat(v.z.toFixed(3))
+  );
+  return v;
+}
+
+class SimpleTransformControls extends GizmoPointerControls {
+  constructor(camera, domElement) {
+    super(camera, domElement, 'gizmoPrototypeSimple');
+
+    this.size = 1.5;
+    // When true, horizontal drags re-seat the object on whatever surface is
+    // below the drag point (#1446). Set by the viewport per prototype.
+    this.clampToGround = false;
+    // Root to raycast against for ground clamping (the A-Frame scene
+    // object3D — editor helpers live in a separate graph so they are never
+    // hit). Assigned by viewport.js after construction.
+    this.groundRaycastRoot = null;
+
+    this.dragPlane = new THREE.Plane();
+    this.dragOffset = new THREE.Vector3();
+    this.dragStartWorldY = 0;
+    this.groundOffset = 0; // worldPos.y - bbox.min.y, so objects sit on, not in
+    this.startPointerAngle = 0;
+    this.startRotY = 0;
+    this.groundRaycaster = new THREE.Raycaster();
+    this.groundRayOrigin = new THREE.Vector3();
+    this.DOWN = new THREE.Vector3(0, -1, 0);
+    this.worldPos = new THREE.Vector3();
+    this.parentTarget = new THREE.Vector3();
+    this.bbox = new THREE.Box3();
+
+    this.buildHandles();
+  }
+
+  buildHandles() {
+    // --- move disc + arrows ---------------------------------------------
+    this.moveMaterial = new THREE.MeshBasicMaterial({
+      color: COLOR_MOVE,
+      transparent: true,
+      opacity: 0.4,
+      depthTest: false,
+      side: THREE.DoubleSide
+    });
+    this.moveArrowMaterial = new THREE.MeshBasicMaterial({
+      color: COLOR_MOVE,
+      transparent: true,
+      opacity: 0.9,
+      depthTest: false
+    });
+
+    this.moveGroup = new THREE.Group();
+    this.moveGroup.name = 'gizmoPrototypeSimpleMove';
+    this.moveGroup.userData.gizmoAxis = 'move';
+
+    const disc = new THREE.Mesh(
+      new THREE.CircleGeometry(0.55, 32),
+      this.moveMaterial
+    );
+    disc.rotation.x = -Math.PI / 2;
+    disc.renderOrder = 100;
+    this.moveGroup.add(disc);
+
+    // Four outward arrows on the disc edge (move-along-ground affordance).
+    const coneGeom = new THREE.ConeGeometry(0.11, 0.28, 12);
+    const shaftGeom = new THREE.CylinderGeometry(0.04, 0.04, 0.22, 8);
+    const arrowDirs = [
+      { dir: [1, 0, 0], rotZ: -Math.PI / 2, rotX: 0 },
+      { dir: [-1, 0, 0], rotZ: Math.PI / 2, rotX: 0 },
+      { dir: [0, 0, 1], rotZ: 0, rotX: Math.PI / 2 },
+      { dir: [0, 0, -1], rotZ: 0, rotX: -Math.PI / 2 }
+    ];
+    arrowDirs.forEach(({ dir, rotZ, rotX }) => {
+      const shaft = new THREE.Mesh(shaftGeom, this.moveArrowMaterial);
+      shaft.position.set(dir[0] * 0.68, 0, dir[2] * 0.68);
+      shaft.rotation.set(rotX, 0, rotZ);
+      shaft.renderOrder = 101;
+      this.moveGroup.add(shaft);
+
+      const cone = new THREE.Mesh(coneGeom, this.moveArrowMaterial);
+      cone.position.set(dir[0] * 0.9, 0, dir[2] * 0.9);
+      cone.rotation.set(rotX, 0, rotZ);
+      cone.renderOrder = 101;
+      this.moveGroup.add(cone);
+    });
+
+    const movePicker = new THREE.Mesh(
+      new THREE.CircleGeometry(0.95, 16),
+      new THREE.MeshBasicMaterial({ visible: false, side: THREE.DoubleSide })
+    );
+    movePicker.rotation.x = -Math.PI / 2;
+    movePicker.name = 'move';
+    movePicker.userData.gizmoAxis = 'move';
+    this.movePicker = movePicker;
+
+    // --- rotate ring -----------------------------------------------------
+    this.rotateMaterial = new THREE.MeshBasicMaterial({
+      color: COLOR_ROTATE,
+      transparent: true,
+      opacity: 0.9,
+      depthTest: false
+    });
+
+    // Thick tube instead of a 1px line (#1674).
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(1.2, 0.05, 8, 64),
+      this.rotateMaterial
+    );
+    ring.rotation.x = -Math.PI / 2;
+    ring.renderOrder = 99;
+    ring.name = 'gizmoPrototypeSimpleRotate';
+    this.rotateRing = ring;
+
+    const rotatePicker = new THREE.Mesh(
+      new THREE.TorusGeometry(1.2, 0.22, 8, 32),
+      new THREE.MeshBasicMaterial({ visible: false })
+    );
+    rotatePicker.rotation.x = -Math.PI / 2;
+    rotatePicker.name = 'rotate';
+    rotatePicker.userData.gizmoAxis = 'rotate';
+    this.rotatePicker = rotatePicker;
+
+    this.hoverMaterial = new THREE.MeshBasicMaterial({
+      color: COLOR_HOVER,
+      transparent: true,
+      opacity: 0.95,
+      depthTest: false
+    });
+
+    this.add(this.moveGroup);
+    this.add(movePicker);
+    this.add(ring);
+    this.add(rotatePicker);
+  }
+
+  getPickers() {
+    return [this.movePicker, this.rotatePicker];
+  }
+
+  highlight(axis) {
+    const moveMats = axis === 'move';
+    this.moveGroup.traverse((node) => {
+      if (!node.isMesh) return;
+      if (node.geometry.type === 'CircleGeometry') {
+        node.material = moveMats ? this.hoverMaterial : this.moveMaterial;
+      } else {
+        node.material = moveMats ? this.hoverMaterial : this.moveArrowMaterial;
+      }
+    });
+    this.rotateRing.material =
+      axis === 'rotate' ? this.hoverMaterial : this.rotateMaterial;
+  }
+
+  attach(object) {
+    this.object = object;
+    this.visible = true;
+    return this;
+  }
+
+  detach() {
+    this.object = undefined;
+    this.visible = false;
+    this.axis = null;
+    return this;
+  }
+
+  // Follow the attached object and keep an approximately constant screen
+  // size, like TransformControls does.
+  updateMatrixWorld(force) {
+    if (this.object) {
+      this.object.updateWorldMatrix(true, false);
+      this.object.getWorldPosition(this.position);
+      let factor;
+      if (this.camera.isOrthographicCamera) {
+        factor = (this.camera.top - this.camera.bottom) / this.camera.zoom;
+      } else {
+        factor =
+          this.position.distanceTo(this.camera.position) *
+          Math.min(
+            (1.9 * Math.tan((Math.PI * this.camera.fov) / 360)) /
+              this.camera.zoom,
+            7
+          );
+      }
+      const scale = (factor * this.size) / 4;
+      this.scale.set(scale, scale, scale);
+    }
+    super.updateMatrixWorld(force);
+  }
+
+  startDrag(axis, event) {
+    const object = this.object;
+    object.getWorldPosition(this.worldPos);
+    this.dragStartWorldY = this.worldPos.y;
+    this.dragPlane.set(new THREE.Vector3(0, 1, 0), -this.worldPos.y);
+
+    if (!this.intersectPlane(this.dragPlane, this.tempVec)) return false;
+
+    if (axis === 'move') {
+      this.dragOffset.copy(this.worldPos).sub(this.tempVec);
+      this.groundOffset = 0;
+      if (this.clampToGround) {
+        this.bbox.setFromObject(object);
+        if (!this.bbox.isEmpty()) {
+          this.groundOffset = this.worldPos.y - this.bbox.min.y;
+        }
+      }
+    } else if (axis === 'rotate') {
+      this.startPointerAngle = Math.atan2(
+        this.tempVec.x - this.worldPos.x,
+        this.tempVec.z - this.worldPos.z
+      );
+      this.startRotY = object.rotation.y;
+    }
+  }
+
+  moveDrag(event) {
+    if (!this.intersectPlane(this.dragPlane, this.tempVec)) return;
+    const object = this.object;
+
+    if (this.axis === 'move') {
+      const target = this.tempVec.add(this.dragOffset);
+      if (event.shiftKey) {
+        target.x = Math.round(target.x / TRANSLATE_SNAP) * TRANSLATE_SNAP;
+        target.z = Math.round(target.z / TRANSLATE_SNAP) * TRANSLATE_SNAP;
+      }
+      target.y = this.dragStartWorldY;
+      if (this.clampToGround) {
+        const groundY = this.findGroundY(target.x, target.z);
+        if (groundY !== null) {
+          target.y = groundY + this.groundOffset;
+        }
+      }
+      this.parentTarget.copy(target);
+      object.parent.worldToLocal(this.parentTarget);
+      object.position.copy(roundVec3(this.parentTarget));
+      this.objectChangeEvent.mode = 'translate';
+    } else if (this.axis === 'rotate') {
+      const angle = Math.atan2(
+        this.tempVec.x - this.worldPos.x,
+        this.tempVec.z - this.worldPos.z
+      );
+      let rotY = this.startRotY + (angle - this.startPointerAngle);
+      if (event.shiftKey) {
+        rotY = Math.round(rotY / ROTATE_SNAP) * ROTATE_SNAP;
+      }
+      object.rotation.y = parseFloat(rotY.toFixed(3));
+      this.objectChangeEvent.mode = 'rotate';
+    }
+
+    this.dispatchEvent(this.changeEvent);
+    this.dispatchEvent(this.objectChangeEvent);
+  }
+
+  /**
+   * Highest surface under (x, z), excluding the dragged object itself and
+   * anything invisible. Returns null when nothing is below.
+   */
+  findGroundY(x, z) {
+    if (!this.groundRaycastRoot) return null;
+    this.groundRayOrigin.set(x, this.dragStartWorldY + 500, z);
+    this.groundRaycaster.set(this.groundRayOrigin, this.DOWN);
+    this.groundRaycaster.far = 2000;
+    const hits = this.groundRaycaster.intersectObject(
+      this.groundRaycastRoot,
+      true
+    );
+    for (const hit of hits) {
+      if (this.isOwnOrHidden(hit.object)) continue;
+      return hit.point.y;
+    }
+    return null;
+  }
+
+  isOwnOrHidden(node) {
+    let n = node;
+    while (n) {
+      if (n === this.object || n === this) return true;
+      if (n.visible === false) return true;
+      n = n.parent;
+    }
+    return false;
+  }
+}
+
+export { SimpleTransformControls };

--- a/src/editor/lib/gizmos/StreetNodeControls.js
+++ b/src/editor/lib/gizmos/StreetNodeControls.js
@@ -1,0 +1,297 @@
+import { GizmoPointerControls } from './GizmoPointerControls';
+import { getTravelledWaySegments } from '../../../aframe-components/street-layout-utils';
+
+/**
+ * StreetNodeControls — "Street Endpoint Nodes" prototype (#1096).
+ *
+ * A managed street is presented as a line with a draggable circle at each
+ * end. Dragging a circle moves that endpoint while the other stays fixed;
+ * the street's position, Y rotation, and managed-street.length are updated
+ * so the two circles always sit at the street's ends.
+ *
+ * Works only on entities with a `managed-street` component (legacy
+ * streetmix streets are intentionally unsupported). All math happens in the
+ * street's parent space, so nested/offset layer containers behave.
+ *
+ * Endpoint local coordinates depend on street-align:
+ *   length 'start'  -> street spans local z in [-L, 0]
+ *   length 'middle' -> [-L/2, +L/2]
+ *   length 'end'    -> [0, +L]
+ *   width 'center'|'left'|'right' -> centerline x offset 0 | +W/2 | -W/2
+ */
+
+const MIN_LENGTH = 1;
+const LENGTH_APPLY_THROTTLE_MS = 100;
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
+
+class StreetNodeControls extends GizmoPointerControls {
+  constructor(camera, domElement) {
+    super(camera, domElement, 'gizmoPrototypeStreetNodes');
+
+    this.el = undefined; // the managed-street entity
+
+    this.centerlineX = 0;
+    this.refreshLayoutCache = this.refreshLayoutCache.bind(this);
+
+    this.dragPlane = new THREE.Plane();
+    this.fixedWorld = new THREE.Vector3();
+    this.fixedParent = new THREE.Vector3();
+    this.movingParent = new THREE.Vector3();
+    this.originParent = new THREE.Vector3();
+    this.tmpDir = new THREE.Vector3();
+    this.tmpLocal = new THREE.Vector3();
+    this.lastLengthApply = 0;
+    this.pendingLength = null;
+    this.dragStartSnapshot = null;
+
+    this.buildHandles();
+  }
+
+  buildHandles() {
+    // Flat circles similar in feel to the gizmo's ground-plane square:
+    // transparent purple, solid yellow on hover (#1096).
+    this.idleMaterial = new THREE.MeshBasicMaterial({
+      color: 0x8b5cf6,
+      transparent: true,
+      opacity: 0.45,
+      depthTest: false
+    });
+    this.hoverMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffd633,
+      transparent: false,
+      depthTest: false
+    });
+
+    const discGeom = new THREE.CylinderGeometry(1.6, 1.6, 0.12, 40);
+    const rimGeom = new THREE.TorusGeometry(1.6, 0.08, 8, 40);
+
+    this.handles = {};
+    ['start', 'end'].forEach((key) => {
+      const group = new THREE.Group();
+      group.name = 'gizmoPrototypeStreetNode-' + key;
+      group.userData.gizmoAxis = key;
+
+      const disc = new THREE.Mesh(discGeom, this.idleMaterial);
+      disc.renderOrder = 100;
+      group.add(disc);
+
+      const rim = new THREE.Mesh(rimGeom, this.idleMaterial);
+      rim.rotation.x = -Math.PI / 2;
+      rim.renderOrder = 101;
+      group.add(rim);
+
+      this.handles[key] = group;
+      this.add(group);
+    });
+  }
+
+  getPickers() {
+    return [this.handles.start, this.handles.end];
+  }
+
+  highlight(axis) {
+    ['start', 'end'].forEach((key) => {
+      const mat = key === axis ? this.hoverMaterial : this.idleMaterial;
+      this.handles[key].traverse((node) => {
+        if (node.isMesh) node.material = mat;
+      });
+    });
+  }
+
+  attach(el) {
+    if (!el || !el.components || !el.components['managed-street']) return this;
+    this.el = el;
+    this.object = el.object3D;
+    this.visible = true;
+    this.refreshLayoutCache();
+    el.addEventListener('segments-changed', this.refreshLayoutCache);
+    el.addEventListener('alignment-changed', this.refreshLayoutCache);
+    return this;
+  }
+
+  detach() {
+    if (this.el) {
+      this.el.removeEventListener('segments-changed', this.refreshLayoutCache);
+      this.el.removeEventListener('alignment-changed', this.refreshLayoutCache);
+    }
+    this.el = undefined;
+    this.object = undefined;
+    this.visible = false;
+    this.axis = null;
+    return this;
+  }
+
+  /** Cached travelled-way centerline offset (recomputed on layout changes). */
+  refreshLayoutCache() {
+    if (!this.el) return;
+    const widthAlign = this.el.components['street-align']?.data?.width;
+    if (widthAlign === 'center' || widthAlign === undefined) {
+      this.centerlineX = 0;
+      return;
+    }
+    const totalWidth = getTravelledWaySegments(this.el).reduce(
+      (sum, seg) => sum + (seg.getAttribute('street-segment')?.width || 0),
+      0
+    );
+    this.centerlineX = widthAlign === 'left' ? totalWidth / 2 : -totalWidth / 2;
+  }
+
+  getStreetLength() {
+    return this.el?.components['managed-street']?.data?.length || 0;
+  }
+
+  getLengthAlign() {
+    return this.el?.components['street-align']?.data?.length || 'start';
+  }
+
+  /** Local-space z of both endpoints for a given length + alignment. */
+  endpointLocalZ(length, align) {
+    if (align === 'middle') return { start: -length / 2, end: length / 2 };
+    if (align === 'end') return { start: 0, end: length };
+    return { start: -length, end: 0 }; // 'start' (default)
+  }
+
+  endpointLocal(key, length, align) {
+    const z = this.endpointLocalZ(length, align);
+    return this.tmpLocal.set(this.centerlineX, 0, z[key]);
+  }
+
+  updateMatrixWorld(force) {
+    if (this.el && this.object) {
+      this.object.updateWorldMatrix(true, false);
+      const length = this.getStreetLength();
+      const align = this.getLengthAlign();
+      ['start', 'end'].forEach((key) => {
+        const handle = this.handles[key];
+        handle.position.copy(this.endpointLocal(key, length, align));
+        this.object.localToWorld(handle.position);
+        handle.position.y += 0.2;
+        // Mild distance scaling so handles stay usable when zoomed out.
+        const dist = handle.position.distanceTo(this.camera.position);
+        const s = THREE.MathUtils.clamp(dist * 0.015, 1, 6);
+        handle.scale.set(s, s, s);
+      });
+    }
+    super.updateMatrixWorld(force);
+  }
+
+  startDrag(axis, event) {
+    const handle = this.handles[axis];
+    this.dragPlane.set(Y_AXIS, -handle.position.y);
+    if (!this.intersectPlane(this.dragPlane, this.tempVec)) return false;
+
+    const other = axis === 'start' ? 'end' : 'start';
+    this.fixedWorld.copy(this.handles[other].position);
+
+    const pos = this.el.getAttribute('position');
+    const rot = this.el.getAttribute('rotation');
+    this.dragStartSnapshot = {
+      position: `${pos.x} ${pos.y} ${pos.z}`,
+      rotation: `${rot.x} ${rot.y} ${rot.z}`,
+      rotationXZ: { x: rot.x, z: rot.z },
+      positionY: pos.y,
+      length: this.getStreetLength()
+    };
+    this.pendingLength = null;
+    this.lastLengthApply = 0;
+  }
+
+  moveDrag(event) {
+    if (!this.intersectPlane(this.dragPlane, this.tempVec)) return;
+    const parent = this.object.parent;
+    const align = this.getLengthAlign();
+
+    // Work in the street's parent space (XZ only).
+    this.movingParent.copy(this.tempVec);
+    parent.worldToLocal(this.movingParent);
+    this.fixedParent.copy(this.fixedWorld);
+    parent.worldToLocal(this.fixedParent);
+    this.movingParent.y = 0;
+    this.fixedParent.y = 0;
+
+    let newLength = this.movingParent.distanceTo(this.fixedParent);
+    newLength = Math.max(MIN_LENGTH, parseFloat(newLength.toFixed(2)));
+
+    // Street local +Z runs start -> end.
+    if (this.axis === 'end') {
+      this.tmpDir.subVectors(this.movingParent, this.fixedParent);
+    } else {
+      this.tmpDir.subVectors(this.fixedParent, this.movingParent);
+    }
+    if (this.tmpDir.lengthSq() < 1e-6) return;
+    this.tmpDir.normalize();
+    const rotY = Math.atan2(this.tmpDir.x, this.tmpDir.z);
+
+    // Re-derive the origin so the fixed endpoint stays exactly put:
+    // origin = fixed - R(rotY) * fixedLocal(newLength)
+    const fixedKey = this.axis === 'start' ? 'end' : 'start';
+    const fixedLocal = this.endpointLocal(fixedKey, newLength, align).clone();
+    fixedLocal.applyAxisAngle(Y_AXIS, rotY);
+    this.originParent.copy(this.fixedParent).sub(fixedLocal);
+
+    const snap = this.dragStartSnapshot;
+    this.el.setAttribute('position', {
+      x: parseFloat(this.originParent.x.toFixed(3)),
+      y: snap.positionY,
+      z: parseFloat(this.originParent.z.toFixed(3))
+    });
+    this.el.setAttribute('rotation', {
+      x: snap.rotationXZ.x,
+      y: parseFloat(THREE.MathUtils.radToDeg(rotY).toFixed(2)),
+      z: snap.rotationXZ.z
+    });
+
+    // Length re-layout cascades to every segment — throttle it during the
+    // drag, and always flush the final value in endDrag().
+    this.pendingLength = newLength;
+    const now = performance.now();
+    if (now - this.lastLengthApply > LENGTH_APPLY_THROTTLE_MS) {
+      this.lastLengthApply = now;
+      this.el.setAttribute('managed-street', 'length', newLength);
+    }
+
+    this.dispatchEvent(this.changeEvent);
+    this.dispatchEvent(this.objectChangeEvent);
+  }
+
+  endDrag(event) {
+    const snap = this.dragStartSnapshot;
+    if (!snap || !this.el) return;
+
+    if (
+      this.pendingLength !== null &&
+      this.pendingLength !== this.getStreetLength()
+    ) {
+      this.el.setAttribute('managed-street', 'length', this.pendingLength);
+    }
+
+    const pos = this.el.getAttribute('position');
+    const rot = this.el.getAttribute('rotation');
+    this.dispatchEvent({
+      type: 'commitDrag',
+      entity: this.el,
+      changes: [
+        {
+          component: 'position',
+          value: `${pos.x} ${pos.y} ${pos.z}`,
+          oldValue: snap.position
+        },
+        {
+          component: 'rotation',
+          value: `${rot.x} ${rot.y} ${rot.z}`,
+          oldValue: snap.rotation
+        },
+        {
+          component: 'managed-street',
+          property: 'length',
+          value: this.getStreetLength(),
+          oldValue: snap.length
+        }
+      ]
+    });
+    this.dragStartSnapshot = null;
+    this.pendingLength = null;
+  }
+}
+
+export { StreetNodeControls };

--- a/src/editor/lib/gizmos/constants.js
+++ b/src/editor/lib/gizmos/constants.js
@@ -1,0 +1,49 @@
+/**
+ * Gizmo prototype lab (#1674, #1446, #1096, #1218, #1806).
+ *
+ * Experimental, switchable gizmo behaviors for the viewport. The active
+ * prototype is a persisted editor preference (store.gizmoPrototype) picked
+ * from View → Gizmo Prototypes (Lab). Each prototype changes which controls
+ * attach to a selected entity — see attachControlsForSelection() in
+ * viewport.js for the routing table.
+ */
+
+export const GIZMO_PROTOTYPES = [
+  {
+    id: 'legacy',
+    label: 'Legacy (current gizmo)',
+    description: 'Standard three.js TransformControls, unchanged.'
+  },
+  {
+    id: 'simple',
+    label: 'Simplified Move + Rotate',
+    description:
+      'Combined gizmo: drag the disc to move along the ground plane, drag the ring to rotate around Y. Hold Shift to snap. (#1674)'
+  },
+  {
+    id: 'ground-clamp',
+    label: 'Simplified + Ground Clamp',
+    description:
+      'Same as Simplified, but while dragging the object is clamped to sit on whatever surface is below it — streets, 3D tiles, shapes. (#1446)'
+  },
+  {
+    id: 'street-nodes',
+    label: 'Street Endpoint Nodes',
+    description:
+      'Managed streets get a draggable circle at each end; dragging an endpoint updates street position, rotation and length. Other entities use the Simplified gizmo. (#1096)'
+  },
+  {
+    id: 'segment-width',
+    label: 'Segment Width Handles',
+    description:
+      'Street segments get edge handles: drag an edge to widen or narrow the segment in place. Other entities use the Simplified gizmo. (#1218)'
+  }
+];
+
+export const DEFAULT_GIZMO_PROTOTYPE = 'legacy';
+
+export const GIZMO_PROTOTYPE_IDS = GIZMO_PROTOTYPES.map((p) => p.id);
+
+export function isValidGizmoPrototype(id) {
+  return GIZMO_PROTOTYPE_IDS.includes(id);
+}

--- a/src/editor/lib/nav-experimental/cursorAnchor.js
+++ b/src/editor/lib/nav-experimental/cursorAnchor.js
@@ -73,7 +73,10 @@ const EXCLUDE_NAME_SUBSTRINGS = [
   // The rotation-centre ring billboard (KD-30 / KD-03). depthTest is off
   // so it would otherwise be a tempting raycast hit; never let it become
   // a pivot/anchor target.
-  'navRotationIndicator'
+  'navRotationIndicator',
+  // Gizmo prototype lab controls (editor/lib/gizmos/) — every root and
+  // named child carries this prefix.
+  'gizmoPrototype'
 ];
 
 // Class-attribute / component substrings on the entity element.

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -2,6 +2,9 @@ import { TransformControls } from './TransformControls.js';
 // eslint-disable-next-line no-unused-vars
 import EditorControls from './EditorControls.js';
 import { MeasureLineControls } from './MeasureLineControls.js';
+import { SimpleTransformControls } from './gizmos/SimpleTransformControls.js';
+import { StreetNodeControls } from './gizmos/StreetNodeControls.js';
+import { SegmentWidthControls } from './gizmos/SegmentWidthControls.js';
 import InfiniteGridHelper from './InfiniteGridHelper.js';
 import {
   ExperimentalControls,
@@ -322,6 +325,25 @@ export function Viewport(inspector) {
   measureLineControls.visible = false;
   measureLineControls.enabled = true;
 
+  // --- Gizmo prototype lab (#1674 #1446 #1096 #1218 #1806) --------------
+  // Experimental alternative controls, selected via the persisted
+  // store.gizmoPrototype preference (View → Gizmo Prototypes (Lab)).
+  // attachControlsForSelection() below is the single routing table deciding
+  // which controls attach to the current selection.
+  const simpleGizmoControls = new SimpleTransformControls(
+    camera,
+    inspector.container
+  );
+  simpleGizmoControls.groundRaycastRoot = inspector.sceneEl.object3D;
+  const streetNodeControls = new StreetNodeControls(
+    camera,
+    inspector.container
+  );
+  const segmentWidthControls = new SegmentWidthControls(
+    camera,
+    inspector.container
+  );
+
   // Pose snapshot taken on the gizmo's mouseDown, BEFORE TransformControls
   // mutates the object. The undo command can't capture this itself:
   // getAttribute('position') returns the live object3D values, which are
@@ -442,8 +464,91 @@ export function Viewport(inspector) {
     });
   });
 
+  simpleGizmoControls.addEventListener('mouseDown', () => {
+    const object = simpleGizmoControls.object;
+    if (object) {
+      const d = THREE.MathUtils.radToDeg;
+      transformPreDragValues = {
+        position: `${object.position.x} ${object.position.y} ${object.position.z}`,
+        rotation: `${d(object.rotation.x)} ${d(object.rotation.y)} ${d(
+          object.rotation.z
+        )}`
+      };
+    }
+    controls.enabled = false;
+    hoverBox.visible = false;
+  });
+
+  simpleGizmoControls.addEventListener('mouseUp', () => {
+    controls.enabled = true;
+  });
+
+  simpleGizmoControls.addEventListener('objectChange', (evt) => {
+    const object = simpleGizmoControls.object;
+    if (object === undefined) return;
+
+    syncBatchedSubtree(object.el);
+    selectionBox.setFromObject(object);
+    updateHelpers(object);
+
+    let component;
+    let value;
+    if (evt.mode === 'rotate') {
+      component = 'rotation';
+      const d = THREE.MathUtils.radToDeg;
+      value = `${d(object.rotation.x)} ${d(object.rotation.y)} ${d(
+        object.rotation.z
+      )}`;
+    } else {
+      component = 'position';
+      value = `${object.position.x} ${object.position.y} ${object.position.z}`;
+    }
+
+    inspector.execute('entityupdate', {
+      component: component,
+      entity: object.el,
+      value: value,
+      oldValue: transformPreDragValues?.[component]
+    });
+  });
+
+  // The street gizmos mutate attributes live during the drag (so the normal
+  // managed-street re-layout cascade runs) and report the whole drag once on
+  // mouseUp via 'commitDrag' — turned into a single undo step here.
+  [streetNodeControls, segmentWidthControls].forEach((streetControls) => {
+    streetControls.addEventListener('mouseDown', () => {
+      controls.enabled = false;
+      hoverBox.visible = false;
+    });
+    streetControls.addEventListener('mouseUp', () => {
+      controls.enabled = true;
+    });
+    streetControls.addEventListener('objectChange', () => {
+      const object = streetControls.object;
+      if (!object) return;
+      selectionBox.setFromObject(object);
+      updateHelpers(object);
+    });
+    streetControls.addEventListener('commitDrag', (evt) => {
+      const changed = evt.changes.filter((c) => c.value !== c.oldValue);
+      if (changed.length === 0) return;
+      const commands = changed.map((c) => [
+        'entityupdate',
+        { entity: evt.entity, ...c }
+      ]);
+      if (commands.length === 1) {
+        inspector.execute('entityupdate', commands[0][1]);
+      } else {
+        inspector.execute('multi', commands);
+      }
+    });
+  });
+
   sceneHelpers.add(transformControls.getHelper());
   sceneHelpers.add(measureLineControls);
+  sceneHelpers.add(simpleGizmoControls);
+  sceneHelpers.add(streetNodeControls);
+  sceneHelpers.add(segmentWidthControls);
 
   Events.on('entityupdate', (detail) => {
     const object = detail.entity.object3D;
@@ -501,6 +606,9 @@ export function Viewport(inspector) {
         inspector.camera = perspective;
         transformControls.camera = perspective;
         measureLineControls.camera = perspective;
+        simpleGizmoControls.camera = perspective;
+        streetNodeControls.camera = perspective;
+        segmentWidthControls.camera = perspective;
         controls.setCamera(perspective);
         updateAspectRatio();
         controls.handlePlanViewRequest();
@@ -510,12 +618,18 @@ export function Viewport(inspector) {
     controls.setCamera(data.camera);
     transformControls.camera = data.camera;
     measureLineControls.camera = data.camera;
+    simpleGizmoControls.camera = data.camera;
+    streetNodeControls.camera = data.camera;
+    segmentWidthControls.camera = data.camera;
     updateAspectRatio();
   });
 
   function enableControls() {
     mouseCursor.enable();
     transformControls.enabled = true;
+    simpleGizmoControls.enabled = true;
+    streetNodeControls.enabled = true;
+    segmentWidthControls.enabled = true;
     controls.enabled = true;
   }
   enableControls();
@@ -524,7 +638,62 @@ export function Viewport(inspector) {
     controls.center.set(0, 0, 0);
   });
 
+  let currentTransformMode = 'translate';
+
+  function detachAllTransformControls() {
+    transformControls.detach();
+    measureLineControls.detach();
+    simpleGizmoControls.detach();
+    streetNodeControls.detach();
+    segmentWidthControls.detach();
+  }
+
+  // Routing table for the gizmo prototype lab: decides which controls
+  // attach to the current selection, based on the active prototype
+  // (store.gizmoPrototype) and what is selected. 'legacy' reproduces the
+  // pre-lab behavior exactly.
+  function attachControlsForSelection() {
+    detachAllTransformControls();
+    const el = inspector.selectedEntity;
+    if (
+      !el ||
+      !inspector.cursor.isPlaying ||
+      el.hasAttribute('data-no-transform')
+    ) {
+      return;
+    }
+    if (el.components['measure-line']) {
+      measureLineControls.attach(el);
+      return;
+    }
+    const proto = useStore.getState().gizmoPrototype;
+    if (proto === 'legacy' || currentTransformMode === 'scale') {
+      // Scale has no simplified equivalent — the stock gizmo stays the
+      // advanced escape hatch under every prototype.
+      transformControls.attach(el.object3D);
+      return;
+    }
+    const isSegment =
+      el.components['street-segment'] &&
+      el.parentElement?.components?.['managed-street'];
+    if (isSegment) {
+      // street-align owns segment transforms (#1806): never show a
+      // move/rotate gizmo on a segment. Width handles only, when active.
+      if (proto === 'segment-width') {
+        segmentWidthControls.attach(el);
+      }
+      return;
+    }
+    if (proto === 'street-nodes' && el.components['managed-street']) {
+      streetNodeControls.attach(el);
+      return;
+    }
+    simpleGizmoControls.clampToGround = proto === 'ground-clamp';
+    simpleGizmoControls.attach(el.object3D);
+  }
+
   Events.on('transformmodechange', (mode) => {
+    currentTransformMode = mode;
     transformControls.setMode(mode);
     // Restrict rotation to the Y axis only.
     if (mode === 'rotate') {
@@ -538,20 +707,19 @@ export function Viewport(inspector) {
     }
 
     // If there's a selected entity, reattach the appropriate controls
-    if (
-      inspector.selectedEntity &&
-      inspector.cursor.isPlaying &&
-      !inspector.selectedEntity.hasAttribute('data-no-transform')
-    ) {
-      if (inspector.selectedEntity.components['measure-line']) {
-        transformControls.detach();
-        measureLineControls.attach(inspector.selectedEntity);
-      } else {
-        measureLineControls.detach();
-        transformControls.attach(inspector.selectedEntity.object3D);
-      }
+    if (inspector.selectedEntity) {
+      attachControlsForSelection();
     }
   });
+
+  // Re-route the attached controls when the user switches prototypes in
+  // View → Gizmo Prototypes (Lab).
+  useStore.subscribe(
+    (state) => state.gizmoPrototype,
+    () => {
+      attachControlsForSelection();
+    }
+  );
 
   Events.on('translationsnapchanged', (dist) => {
     transformControls.setTranslationSnap(dist);
@@ -568,8 +736,7 @@ export function Viewport(inspector) {
   Events.on('objectselect', (object) => {
     hoverBox.visible = false;
     selectionBox.visible = false;
-    transformControls.detach();
-    measureLineControls.detach();
+    detachAllTransformControls();
 
     if (object && object.el) {
       if (object.el.getObject3D('mesh') || isBatched(object.el)) {
@@ -594,16 +761,7 @@ export function Viewport(inspector) {
         selectionBox.visible = true;
       }
 
-      if (
-        inspector.cursor.isPlaying &&
-        !object.el.hasAttribute('data-no-transform')
-      ) {
-        if (object.el.components['measure-line']) {
-          measureLineControls.attach(object.el);
-        } else {
-          transformControls.attach(object);
-        }
-      }
+      attachControlsForSelection();
     }
   });
 
@@ -707,6 +865,9 @@ export function Viewport(inspector) {
         // borrow the rig via mode-manager and give it back.
         mouseCursor.disable();
         transformControls.enabled = false;
+        simpleGizmoControls.enabled = false;
+        streetNodeControls.enabled = false;
+        segmentWidthControls.enabled = false;
         controls.enabled = true;
         // The Viewer is always perspective — leave an ortho editing view.
         if (inspector.camera.isOrthographicCamera) {

--- a/src/store.js
+++ b/src/store.js
@@ -133,6 +133,15 @@ const useStore = create(
           localStorage.setItem('unitsPreference', newUnitsPreference);
           set({ unitsPreference: newUnitsPreference });
         },
+        // Gizmo prototype lab (#1674 #1446 #1096 #1218 #1806): which
+        // experimental viewport gizmo behavior is active. Persisted like
+        // unitsPreference; viewport.js subscribes and re-routes controls.
+        // Valid ids live in editor/lib/gizmos/constants.js.
+        gizmoPrototype: localStorage.getItem('gizmoPrototype') || 'legacy',
+        setGizmoPrototype: (newGizmoPrototype) => {
+          localStorage.setItem('gizmoPrototype', newGizmoPrototype);
+          set({ gizmoPrototype: newGizmoPrototype });
+        },
         // UI language for the localization experiment (#656). Auto-detected
         // from the browser on first load, then overridden by the user's stored
         // choice (persisted to localStorage via the View > Language menu).


### PR DESCRIPTION
## Summary

Introduces a **Gizmo Prototype Lab** — an experimental, switchable system for alternative viewport transform controls. Users can now select from multiple gizmo behaviors via **View → Gizmo Prototypes (Lab)**, with the choice persisted as a local preference. This enables side-by-side exploration of simplified move/rotate, ground clamping, street endpoint editing, and segment width adjustment without committing to a single "perfect" gizmo design.

## Key Changes

- **New gizmo base class** (`GizmoPointerControls`): Shared pointer event plumbing for custom gizmos, modeled on `MeasureLineControls`. Handles raycasting, hover feedback, and drag lifecycle with TransformControls-compatible events (`mouseDown`, `mouseUp`, `objectChange`, `change`).

- **SimpleTransformControls** (#1674, #1446): Combined move + rotate gizmo with:
  - Purple translucent disc with four directional arrows for ground-plane movement (XZ, Y preserved)
  - Blue ring for Y-axis rotation
  - Shift-key snapping (0.5 m grid, 15° rotation)
  - Optional ground clamping via raycasting to re-seat objects on surfaces below

- **StreetNodeControls** (#1096): Draggable endpoint circles for managed streets:
  - Drag an endpoint to move it while the other stays fixed
  - Street position, rotation, and length update automatically
  - Works in the street's parent space for nested/offset containers

- **SegmentWidthControls** (#1218): Edge handles for street segments:
  - Drag left/right edges to widen/narrow segments in place
  - Measured in street's local X frame for stable feedback during re-layout
  - Shift-key snapping (0.5 m)

- **Prototype routing** in `viewport.js`:
  - Single `attachControlsForSelection()` routing table decides which controls attach based on active prototype and selection type
  - Detaches all controls before attaching the appropriate one
  - Reuses existing pre-drag snapshot + `entityupdate` wiring for undo/redo
  - Street gizmos report drag completion via `commitDrag` event for atomic undo steps

- **UI integration** (`AppMenu.jsx`, `store.js`):
  - New menu item under View with radio-button prototype selection
  - Persisted preference in Zustand store (`gizmoPrototype`, localStorage-backed)
  - PostHog analytics on prototype changes

- **Constants & documentation**:
  - `gizmos/constants.js`: Prototype definitions with IDs, labels, descriptions
  - `docs/gizmo-prototypes.md`: User-facing guide with feature matrix and keyboard hints

## Implementation Details

- All gizmos inherit from `GizmoPointerControls` and implement `getPickers()`, `highlight()`, `startDrag()`, `moveDrag()`, and optional `endDrag()` hooks
- Gizmos are added to `sceneHelpers` and updated with camera changes (perspective/orthographic, zoom)
- Scale mode and legacy behavior fall back to stock `TransformControls`
- Street gizmos throttle layout cascades during drag (100 ms) and flush final values on `endDrag()`
- Ground clamping uses a separate raycaster to find the highest surface under the drag point, excluding the dragged object and hidden nodes
- All numeric values are rounded to 2–3 decimal places to avoid floating-point artifacts

https://claude.ai/code/session_01VLcN1cdaNCbtPonbw7ZCUF