### PR TITLE
Always show Get More Tokens in token hover card

### DIFF
--- a/src/shared/auth/components/TokenDetailsCard.jsx
+++ b/src/shared/auth/components/TokenDetailsCard.jsx
@@ -23,6 +23,16 @@ const TokenDetailsCard = ({
     setIsOpen(!isOpen);
   };
 
+  // Routed by the host app: generator opens UpgradeModal (packs for paid
+  // users via onAlreadyPro), editor routes by token type and plan.
+  const openPurchaseModal = () => {
+    window.dispatchEvent(
+      new CustomEvent('openPurchaseModal', {
+        detail: { tokenType }
+      })
+    );
+  };
+
   // If showDetails is false, just render the children without hover card
   if (!showDetails || !currentUser) {
     return children;
@@ -75,9 +85,10 @@ const TokenDetailsCard = ({
 
             <p className={styles.tokenDescription}>{tokenDescription}</p>
 
-            {/* Actions Section */}
+            {/* Actions Section — the purchase button is always available;
+                only the warning treatment is threshold-gated. */}
             <div className={styles.actionsSection}>
-              {tokenCount < 10 && (
+              {tokenCount < 10 ? (
                 <div
                   className={
                     tokenCount < 1 ? styles.outOfTokens : styles.lowTokenWarning
@@ -90,17 +101,18 @@ const TokenDetailsCard = ({
                   </p>
                   <button
                     className={styles.purchaseButton}
-                    onClick={() => {
-                      window.dispatchEvent(
-                        new CustomEvent('openPurchaseModal', {
-                          detail: { tokenType }
-                        })
-                      );
-                    }}
+                    onClick={openPurchaseModal}
                   >
                     {t('getMoreTokens')}
                   </button>
                 </div>
+              ) : (
+                <button
+                  className={styles.purchaseButtonQuiet}
+                  onClick={openPurchaseModal}
+                >
+                  {t('getMoreTokens')}
+                </button>
               )}
             </div>
 

--- a/src/shared/auth/components/TokenDetailsCard.module.scss
+++ b/src/shared/auth/components/TokenDetailsCard.module.scss
@@ -127,6 +127,25 @@
   }
 }
 
+// Healthy-balance variant: same button, no alarm styling — purchasing is
+// always available, the red/amber treatment is reserved for low balances.
+.purchaseButtonQuiet {
+  width: 100%;
+  padding: 8px 16px;
+  background: transparent;
+  color: #374151;
+  border: 1px solid #d4d4d4;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #f5f5f5;
+  }
+}
+
 .lowTokenWarning {
   padding: 10px;
   background: #fffbeb;
@@ -230,6 +249,15 @@
   .lowTokenWarning {
     background: #2a2515;
     border-color: #713f12;
+  }
+
+  .purchaseButtonQuiet {
+    color: #e5e5e5;
+    border-color: #404040;
+
+    &:hover {
+      background: #262626;
+    }
   }
 
   .optionLabel {


### PR DESCRIPTION
Follow-up to #1905. The token hover card's **Get More Tokens** button only existed inside the low-balance warning (`tokenCount < 10`), so the purchase path disappeared entirely for healthy balances.

Now the button always renders; only the styling is threshold-gated:

- **< 1**: red "out of tokens" box (unchanged)
- **1–9**: amber "low tokens" box (unchanged)
- **≥ 10**: the same button standalone in a quiet outlined style (new `purchaseButtonQuiet`, light + dark mode), no warning box

Routing is unchanged and already handles every plan state: generator → UpgradeModal (→ pack modal for paid users via `onAlreadyPro`), editor listener routes by token type and plan. Only the generator renders this card today.

Test: hover the generator token display with a balance ≥ 10 → quiet Get More Tokens button, no warning; drop below 10/1 for the amber/red states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)