### PR TITLE
Add WebMCP support for in-browser AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ nodes that rewrite position/rotation/length, segment width bars), additive to
 the standard TransformControls gizmo. Code in `src/editor/lib/gizmos/`; doc is
 `docs/street-gizmos.md`.
 
+**AI tool surface (MCP + WebMCP):** one registry (`src/editor/lib/commands/registry.js`) feeds three consumers: the in-editor Gemini chat, the MCP relay (tab = MCP server, external `3dstreet-mcp` npm relay bridges stdio↔localhost WS; design in #1582), and WebMCP (`src/editor/lib/mcp/useWebMCP.js` registers the same tools with `document.modelContext` so a browser-embedded agent — Chrome 149+ origin trial / ChatGPT desktop browser — calls them in-process, no relay). Shared executor `callToolAsMCPContent` in `src/editor/lib/mcp/dispatch.js`; entry point: `docs/webmcp.md`.
+
 **Layer Reordering:** Drag-and-drop reordering of layers within the same parent in the SceneGraph. Uses `EntityReparentCommand` which serializes via `STREET.utils.getElementData()` and recreates via `STREET.utils.createEntityFromObj()` — the same proven save/load code path.
 
 ## Asset System

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -44,10 +44,11 @@ registry.js ─ dispatch.js┤
   browser exposes the API, and shares the **Read-only** toggle between both
   transports.
 
-Registration prefers bulk `provideContext({ tools })` when the browser
-implements it (replacing the whole set is idempotent across re-mounts) and
-falls back to per-tool `registerTool(tool, { signal })` per the current
-explainer. Tool handler failures return
+Registration uses per-tool
+`document.modelContext.registerTool({ name, description, inputSchema, execute })`
+(the current explainer's API, lifetime scoped to an AbortSignal), falling back
+to bulk `provideContext({ tools })` on older builds. Tool handler failures
+return
 `{ content: [{type:'text', text}], isError: true }` rather than throwing, so
 the agent can read the error and self-correct.
 

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -20,7 +20,7 @@ one implementation:
 ```
                          ┌── ws://127.0.0.1:51735 ── 3dstreet-mcp relay ── Claude (stdio MCP)
 registry.js ─ dispatch.js┤
- (17 tools)              └── document.modelContext ── browser-embedded agent (WebMCP)
+ (22 tools)              └── document.modelContext ── browser-embedded agent (WebMCP)
 ```
 
 - `src/editor/lib/commands/registry.js` — single source of truth for tool
@@ -56,17 +56,18 @@ the agent can read the error and self-correct.
 WebMCP is **not in production browsers** — it's a Chrome origin trial
 (Chrome 149–156, ends no later than Nov 16, 2026).
 
-- **`3dstreet.app` (+ subdomains) in stock Chrome 149+:** works with no flag —
-  `index.html` script-injects our
-  [origin-trial token](https://developer.chrome.com/origintrials/#/view_trial/4163014905550602241)
-  (registered third-party + match-subdomains; the token is public by design,
-  and must be injected via script rather than a static meta tag per the
+- **`3dstreet.app` or `dev-3dstreet.web.app` (+ subdomains) in stock Chrome
+  149+:** works with no flag — `index.html` script-injects our
+  [origin-trial tokens](https://developer.chrome.com/origintrials/#/view_trial/4163014905550602241),
+  one per origin (registered third-party + match-subdomains; tokens are public
+  by design, and must be injected via script rather than a static meta tag per
+  the
   [third-party token docs](https://developer.chrome.com/docs/web-platform/third-party-origin-trials)).
-  When the trial expires or the token needs rotating, update the token in
+  When the trial expires or a token needs rotating, update the list in
   `index.html`.
-- **Any other origin (localhost dev, `dev-3dstreet.web.app`) in Chrome 149+:**
-  enable `chrome://flags/#enable-webmcp-testing` and restart — the token only
-  covers `3dstreet.app`. The Console tab's status bar shows **WebMCP active
+- **Any other origin (e.g. localhost dev) in Chrome 149+:** enable
+  `chrome://flags/#enable-webmcp-testing` and restart — the tokens are
+  origin-bound. The Console tab's status bar shows **WebMCP active
   (N tools)**. Use a WebMCP-capable agent or extension (e.g. Chrome's
   WebMCP DevTools tooling) to list and call tools.
 - **ChatGPT desktop browser:** open the editor and ask the agent to, e.g.,

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -54,10 +54,19 @@ the agent can read the error and self-correct.
 ## Trying it
 
 WebMCP is **not in production browsers** — it's a Chrome origin trial
-(Chrome 149–156).
+(Chrome 149–156, ends no later than Nov 16, 2026).
 
-- **Chrome 149+:** enable `chrome://flags/#enable-webmcp-testing`, restart,
-  open the editor. The Console tab's status bar shows **WebMCP active
+- **`3dstreet.app` (+ subdomains) in stock Chrome 149+:** works with no flag —
+  `index.html` script-injects our
+  [origin-trial token](https://developer.chrome.com/origintrials/#/view_trial/4163014905550602241)
+  (registered third-party + match-subdomains; the token is public by design,
+  and must be injected via script rather than a static meta tag per the
+  [third-party token docs](https://developer.chrome.com/docs/web-platform/third-party-origin-trials)).
+  When the trial expires or the token needs rotating, update the token in
+  `index.html`.
+- **Any other origin (localhost dev, `dev-3dstreet.web.app`) in Chrome 149+:**
+  enable `chrome://flags/#enable-webmcp-testing` and restart — the token only
+  covers `3dstreet.app`. The Console tab's status bar shows **WebMCP active
   (N tools)**. Use a WebMCP-capable agent or extension (e.g. Chrome's
   WebMCP DevTools tooling) to list and call tools.
 - **ChatGPT desktop browser:** open the editor and ask the agent to, e.g.,

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -20,7 +20,7 @@ one implementation:
 ```
                          ┌── ws://127.0.0.1:51735 ── 3dstreet-mcp relay ── Claude (stdio MCP)
 registry.js ─ dispatch.js┤
- (22 tools)              └── document.modelContext ── browser-embedded agent (WebMCP)
+ (21 tools)              └── document.modelContext ── browser-embedded agent (WebMCP)
 ```
 
 - `src/editor/lib/commands/registry.js` — single source of truth for tool

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -1,0 +1,79 @@
+# WebMCP integration
+
+3DStreet's editor exposes its AI tool surface over two transports that share
+one implementation:
+
+1. **MCP relay** (existing, [#1582](https://github.com/3DStreet/3dstreet/issues/1582)):
+   the browser tab is the MCP server; the external
+   [`3dstreet-mcp`](https://github.com/3DStreet/3dstreet-mcp) npm relay bridges
+   a stdio MCP client (Claude Desktop / Claude Code) to the tab over
+   `ws://127.0.0.1:51735`.
+2. **WebMCP** (this doc): the page registers the same tools directly with the
+   _browser_ via [`document.modelContext`](https://github.com/webmachinelearning/webmcp),
+   and an agent driving that browser (ChatGPT's desktop browser, Chrome with
+   the WebMCP flag, eventually Gemini in Chrome) calls them in-process. No
+   relay, no pairing, no port — the agent operates the user's own signed-in
+   tab, so there is nothing to install and no server-side rendering.
+
+## How it works
+
+```
+                         ┌── ws://127.0.0.1:51735 ── 3dstreet-mcp relay ── Claude (stdio MCP)
+registry.js ─ dispatch.js┤
+ (17 tools)              └── document.modelContext ── browser-embedded agent (WebMCP)
+```
+
+- `src/editor/lib/commands/registry.js` — single source of truth for tool
+  definitions (`{name, description, inputSchema}`) and execution
+  (`dispatchToolCall` → `INSPECTOR.execute`, so every mutation lands in undo
+  history).
+- `src/editor/lib/mcp/dispatch.js` — `callToolAsMCPContent()` executes one
+  tool and wraps the result as an MCP `content` array (including the
+  `takeSnapshot` image content block). Shared verbatim by both transports,
+  including the read-only gate.
+- `src/editor/lib/mcp/useWebMCP.js` — the WebMCP hook. Feature-detects
+  `document.modelContext` (with the deprecated `navigator.modelContext`
+  alias), registers every tool from `listMCPTools()` (registry commands +
+  MCP read tools), and funnels each `execute()` through
+  `callToolAsMCPContent`. Tool calls append to the same transcript UI the
+  relay uses, so the chat panel shows the agent working
+  (`webmcp · managedStreetCreate`, …).
+- `src/editor/components/scenegraph/AIChatPanel.jsx` — mounts the hook (the
+  panel stays mounted across right-panel tab switches, so registration
+  persists), renders the **WebMCP active (N tools)** status bar whenever the
+  browser exposes the API, and shares the **Read-only** toggle between both
+  transports.
+
+Registration prefers bulk `provideContext({ tools })` when the browser
+implements it (replacing the whole set is idempotent across re-mounts) and
+falls back to per-tool `registerTool(tool, { signal })` per the current
+explainer. Tool handler failures return
+`{ content: [{type:'text', text}], isError: true }` rather than throwing, so
+the agent can read the error and self-correct.
+
+## Trying it
+
+WebMCP is **not in production browsers** — it's a Chrome origin trial
+(Chrome 149–156).
+
+- **Chrome 149+:** enable `chrome://flags/#enable-webmcp-testing`, restart,
+  open the editor. The Console tab's status bar shows **WebMCP active
+  (N tools)**. Use a WebMCP-capable agent or extension (e.g. Chrome's
+  WebMCP DevTools tooling) to list and call tools.
+- **ChatGPT desktop browser:** open the editor and ask the agent to, e.g.,
+  "make a street with two drive lanes, bike lanes and sidewalks, then take a
+  snapshot."
+- Everyone else: no `modelContext` global → the hook is a no-op and no
+  WebMCP UI appears.
+
+`/mcp` in the chat console prints setup help for both transports.
+
+## Notes / future
+
+- The relay remains the path for headless or out-of-browser clients (Claude
+  Desktop/Code); WebMCP covers attended, in-browser agents. Both can be
+  live at once — they don't conflict.
+- The read-only gate currently blocks `takeSnapshot` too (registry tools are
+  all treated as mutating); pre-existing, tracked in `dispatch.js`.
+- Growing the tool surface = adding `static llmTool` to a command class or an
+  entry to `nonCommandTools.js`; both transports pick it up automatically.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,20 @@
 <html>
 
 <head>
+  <!-- WebMCP origin trial (https://developer.chrome.com/origintrials/#/view_trial/4163014905550602241):
+       enables document.modelContext on 3dstreet.app (+subdomains) in stock
+       Chrome 149-156 without the chrome://flags toggle. Third-party tokens
+       must be injected via script, not a static meta tag. Registered as
+       third-party + match-subdomains; expires with the trial (<= Nov 16, 2026).
+       The token is public by design. See docs/webmcp.md. -->
+  <script>
+    (function () {
+      var otMeta = document.createElement('meta');
+      otMeta.httpEquiv = 'origin-trial';
+      otMeta.content = 'A9+JhgceM7462UljgPlsJjVWixgI3q/hSzJ/S6SOjNEcsHJAFKRBEcXucWW5rcl37/8KCwRhByYmmrXrK38KrwkAAABzeyJvcmlnaW4iOiJodHRwczovLzNkc3RyZWV0LmFwcDo0NDMiLCJmZWF0dXJlIjoiV2ViTUNQIiwiZXhwaXJ5IjoxNzk0ODczNjAwLCJpc1N1YmRvbWFpbiI6dHJ1ZSwiaXNUaGlyZFBhcnR5Ijp0cnVlfQ==';
+      document.head.append(otMeta);
+    })();
+  </script>
   <!-- aframe: this release ships super-three 0.184.0. The npm `three` version in
        package.json must match, so upgrade A-Frame and npm `three` together. -->
   <script src="https://aframe.io/releases/1.8.0/aframe.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,25 @@
 
 <head>
   <!-- WebMCP origin trial (https://developer.chrome.com/origintrials/#/view_trial/4163014905550602241):
-       enables document.modelContext on 3dstreet.app (+subdomains) in stock
-       Chrome 149-156 without the chrome://flags toggle. Third-party tokens
-       must be injected via script, not a static meta tag. Registered as
-       third-party + match-subdomains; expires with the trial (<= Nov 16, 2026).
-       The token is public by design. See docs/webmcp.md. -->
+       enables document.modelContext on 3dstreet.app and dev-3dstreet.web.app
+       (+subdomains) in stock Chrome 149-156 without the chrome://flags toggle.
+       Third-party tokens must be injected via script, not a static meta tag.
+       Registered third-party + match-subdomains; tokens are origin-bound (one
+       per origin), public by design, and expire with the trial
+       (<= Nov 16, 2026). See docs/webmcp.md. -->
   <script>
     (function () {
-      var otMeta = document.createElement('meta');
-      otMeta.httpEquiv = 'origin-trial';
-      otMeta.content = 'A9+JhgceM7462UljgPlsJjVWixgI3q/hSzJ/S6SOjNEcsHJAFKRBEcXucWW5rcl37/8KCwRhByYmmrXrK38KrwkAAABzeyJvcmlnaW4iOiJodHRwczovLzNkc3RyZWV0LmFwcDo0NDMiLCJmZWF0dXJlIjoiV2ViTUNQIiwiZXhwaXJ5IjoxNzk0ODczNjAwLCJpc1N1YmRvbWFpbiI6dHJ1ZSwiaXNUaGlyZFBhcnR5Ijp0cnVlfQ==';
-      document.head.append(otMeta);
+      [
+        // https://3dstreet.app
+        'A9+JhgceM7462UljgPlsJjVWixgI3q/hSzJ/S6SOjNEcsHJAFKRBEcXucWW5rcl37/8KCwRhByYmmrXrK38KrwkAAABzeyJvcmlnaW4iOiJodHRwczovLzNkc3RyZWV0LmFwcDo0NDMiLCJmZWF0dXJlIjoiV2ViTUNQIiwiZXhwaXJ5IjoxNzk0ODczNjAwLCJpc1N1YmRvbWFpbiI6dHJ1ZSwiaXNUaGlyZFBhcnR5Ijp0cnVlfQ==',
+        // https://dev-3dstreet.web.app
+        'A7TVEak5256jDv8jC+fCuwH1jhxAZuruXNasmCKFQsBEoGFZ7NPC/ntGN3v+tEy/wJn/MTNWXW2e31SKw2SnaAkAAAB7eyJvcmlnaW4iOiJodHRwczovL2Rldi0zZHN0cmVldC53ZWIuYXBwOjQ0MyIsImZlYXR1cmUiOiJXZWJNQ1AiLCJleHBpcnkiOjE3OTQ4NzM2MDAsImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9'
+      ].forEach(function (token) {
+        var otMeta = document.createElement('meta');
+        otMeta.httpEquiv = 'origin-trial';
+        otMeta.content = token;
+        document.head.append(otMeta);
+      });
     })();
   </script>
   <!-- aframe: this release ships super-three 0.184.0. The npm `three` version in

--- a/public/functions/ai-chat-proxy.js
+++ b/public/functions/ai-chat-proxy.js
@@ -35,9 +35,8 @@ const { GoogleGenAI } = require('@google/genai');
 
 // Locked server-side. The Editor only ever needs text generation; the image
 // model is deliberately unreachable from here.
-// GA model (launched 2026-08-13) — previous `gemini-3-flash-preview` was a
-// preview id that will be retired like the Gemini 2.5 line (issue #1890).
-const MODEL_ID = 'gemini-3.7-flash';
+// GA model (3.8 Flash stable, Sept 2026)
+const MODEL_ID = 'gemini-3.8-flash';
 const LOCATION = 'global';
 
 const MAX_OUTPUT_TOKENS = 4096;

--- a/public/functions/geoid-height.js
+++ b/public/functions/geoid-height.js
@@ -5,6 +5,31 @@ const { Client: GoogleMapsClient } = require('@googlemaps/google-maps-services-j
 const { isUserProInternal } = require('./token-management.js');
 const { assertAppCheck } = require('./app-check.js');
 
+// WebMCP hackathon demo carve-out (PR #1931): anonymous location lookups are
+// allowed within California until the demo window closes, so browser agents
+// (ChatGPT desktop browser, Chrome 149+ origin trial) can demo geospatial
+// without an account — third-party sign-in flows are unreliable inside
+// agent-embedded browsers. Cost exposure stays bounded by the bbox + expiry
+// (+ App Check once enforced). Client-side mirror of these constants (for
+// pre-flight error messages): ANON_GEO_DEMO in
+// src/editor/lib/commands/nonCommandTools.js — keep them in sync.
+// Remove both after the window closes.
+const ANON_GEO_DEMO = {
+  until: Date.parse('2026-10-01T00:00:00Z'),
+  // California bounding box
+  bbox: { latMin: 32.5, latMax: 42.05, lonMin: -124.45, lonMax: -114.13 }
+};
+
+function isAnonGeoDemoAllowed (lat, lon) {
+  const { until, bbox } = ANON_GEO_DEMO;
+  return (
+    Date.now() < until &&
+    Number.isFinite(lat) && Number.isFinite(lon) &&
+    lat >= bbox.latMin && lat <= bbox.latMax &&
+    lon >= bbox.lonMin && lon <= bbox.lonMax
+  );
+}
+
 // Function to get geoid height and location information
 exports.getGeoidHeight = functions
   .runWith({ secrets: ['GOOGLE_MAPS_ELEVATION_API_KEY', 'ALLOWED_PRO_TEAM_DOMAINS'] })
@@ -19,21 +44,29 @@ exports.getGeoidHeight = functions
     // No-op until APP_CHECK_ENFORCE is enabled (see app-check.js).
     assertAppCheck(context);
 
+    const lat = parseFloat(data.lat);
+    const lon = parseFloat(data.lon);
+
+    // Anonymous is allowed for the WebMCP demo carve-out (in-bbox, in-window)
+    // — the server decides from lat/lon alone, no client flag to trust.
+    const anonDemoAllowed = !context.auth && isAnonGeoDemoAllowed(lat, lon);
+
     // Check if user is authenticated (skip for GeoJSON imports during beta)
-    if (!context.auth && !fromGeojsonImport) {
+    if (!context.auth && !fromGeojsonImport && !anonDemoAllowed) {
       throw new functions.https.HttpsError('unauthenticated', 'User must be authenticated');
     }
 
-    const userId = context.auth ? context.auth.uid : 'anonymous-geojson-import';
-    const lat = parseFloat(data.lat);
-    const lon = parseFloat(data.lon);
+    const userId = context.auth
+      ? context.auth.uid
+      : (fromGeojsonImport ? 'anonymous-geojson-import' : 'anonymous-webmcp-demo');
 
     // Check if user is Pro or has tokens
     const db = admin.firestore();
     const isProUser = context.auth ? await isUserProInternal(userId) : false;
 
-    // Skip token checks for GeoJSON imports (free during beta)
-    let canProceed = fromGeojsonImport || isProUser;
+    // Skip token checks for GeoJSON imports (free during beta) and the
+    // anonymous WebMCP demo carve-out
+    let canProceed = fromGeojsonImport || anonDemoAllowed || isProUser;
 
     // If not Pro and not from GeoJSON import, check tokens
     if (!canProceed) {
@@ -169,7 +202,7 @@ exports.getGeoidHeight = functions
     // it to skip anyone who has already tried the feature. Stamped for Pro
     // users too (below), since they skip the decrement.
     let remainingTokens = null;
-    if (!isProUser && !fromGeojsonImport) {
+    if (!isProUser && !fromGeojsonImport && !anonDemoAllowed) {
       const tokenProfileRef = db.collection('tokenProfile').doc(userId);
       const tokenDoc = await tokenProfileRef.get();
 

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -34,7 +34,7 @@ import Events from '../../lib/Events';
 import { useMCPClient } from '../../lib/mcp/useMCPClient.js';
 import { useWebMCP } from '../../lib/mcp/useWebMCP.js';
 
-const AI_MODEL_ID = 'gemini-3.7-flash';
+const AI_MODEL_ID = 'gemini-3.8-flash';
 let AI_CONVERSATION_ID = uuidv4();
 
 // Cap pill list growth so a multi-hour session doesn't accumulate thousands

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -32,6 +32,7 @@ import {
 import { getGroupedMixinOptions } from '../../lib/mixinUtils';
 import Events from '../../lib/Events';
 import { useMCPClient } from '../../lib/mcp/useMCPClient.js';
+import { useWebMCP } from '../../lib/mcp/useWebMCP.js';
 
 const AI_MODEL_ID = 'gemini-3.7-flash';
 let AI_CONVERSATION_ID = uuidv4();
@@ -72,7 +73,7 @@ const HELP_COMMANDS = [
   {
     command: '/mcp',
     description:
-      'Connect Claude Desktop or Claude Code over the MCP relay (alpha)'
+      'Connect an AI agent: Claude via the MCP relay, or WebMCP in agentic browsers (alpha)'
   }
 ];
 
@@ -96,7 +97,9 @@ claude mcp add 3dstreet -- npx -y 3dstreet-mcp
 }
 \`\`\`
 
-Then click **Reconnect** above. Once paired, the relay forwards Claude's tool calls to this tab. Toggle **Read-only** to block scene mutations. Source and docs: [github.com/3DStreet/3dstreet-mcp](https://github.com/3DStreet/3dstreet-mcp).`;
+Then click **Reconnect** above. Once paired, the relay forwards Claude's tool calls to this tab. Toggle **Read-only** to block scene mutations. Source and docs: [github.com/3DStreet/3dstreet-mcp](https://github.com/3DStreet/3dstreet-mcp).
+
+**WebMCP** (no relay needed): in an agentic browser — ChatGPT's desktop browser, or Chrome 149+ with \`chrome://flags/#enable-webmcp-testing\` — this page registers its tools with the browser automatically and the status bar shows **WebMCP active**. Just ask the browser's agent to edit the scene; its tool calls appear in this feed.`;
 
 const MCP_PAIR_SUCCESS_MARKDOWN =
   '**MCP relay paired.** Tool calls from your MCP client are now wired through this tab. Return to **Claude** (or whichever MCP client you launched the relay from) to continue your workflow. Keep this tab open in the background.';
@@ -340,12 +343,13 @@ const SnapshotMessage = ({ snapshot }) => {
 
 // Inline transcript entry for an incoming MCP frame. Mirrors
 // FunctionCallMessage so users can recognize "the LLM is calling a tool"
-// regardless of whether it came from the in-editor Gemini path or from
-// Claude over the MCP relay.
+// regardless of whether it came from the in-editor Gemini path, from
+// Claude over the MCP relay, or from a browser agent via WebMCP.
 const MCPFrameMessage = ({ frame }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { method, name, args, status, result } = frame;
+  const { method, name, args, status, result, channel } = frame;
   const label = name || method;
+  const channelLabel = channel === 'webmcp' ? 'webmcp' : 'mcp';
 
   return (
     <div
@@ -356,7 +360,10 @@ const MCPFrameMessage = ({ frame }) => {
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <span className={`${styles.statusIndicator} ${styles[status]}`}></span>
-        <strong>mcp · {label}</strong>:{' '}
+        <strong>
+          {channelLabel} · {label}
+        </strong>
+        :{' '}
         {status === 'pending'
           ? 'Executing…'
           : status === 'success'
@@ -453,6 +460,60 @@ const MCPStatusBar = ({
             readOnly
               ? 'Read-only mode on: mutating tools rejected'
               : 'Toggle read-only mode (block scene mutations from the MCP)'
+          }
+        >
+          <AwesomeIcon icon={readOnly ? faLock : faLockOpen} />
+          <span>{readOnly ? 'Read-only' : 'Allow edits'}</span>
+        </button>
+      )}
+    </div>
+  );
+};
+
+const WEBMCP_STATUS_LABEL = {
+  registering: 'WebMCP: registering tools…',
+  registered: 'WebMCP active',
+  error: 'WebMCP registration failed'
+};
+
+// Map WebMCP hook statuses onto the existing MCP dot styles so the two
+// bars read as one system: green = an agent can call us right now.
+const WEBMCP_DOT_STYLE = {
+  registering: 'mcpStatus_connecting',
+  registered: 'mcpStatus_connected',
+  error: 'mcpStatus_paired-elsewhere'
+};
+
+// Shown only when the browser exposes `modelContext` (agentic browser or
+// Chrome with the WebMCP flag) — everyone else never sees WebMCP UI.
+const WebMCPStatusBar = ({ status, toolCount, readOnly, onToggleReadOnly }) => {
+  const label =
+    status === 'registered'
+      ? `${WEBMCP_STATUS_LABEL[status]} (${toolCount} tools)`
+      : WEBMCP_STATUS_LABEL[status] || status;
+  const tooltip =
+    status === 'registered'
+      ? 'This browser exposes WebMCP; the scene tools are registered. Ask the browser’s AI agent to edit the scene.'
+      : status === 'error'
+        ? 'The browser exposes WebMCP but tool registration failed — see console.'
+        : 'Registering tools with the browser’s model context…';
+  return (
+    <div className={styles.mcpStatusBar} title={tooltip}>
+      <span
+        className={`${styles.mcpStatusDot} ${styles[WEBMCP_DOT_STYLE[status]] || ''}`}
+      />
+      <span className={styles.mcpStatusLabel}>{label}</span>
+      {status === 'registered' && (
+        <button
+          type="button"
+          className={`${styles.mcpStatusButton} ${
+            readOnly ? styles.mcpReadOnlyOn : ''
+          }`}
+          onClick={onToggleReadOnly}
+          title={
+            readOnly
+              ? 'Read-only mode on: mutating tools rejected'
+              : 'Toggle read-only mode (block scene mutations from agents)'
           }
         >
           <AwesomeIcon icon={readOnly ? faLock : faLockOpen} />
@@ -726,6 +787,15 @@ function AIChatPanel() {
     persistRetries: mcpVisible
   });
 
+  // WebMCP: when the browser itself exposes `modelContext` (agentic
+  // browser, or Chrome with the WebMCP flag), register the same tool
+  // surface directly — no relay, no pairing. Shares the read-only toggle
+  // with the relay path.
+  const webmcp = useWebMCP({
+    currentUser,
+    readOnly: mcpReadOnly
+  });
+
   const postPairSuccess = () => {
     setMessages((prev) => [
       ...prev,
@@ -808,23 +878,24 @@ function AIChatPanel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Interleave Gemini chat messages with incoming MCP frames so a single
-  // chronological feed shows both LLM channels. Both arrays already carry
-  // Date timestamps; sort once per render.
+  // Interleave Gemini chat messages with incoming MCP/WebMCP frames so a
+  // single chronological feed shows every LLM channel. All arrays already
+  // carry Date timestamps; sort once per render.
   const renderedMessages = useMemo(() => {
-    if (mcp.transcript.length === 0) return messages;
-    const mcpEntries = mcp.transcript.map((t) => ({
-      ...t,
-      type: 'mcpFrame'
-    }));
-    const merged = messages.concat(mcpEntries);
+    if (mcp.transcript.length === 0 && webmcp.transcript.length === 0) {
+      return messages;
+    }
+    const frameEntries = mcp.transcript
+      .concat(webmcp.transcript)
+      .map((t) => ({ ...t, type: 'mcpFrame' }));
+    const merged = messages.concat(frameEntries);
     merged.sort((a, b) => {
       const at = a.timestamp ? a.timestamp.getTime() : 0;
       const bt = b.timestamp ? b.timestamp.getTime() : 0;
       return at - bt;
     });
     return merged;
-  }, [messages, mcp.transcript]);
+  }, [messages, mcp.transcript, webmcp.transcript]);
 
   // Focus the textarea when the console tab becomes active so Enter sends the
   // command instead of re-clicking the tab button that was just focused.
@@ -1491,7 +1562,7 @@ function AIChatPanel() {
       chatContainerRef.current.scrollTop =
         chatContainerRef.current.scrollHeight;
     }
-  }, [messages, mcp.transcript]);
+  }, [messages, mcp.transcript, webmcp.transcript]);
 
   const resetConversation = () => {
     // Preserve command history pills — the underlying A-Frame undo stack
@@ -1596,6 +1667,14 @@ function AIChatPanel() {
   return (
     <div className={`${styles.chatContainer} ai-chat-panel-container`}>
       <div className={styles.proFeaturesWrapper}>
+        {webmcp.available && (
+          <WebMCPStatusBar
+            status={webmcp.status}
+            toolCount={webmcp.toolCount}
+            readOnly={mcpReadOnly}
+            onToggleReadOnly={() => setMcpReadOnly((v) => !v)}
+          />
+        )}
         {mcpVisible && (
           <MCPStatusBar
             status={mcp.status}

--- a/src/editor/lib/commands/ComponentAddCommand.js
+++ b/src/editor/lib/commands/ComponentAddCommand.js
@@ -1,7 +1,6 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { createUniqueId } from '../entity.js';
-import { getEditableEntity } from './llmToolGuards.js';
 
 export class ComponentAddCommand extends Command {
   static llmTool = {
@@ -34,8 +33,10 @@ export class ComponentAddCommand extends Command {
   // attribute while the tool still reports "executed" — validate against
   // A-Frame's component registry (base name, so multi-instance suffixes
   // validate against their base component).
-  static transformLLMArgs(args) {
-    const entity = getEditableEntity(args.entityId, { allowRoot: true });
+  // Components may be added to the scene roots themselves (e.g. #environment).
+  static llmAllowRootTarget = true;
+
+  static transformLLMArgs(args, { entity } = {}) {
     const name = args.component;
     if (typeof name !== 'string' || !name) {
       throw new Error("'component' is required and must be a string");

--- a/src/editor/lib/commands/ComponentAddCommand.js
+++ b/src/editor/lib/commands/ComponentAddCommand.js
@@ -1,8 +1,63 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { createUniqueId } from '../entity.js';
+import { getEditableEntity } from './llmToolGuards.js';
 
 export class ComponentAddCommand extends Command {
+  static llmTool = {
+    name: 'componentAdd',
+    description:
+      "Add an A-Frame component to an entity with an optional initial value (e.g. component 'animation__spin', value 'property: rotation; to: 0 360 0; loop: true; dur: 4000'). Use entityUpdate to change a component the entity already has, and managedStreetUpdate for street-segment generated components.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entityId: {
+          type: 'string',
+          description: 'The ID of the entity to add the component to'
+        },
+        component: {
+          type: 'string',
+          description:
+            "The component name, including a multi-instance suffix when several of the same type are wanted (e.g. 'animation__spin')"
+        },
+        value: {
+          type: 'string',
+          description:
+            "Initial component value as an A-Frame attribute string ('prop: v; prop2: v2'); omit for component defaults"
+        }
+      },
+      required: ['entityId', 'component']
+    }
+  };
+
+  // A hallucinated component name would otherwise become an inert HTML
+  // attribute while the tool still reports "executed" — validate against
+  // A-Frame's component registry (base name, so multi-instance suffixes
+  // validate against their base component).
+  static transformLLMArgs(args) {
+    const entity = getEditableEntity(args.entityId, { allowRoot: true });
+    const name = args.component;
+    if (typeof name !== 'string' || !name) {
+      throw new Error("'component' is required and must be a string");
+    }
+    const baseName = name.split('__')[0];
+    if (!AFRAME.components[baseName]) {
+      throw new Error(
+        `Unknown component '${name}' — A-Frame has no such component registered`
+      );
+    }
+    if (entity.components?.[name] || entity.hasAttribute(name)) {
+      throw new Error(
+        `Entity ${args.entityId} already has component '${name}' — use entityUpdate to change it`
+      );
+    }
+    return {
+      entityId: args.entityId,
+      component: name,
+      value: args.value ?? ''
+    };
+  }
+
   constructor(editor, payload) {
     super(editor);
 

--- a/src/editor/lib/commands/ComponentRemoveCommand.js
+++ b/src/editor/lib/commands/ComponentRemoveCommand.js
@@ -1,7 +1,6 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { createUniqueId } from '../entity.js';
-import { getEditableEntity } from './llmToolGuards.js';
 
 export class ComponentRemoveCommand extends Command {
   static llmTool = {
@@ -28,8 +27,9 @@ export class ComponentRemoveCommand extends Command {
   // The constructor snapshots the current value via the component instance,
   // so only a live component can be removed — a plain attribute (data-*,
   // class) would crash it. Validate here so the model gets a clean error.
-  static transformLLMArgs(args) {
-    const entity = getEditableEntity(args.entityId, { allowRoot: true });
+  static llmAllowRootTarget = true;
+
+  static transformLLMArgs(args, { entity } = {}) {
     const name = args.component;
     if (typeof name !== 'string' || !name) {
       throw new Error("'component' is required and must be a string");

--- a/src/editor/lib/commands/ComponentRemoveCommand.js
+++ b/src/editor/lib/commands/ComponentRemoveCommand.js
@@ -1,8 +1,48 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { createUniqueId } from '../entity.js';
+import { getEditableEntity } from './llmToolGuards.js';
 
 export class ComponentRemoveCommand extends Command {
+  static llmTool = {
+    name: 'componentRemove',
+    description:
+      'Remove an A-Frame component from an entity. Undoable — the removed value is restored on undo.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entityId: {
+          type: 'string',
+          description: 'The ID of the entity to remove the component from'
+        },
+        component: {
+          type: 'string',
+          description:
+            "The component name as it appears on the entity (e.g. 'animation__spin')"
+        }
+      },
+      required: ['entityId', 'component']
+    }
+  };
+
+  // The constructor snapshots the current value via the component instance,
+  // so only a live component can be removed — a plain attribute (data-*,
+  // class) would crash it. Validate here so the model gets a clean error.
+  static transformLLMArgs(args) {
+    const entity = getEditableEntity(args.entityId, { allowRoot: true });
+    const name = args.component;
+    if (typeof name !== 'string' || !name) {
+      throw new Error("'component' is required and must be a string");
+    }
+    if (!entity.components?.[name]) {
+      const present = Object.keys(entity.components || {});
+      throw new Error(
+        `Entity ${args.entityId} has no component '${name}'. Components present: ${present.join(', ') || '(none)'}. For plain attributes use entityUpdate with value null.`
+      );
+    }
+    return { entityId: args.entityId, component: name };
+  }
+
   constructor(editor, payload) {
     super(editor);
 

--- a/src/editor/lib/commands/EntityCloneCommand.js
+++ b/src/editor/lib/commands/EntityCloneCommand.js
@@ -1,7 +1,6 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { cloneEntityImpl, createUniqueId, insertAfter } from '../entity.js';
-import { getEditableEntity } from './llmToolGuards.js';
 
 export class EntityCloneCommand extends Command {
   static llmTool = {
@@ -19,11 +18,6 @@ export class EntityCloneCommand extends Command {
       required: ['entityId']
     }
   };
-
-  static transformLLMArgs(args) {
-    getEditableEntity(args.entityId);
-    return args;
-  }
 
   // Editor callers pass the entity directly; the LLM registry passes the
   // `{entity}` payload its id-resolution produces. Accept both.

--- a/src/editor/lib/commands/EntityCloneCommand.js
+++ b/src/editor/lib/commands/EntityCloneCommand.js
@@ -1,14 +1,41 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { cloneEntityImpl, createUniqueId, insertAfter } from '../entity.js';
+import { getEditableEntity } from './llmToolGuards.js';
 
 export class EntityCloneCommand extends Command {
-  constructor(editor, entity) {
+  static llmTool = {
+    name: 'entityClone',
+    description:
+      'Clone an entity (including its children) and insert the copy as its next sibling. Returns with the clone selected; read getSelectedEntity for the new id.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entityId: {
+          type: 'string',
+          description: 'The ID of the entity to clone'
+        }
+      },
+      required: ['entityId']
+    }
+  };
+
+  static transformLLMArgs(args) {
+    getEditableEntity(args.entityId);
+    return args;
+  }
+
+  // Editor callers pass the entity directly; the LLM registry passes the
+  // `{entity}` payload its id-resolution produces. Accept both.
+  constructor(editor, entityOrPayload) {
     super(editor);
 
     this.type = 'entityclone';
     this.name = 'Clone Entity';
     this.updatable = false;
+    const entity = entityOrPayload.isEntity
+      ? entityOrPayload
+      : entityOrPayload.entity;
     if (!entity.id) {
       entity.id = createUniqueId();
     }

--- a/src/editor/lib/commands/EntityRemoveCommand.js
+++ b/src/editor/lib/commands/EntityRemoveCommand.js
@@ -1,7 +1,6 @@
 import Events from '../Events';
 import { Command } from '../command.js';
 import { findClosestEntity, prepareForSerialization } from '../entity.js';
-import { getEditableEntity } from './llmToolGuards.js';
 
 export class EntityRemoveCommand extends Command {
   static llmTool = {
@@ -18,13 +17,6 @@ export class EntityRemoveCommand extends Command {
       required: ['entityId']
     }
   };
-
-  // Validation only — the registry's generic adapter resolves entityId to
-  // the live element afterwards.
-  static transformLLMArgs(args) {
-    getEditableEntity(args.entityId);
-    return args;
-  }
 
   // Editor callers pass the entity directly; the LLM registry passes the
   // `{entity}` payload its id-resolution produces. Accept both.

--- a/src/editor/lib/commands/EntityRemoveCommand.js
+++ b/src/editor/lib/commands/EntityRemoveCommand.js
@@ -1,15 +1,43 @@
 import Events from '../Events';
 import { Command } from '../command.js';
 import { findClosestEntity, prepareForSerialization } from '../entity.js';
+import { getEditableEntity } from './llmToolGuards.js';
 
 export class EntityRemoveCommand extends Command {
-  constructor(editor, entity) {
+  static llmTool = {
+    name: 'entityRemove',
+    description: 'Remove an entity from the scene. Undoable via the undo tool.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entityId: {
+          type: 'string',
+          description: 'The ID of the entity to remove'
+        }
+      },
+      required: ['entityId']
+    }
+  };
+
+  // Validation only — the registry's generic adapter resolves entityId to
+  // the live element afterwards.
+  static transformLLMArgs(args) {
+    getEditableEntity(args.entityId);
+    return args;
+  }
+
+  // Editor callers pass the entity directly; the LLM registry passes the
+  // `{entity}` payload its id-resolution produces. Accept both.
+  constructor(editor, entityOrPayload) {
     super(editor);
 
     this.type = 'entityremove';
     this.name = 'Remove Entity';
     this.updatable = false;
 
+    const entity = entityOrPayload.isEntity
+      ? entityOrPayload
+      : entityOrPayload.entity;
     this.entity = entity;
     // Store the parent element and index for precise reinsertion
     this.parentEl = entity.parentNode;

--- a/src/editor/lib/commands/EntityReparentCommand.js
+++ b/src/editor/lib/commands/EntityReparentCommand.js
@@ -2,58 +2,11 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { createUniqueId } from '../entity.js';
-import { getEditableEntity } from './llmToolGuards.js';
-
 export class EntityReparentCommand extends Command {
-  static llmTool = {
-    name: 'entityReparent',
-    description:
-      'Move an entity under a different parent entity, preserving its world position. Also reorders within the same parent when newParentId is the current parent.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        entityId: {
-          type: 'string',
-          description: 'The ID of the entity to move'
-        },
-        newParentId: {
-          type: 'string',
-          description: 'The ID of the entity to become the new parent'
-        },
-        index: {
-          type: 'number',
-          description:
-            'Child index (0-based) to insert at in the new parent; appends when omitted'
-        }
-      },
-      required: ['entityId', 'newParentId']
-    }
-  };
-
-  // Reshape LLM args into the {entity, parentEl (id string), indexInParent}
-  // payload the constructor expects. parentEl stays an id — the registry's
-  // adapter only resolves `entityId`/`parentId` keys, and both the command
-  // and the transform guard (`data-transform-no-reparent`) want the id.
-  static transformLLMArgs(args) {
-    const entity = getEditableEntity(args.entityId);
-    const parent = getEditableEntity(args.newParentId, {
-      allowRoot: true,
-      role: 'newParent'
-    });
-    if (entity === parent || entity.contains(parent)) {
-      throw new Error(
-        'Cannot reparent an entity into itself or its own descendant'
-      );
-    }
-    const indexInParent =
-      typeof args.index === 'number' ? args.index : parent.children.length;
-    return {
-      entityId: args.entityId,
-      parentEl: args.newParentId,
-      indexInParent
-    };
-  }
-
+  // Deliberately NOT exposed as an LLM tool (no `static llmTool`): arbitrary
+  // reparenting is not an officially supported user-facing feature yet, and
+  // agent-driven reparents can produce unexpected scene structure. Revisit
+  // once grouping ships as a user-facing feature.
   constructor(editor, payload = null) {
     super(editor);
 

--- a/src/editor/lib/commands/EntityReparentCommand.js
+++ b/src/editor/lib/commands/EntityReparentCommand.js
@@ -2,8 +2,58 @@
 import Events from '../Events.js';
 import { Command } from '../command.js';
 import { createUniqueId } from '../entity.js';
+import { getEditableEntity } from './llmToolGuards.js';
 
 export class EntityReparentCommand extends Command {
+  static llmTool = {
+    name: 'entityReparent',
+    description:
+      'Move an entity under a different parent entity, preserving its world position. Also reorders within the same parent when newParentId is the current parent.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entityId: {
+          type: 'string',
+          description: 'The ID of the entity to move'
+        },
+        newParentId: {
+          type: 'string',
+          description: 'The ID of the entity to become the new parent'
+        },
+        index: {
+          type: 'number',
+          description:
+            'Child index (0-based) to insert at in the new parent; appends when omitted'
+        }
+      },
+      required: ['entityId', 'newParentId']
+    }
+  };
+
+  // Reshape LLM args into the {entity, parentEl (id string), indexInParent}
+  // payload the constructor expects. parentEl stays an id — the registry's
+  // adapter only resolves `entityId`/`parentId` keys, and both the command
+  // and the transform guard (`data-transform-no-reparent`) want the id.
+  static transformLLMArgs(args) {
+    const entity = getEditableEntity(args.entityId);
+    const parent = getEditableEntity(args.newParentId, {
+      allowRoot: true,
+      role: 'newParent'
+    });
+    if (entity === parent || entity.contains(parent)) {
+      throw new Error(
+        'Cannot reparent an entity into itself or its own descendant'
+      );
+    }
+    const indexInParent =
+      typeof args.index === 'number' ? args.index : parent.children.length;
+    return {
+      entityId: args.entityId,
+      parentEl: args.newParentId,
+      indexInParent
+    };
+  }
+
   constructor(editor, payload = null) {
     super(editor);
 

--- a/src/editor/lib/commands/EntityUpdateCommand.js
+++ b/src/editor/lib/commands/EntityUpdateCommand.js
@@ -42,9 +42,13 @@ export class EntityUpdateCommand extends Command {
     }
   };
 
+  // Scene roots are legitimate update targets (#environment presets, the
+  // #reference-layers street-geo, #street-container transforms).
+  static llmAllowRootTarget = true;
+
   // Resolve expressionForValue → numeric value before dispatch. The id→DOM
-  // resolution for entityId is handled by the registry's generic adapter.
-  static transformLLMArgs(args) {
+  // resolution (and the editable-subtree guard) is handled by the registry.
+  static transformLLMArgs(args, { entity } = {}) {
     const out = { ...args };
     if (out.expressionForValue) {
       const expr = String(out.expressionForValue).trim();
@@ -57,7 +61,7 @@ export class EntityUpdateCommand extends Command {
     if (out.value === undefined) {
       throw new Error('Either value or expressionForValue must be provided');
     }
-    EntityUpdateCommand.validateLLMTarget(out);
+    EntityUpdateCommand.validateLLMTarget(out, entity);
     return out;
   }
 
@@ -66,13 +70,12 @@ export class EntityUpdateCommand extends Command {
   // still reports "executed" — the model then tells the user it succeeded
   // (and the verification step rubber-stamps it, having no error to see).
   // Editor UI callers construct the command directly and skip this.
-  static validateLLMTarget(args) {
+  static validateLLMTarget(args, entity) {
     const componentName = args.component;
     if (typeof componentName !== 'string' || !componentName) {
       throw new Error("'component' is required and must be a string");
     }
-    const entity = args.entityId && document.getElementById(args.entityId);
-    if (!entity) return; // missing entity throws later in the registry
+    if (!entity) return; // missing entity throws in the registry
 
     if (['position', 'rotation', 'scale'].includes(componentName)) {
       if (args.property && !['x', 'y', 'z'].includes(args.property)) {

--- a/src/editor/lib/commands/llmToolGuards.js
+++ b/src/editor/lib/commands/llmToolGuards.js
@@ -1,0 +1,36 @@
+/**
+ * Shared validation for LLM-facing command args (`static transformLLMArgs`).
+ *
+ * The LLM surfaces (in-editor chat, MCP relay, WebMCP) can name any DOM id;
+ * these guards keep destructive tool calls inside the user-editable scene
+ * subtree — #street-container, the same root getScene serializes and the
+ * Save button writes — so an agent cannot remove or reparent editor chrome,
+ * cameras, or helper entities. Throwing here surfaces a clean tool error
+ * the model can read and correct, instead of a silent no-op (the tool would
+ * still report "executed") or a broken editor.
+ */
+export function getEditableEntity(entityId, options = {}) {
+  const { allowRoot = false, role = 'entity' } = options;
+  if (!entityId) throw new Error(`${role}Id is required`);
+  const el = document.getElementById(entityId);
+  if (!el) throw new Error(`Entity with ID ${entityId} not found`);
+  if (!el.isEntity) {
+    throw new Error(`DOM id ${entityId} is not an A-Frame entity`);
+  }
+  const root = document.getElementById('street-container');
+  if (!root) throw new Error('street-container not found');
+  if (el === root) {
+    if (!allowRoot) {
+      throw new Error(
+        `Entity ${entityId} is the scene root (#street-container) and cannot be the target of this operation`
+      );
+    }
+    return el;
+  }
+  if (!root.contains(el)) {
+    throw new Error(
+      `Entity ${entityId} is outside the editable scene (#street-container) — tools may only modify scene content`
+    );
+  }
+  return el;
+}

--- a/src/editor/lib/commands/llmToolGuards.js
+++ b/src/editor/lib/commands/llmToolGuards.js
@@ -1,35 +1,49 @@
 /**
- * Shared validation for LLM-facing command args (`static transformLLMArgs`).
+ * Shared id → entity resolution for LLM-facing tools.
  *
- * The LLM surfaces (in-editor chat, MCP relay, WebMCP) can name any DOM id;
- * these guards keep destructive tool calls inside the user-editable scene
- * subtree — #street-container, the same root getScene serializes and the
- * Save button writes — so an agent cannot remove or reparent editor chrome,
- * cameras, or helper entities. Throwing here surfaces a clean tool error
- * the model can read and correct, instead of a silent no-op (the tool would
- * still report "executed") or a broken editor.
+ * The LLM surfaces (in-editor chat, MCP relay, WebMCP) can name any DOM id.
+ * `resolveEntityId` is the plain lookup (read tools use it as-is);
+ * `getEditableEntity` additionally keeps the target inside the user-editable
+ * scene — the three roots getScene serializes and the Save button writes
+ * (#street-container, #environment, #reference-layers) — so an agent cannot
+ * mutate editor chrome, cameras, or helper entities. The registry applies
+ * the editable check to every command-backed tool's `entityId` centrally
+ * (`static llmAllowRootTarget = true` opts a command into targeting a root
+ * itself). Throwing here surfaces a clean tool error the model can read and
+ * correct, instead of a silent no-op (the tool would still report
+ * "executed") or a broken editor.
  */
-export function getEditableEntity(entityId, options = {}) {
-  const { allowRoot = false, role = 'entity' } = options;
+export const EDITABLE_ROOT_IDS = [
+  'street-container',
+  'environment',
+  'reference-layers'
+];
+
+export function resolveEntityId(entityId, role = 'entity') {
   if (!entityId) throw new Error(`${role}Id is required`);
   const el = document.getElementById(entityId);
   if (!el) throw new Error(`Entity with ID ${entityId} not found`);
   if (!el.isEntity) {
     throw new Error(`DOM id ${entityId} is not an A-Frame entity`);
   }
-  const root = document.getElementById('street-container');
-  if (!root) throw new Error('street-container not found');
-  if (el === root) {
+  return el;
+}
+
+export function getEditableEntity(entityId, options = {}) {
+  const { allowRoot = false, role = 'entity' } = options;
+  const el = resolveEntityId(entityId, role);
+  const roots = EDITABLE_ROOT_IDS.map((id) => document.getElementById(id));
+  if (roots.includes(el)) {
     if (!allowRoot) {
       throw new Error(
-        `Entity ${entityId} is the scene root (#street-container) and cannot be the target of this operation`
+        `Entity ${entityId} is a scene root (#${el.id}) and cannot be the target of this operation`
       );
     }
     return el;
   }
-  if (!root.contains(el)) {
+  if (!roots.some((root) => root && root.contains(el))) {
     throw new Error(
-      `Entity ${entityId} is outside the editable scene (#street-container) — tools may only modify scene content`
+      `Entity ${entityId} is outside the editable scene (#${EDITABLE_ROOT_IDS.join(', #')}) — tools may only modify scene content`
     );
   }
   return el;

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -339,6 +339,33 @@ async function takeSnapshotHandler(args) {
   });
 }
 
+// WebMCP hackathon demo carve-out (PR #1931): signed-out sessions may set
+// locations within California until the demo window closes — third-party
+// sign-in is unreliable inside agent-embedded browsers, so browser agents
+// get a real geospatial demo without an account. This mirror exists only for
+// a good pre-flight error message; the server (getGeoidHeight in
+// public/functions/geoid-height.js, ANON_GEO_DEMO) enforces the same bbox +
+// expiry from lat/lon alone and trusts no client flag. Keep in sync; remove
+// both after the window closes.
+const ANON_GEO_DEMO = {
+  until: Date.parse('2026-10-01T00:00:00Z'),
+  // California bounding box
+  bbox: { latMin: 32.5, latMax: 42.05, lonMin: -124.45, lonMax: -114.13 }
+};
+
+function isAnonGeoDemoAllowed(lat, lon) {
+  const { until, bbox } = ANON_GEO_DEMO;
+  return (
+    Date.now() < until &&
+    Number.isFinite(lat) &&
+    Number.isFinite(lon) &&
+    lat >= bbox.latMin &&
+    lat <= bbox.latMax &&
+    lon >= bbox.lonMin &&
+    lon <= bbox.lonMax
+  );
+}
+
 // NOT routed through INSPECTOR.execute by design. Wrapping this as a command
 // would require capturing pre/post lat/lon/elevation, and undo would fire two
 // extra elevation HTTP roundtrips per toggle. Leave uninstrumented until we
@@ -346,8 +373,10 @@ async function takeSnapshotHandler(args) {
 async function setLatLonHandler(args, currentUser) {
   const { latitude, longitude } = args;
 
-  if (!currentUser) {
-    throw new Error('You need to sign in to set location');
+  if (!currentUser && !isAnonGeoDemoAllowed(latitude, longitude)) {
+    throw new Error(
+      'Setting this location requires a signed-in 3DStreet account. Without sign-in, only locations within California work (demo period). Either pick California coordinates (e.g. 37.7749, -122.4194 for San Francisco), or ask the user to sign in using the 3DStreet page UI — note that sign-in may not work inside agent-embedded browsers.'
+    );
   }
 
   const { setSceneLocation } = await import('../utils.js');
@@ -613,7 +642,7 @@ export const nonCommandTools = [
   {
     name: 'setLatLon',
     description:
-      'Set the latitude and longitude for the scene, which will trigger elevation calculation',
+      'Set the latitude and longitude for the scene, which triggers elevation lookup and activates the Google 3D Tiles map layer. Signed-in users can set any location; signed-out sessions are limited to locations within California (demo).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/editor/lib/commands/registry.js
+++ b/src/editor/lib/commands/registry.js
@@ -24,6 +24,7 @@
 import { commandsByType } from './index.js';
 import { nonCommandTools } from './nonCommandTools.js';
 import { TRANSFORM_REFUSED } from '../transformGuard.js';
+import { getEditableEntity } from './llmToolGuards.js';
 
 // class → command type string. Built once from commandsByType.
 const commandTypeByClass = new Map();
@@ -44,7 +45,8 @@ for (const CommandClass of commandTypeByClass.keys()) {
     source: 'command',
     definition: llmTool,
     commandType: commandTypeByClass.get(CommandClass),
-    transformLLMArgs: CommandClass.transformLLMArgs
+    transformLLMArgs: CommandClass.transformLLMArgs,
+    allowRootTarget: !!CommandClass.llmAllowRootTarget
   });
 }
 
@@ -77,22 +79,24 @@ export function getToolDefinitions() {
 /**
  * Resolve string ids in LLM args to live DOM elements before handing the
  * payload to a command. Convention: any `entityId` becomes `entity`, any
- * `parentId` becomes `parentEl`. Throws if a referenced id is missing.
+ * `parentId` becomes `parentEl`. Every lookup goes through
+ * `getEditableEntity`, so a command-backed tool can never target editor
+ * chrome regardless of transport; a command opts into targeting a scene root
+ * itself with `static llmAllowRootTarget = true`.
  *
  * Applied centrally so individual commands don't each repeat the lookup.
  */
-function resolveIdRefs(args) {
+function resolveIdRefs(args, { allowRoot = false } = {}) {
   const out = { ...args };
   if ('entityId' in out) {
-    const el = document.getElementById(out.entityId);
-    if (!el) throw new Error(`Entity with ID ${out.entityId} not found`);
-    out.entity = el;
+    out.entity = getEditableEntity(out.entityId, { allowRoot });
     delete out.entityId;
   }
   if ('parentId' in out) {
-    const el = document.getElementById(out.parentId);
-    if (!el) throw new Error(`Parent with ID ${out.parentId} not found`);
-    out.parentEl = el;
+    out.parentEl = getEditableEntity(out.parentId, {
+      allowRoot: true,
+      role: 'parent'
+    });
     delete out.parentId;
   }
   return out;
@@ -111,10 +115,17 @@ export async function dispatchToolCall(toolName, args, currentUser) {
   }
 
   let payload = args || {};
+  const targetOptions = { allowRoot: entry.allowRootTarget };
   if (entry.transformLLMArgs) {
-    payload = entry.transformLLMArgs(payload);
+    // Pre-resolve the target (same guard as resolveIdRefs) so transforms that
+    // inspect the live entity don't repeat the lookup.
+    const entity =
+      'entityId' in payload
+        ? getEditableEntity(payload.entityId, targetOptions)
+        : null;
+    payload = entry.transformLLMArgs(payload, { entity });
   }
-  payload = resolveIdRefs(payload);
+  payload = resolveIdRefs(payload, targetOptions);
   const result = AFRAME.INSPECTOR.execute(entry.commandType, payload);
   if (result === TRANSFORM_REFUSED) {
     // This function reports success unconditionally, so a refusal has to be

--- a/src/editor/lib/mcp/dispatch.js
+++ b/src/editor/lib/mcp/dispatch.js
@@ -95,6 +95,20 @@ function toMCPContent(toolName, value) {
   return [{ type: 'text', text: JSON.stringify(value, null, 2) }];
 }
 
+/**
+ * Execute one tool and wrap its return as an MCP content array. Shared by
+ * the WebSocket relay path (`handleFrame` below) and the in-browser WebMCP
+ * path (`useWebMCP`), so both transports stay behavior-identical —
+ * including the read-only gate. Throws on unknown tool, read-only block,
+ * or handler failure; the caller owns the transport-specific error shape.
+ */
+export async function callToolAsMCPContent(toolName, args, ctx = {}) {
+  const value = await callTool(toolName, args, ctx.currentUser, {
+    readOnly: !!ctx.readOnly
+  });
+  return toMCPContent(toolName, value);
+}
+
 async function callTool(toolName, args, currentUser, options = {}) {
   const entry = ensureIndex().get(toolName);
   if (!entry) {
@@ -164,14 +178,13 @@ export async function handleFrame(frame, ctx = {}) {
         if (!params || typeof params.name !== 'string') {
           return fail(-32602, 'tools/call requires params.name');
         }
-        const value = await callTool(
+        const content = await callToolAsMCPContent(
           params.name,
           params.arguments,
-          ctx.currentUser,
-          { readOnly: !!ctx.readOnly }
+          { currentUser: ctx.currentUser, readOnly: ctx.readOnly }
         );
         if (isNotification) return null;
-        return reply({ content: toMCPContent(params.name, value) });
+        return reply({ content });
       }
       default: {
         if (isNotification) return null;

--- a/src/editor/lib/mcp/readTools.js
+++ b/src/editor/lib/mcp/readTools.js
@@ -15,20 +15,13 @@
 
 import { getGroupedMixinOptions } from '../mixinUtils.js';
 import Events from '../Events.js';
+import { resolveEntityId } from '../commands/llmToolGuards.js';
 import { getUserProfile } from '@shared/utils/username';
 
 // Guard for entity-id args: the relay forwards arbitrary strings from
 // Claude. Resolve to an A-Frame entity or throw a clean error so the
 // JSON-RPC reply carries it back instead of crashing the inspector.
-function resolveEntity(entityId) {
-  if (!entityId) throw new Error('entityId is required');
-  const el = document.getElementById(entityId);
-  if (!el) throw new Error(`Entity with ID ${entityId} not found`);
-  if (!el.isEntity) {
-    throw new Error(`DOM id ${entityId} is not an A-Frame entity`);
-  }
-  return el;
-}
+const resolveEntity = resolveEntityId;
 
 async function getSceneHandler() {
   const root = document.getElementById('street-container');

--- a/src/editor/lib/mcp/useWebMCP.js
+++ b/src/editor/lib/mcp/useWebMCP.js
@@ -16,11 +16,11 @@
  * API status (Chrome origin trial, Chrome 149–156, or
  * chrome://flags/#enable-webmcp-testing): the getter moved from
  * `navigator.modelContext` to `document.modelContext` in Chrome 150 with
- * the old name kept as an alias. Registration surface is `registerTool`
- * per tool (current explainer) with bulk `provideContext({ tools })` as
- * the earlier form; when both exist we prefer `provideContext` because
- * replacing the whole set is idempotent across re-mounts. On browsers
- * without WebMCP the hook is a no-op reporting `available: false`.
+ * the old name kept as an alias. Registration is `registerTool` per tool
+ * (the current explainer's API, lifetime scoped to an AbortSignal), with
+ * bulk `provideContext({ tools })` kept as a fallback for older builds
+ * that predate registerTool. On browsers without WebMCP the hook is a
+ * no-op reporting `available: false`.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -83,6 +83,12 @@ export function useWebMCP({ currentUser, readOnly }) {
     // Every call funnels through the same executor the WS relay uses, and
     // lands in the panel transcript so the user watches the agent work.
     const makeExecute = (toolName) => async (args) => {
+      // Mark this session as actively agent-driven. Mere presence of
+      // `modelContext` doesn't mean an agent is here — the origin trial
+      // gives every stock Chrome 149+ user the API — but a tool call does.
+      // SignInModal reads this to show its agent-browser sign-in caveat
+      // only where it applies.
+      window.__webmcpAgentActive = true;
       const id = `webmcp_${Date.now()}_${Math.random().toString(16).slice(2)}`;
       appendTranscript({
         id,
@@ -121,20 +127,23 @@ export function useWebMCP({ currentUser, readOnly }) {
 
     (async () => {
       try {
-        if (typeof mc.provideContext === 'function') {
-          usedProvideContext = true;
-          await mc.provideContext({ tools });
-        } else if (typeof mc.registerTool === 'function') {
+        if (typeof mc.registerTool === 'function') {
+          // Primary path per the current explainer: one registerTool per
+          // tool, lifetime scoped to the AbortSignal. (Older builds ignore
+          // the options bag; extra args are harmless.)
           for (const tool of tools) {
-            // Older builds ignore the options bag; extra args are harmless.
             await mc.registerTool(
               tool,
               controller ? { signal: controller.signal } : undefined
             );
           }
+        } else if (typeof mc.provideContext === 'function') {
+          // Legacy bulk surface from earlier Chrome builds.
+          usedProvideContext = true;
+          await mc.provideContext({ tools });
         } else {
           throw new Error(
-            'modelContext exposes neither provideContext nor registerTool'
+            'modelContext exposes neither registerTool nor provideContext'
           );
         }
         if (!cancelled) {

--- a/src/editor/lib/mcp/useWebMCP.js
+++ b/src/editor/lib/mcp/useWebMCP.js
@@ -131,7 +131,23 @@ export function useWebMCP({ currentUser, readOnly }) {
           // Primary path per the current explainer: one registerTool per
           // tool, lifetime scoped to the AbortSignal. (Older builds ignore
           // the options bag; extra args are harmless.)
+          //
+          // This effect re-runs whenever the panel remounts (Play/Stop
+          // toggles the inspector). On builds that ignore the abort signal
+          // the previous registrations survive, so a bare registerTool
+          // would throw on the duplicate name and wedge the bar in
+          // 'error' for the session — unregister first, and the stale
+          // execute closure (old hook instance's refs) goes with it.
+          const canUnregister = typeof mc.unregisterTool === 'function';
           for (const tool of tools) {
+            if (cancelled) return;
+            if (canUnregister) {
+              try {
+                mc.unregisterTool(tool.name);
+              } catch (_) {
+                // Not registered — fine.
+              }
+            }
             await mc.registerTool(
               tool,
               controller ? { signal: controller.signal } : undefined
@@ -160,7 +176,11 @@ export function useWebMCP({ currentUser, readOnly }) {
       cancelled = true;
       try {
         if (controller) controller.abort();
-        if (usedProvideContext) mc.provideContext({ tools: [] });
+        if (usedProvideContext) {
+          mc.provideContext({ tools: [] });
+        } else if (typeof mc.unregisterTool === 'function') {
+          for (const tool of tools) mc.unregisterTool(tool.name);
+        }
       } catch (err) {
         console.warn('[webmcp] cleanup failed:', err);
       }

--- a/src/editor/lib/mcp/useWebMCP.js
+++ b/src/editor/lib/mcp/useWebMCP.js
@@ -1,0 +1,167 @@
+/**
+ * WebMCP registration hook (`document.modelContext`).
+ *
+ * The relay path (useMCPClient.js) makes this tab an MCP server for an
+ * external client over a localhost WebSocket. WebMCP inverts the
+ * transport: the page registers its tools directly with the *browser*,
+ * and an agent driving that browser (Gemini in Chrome, ChatGPT's desktop
+ * browser) calls them in-process. No relay, no pairing, no port — the
+ * agent operates the user's own signed-in session, so registration is
+ * automatic whenever the browser exposes the API.
+ *
+ * Registers the exact tool surface the relay serves (registry commands +
+ * MCP read tools) through the shared executor in dispatch.js, so the two
+ * transports stay behavior-identical, including the read-only gate.
+ *
+ * API status (Chrome origin trial, Chrome 149–156, or
+ * chrome://flags/#enable-webmcp-testing): the getter moved from
+ * `navigator.modelContext` to `document.modelContext` in Chrome 150 with
+ * the old name kept as an alias. Registration surface is `registerTool`
+ * per tool (current explainer) with bulk `provideContext({ tools })` as
+ * the earlier form; when both exist we prefer `provideContext` because
+ * replacing the whole set is idempotent across re-mounts. On browsers
+ * without WebMCP the hook is a no-op reporting `available: false`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { callToolAsMCPContent, listMCPTools } from './dispatch.js';
+
+const MAX_TRANSCRIPT = 200;
+
+const getModelContext = () => {
+  if (typeof document !== 'undefined' && document.modelContext) {
+    return document.modelContext;
+  }
+  if (typeof navigator !== 'undefined' && navigator.modelContext) {
+    return navigator.modelContext;
+  }
+  return null;
+};
+
+export function useWebMCP({ currentUser, readOnly }) {
+  const [status, setStatus] = useState(() =>
+    getModelContext() ? 'registering' : 'unavailable'
+  );
+  const [toolCount, setToolCount] = useState(0);
+  const [transcript, setTranscript] = useState([]);
+
+  // Refs so execute closures see live values without re-registering the
+  // tool set on every auth/read-only flip.
+  const userRef = useRef(currentUser);
+  const readOnlyRef = useRef(!!readOnly);
+  useEffect(() => {
+    userRef.current = currentUser;
+  }, [currentUser]);
+  useEffect(() => {
+    readOnlyRef.current = !!readOnly;
+  }, [readOnly]);
+
+  const appendTranscript = useCallback((entry) => {
+    setTranscript((prev) => {
+      const next = prev.concat(entry);
+      if (next.length <= MAX_TRANSCRIPT) return next;
+      return next.slice(next.length - MAX_TRANSCRIPT);
+    });
+  }, []);
+
+  const updateTranscript = useCallback((id, patch) => {
+    setTranscript((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, ...patch } : e))
+    );
+  }, []);
+
+  useEffect(() => {
+    const mc = getModelContext();
+    if (!mc) return;
+
+    let cancelled = false;
+    // Current explainer scopes a registration's lifetime to an AbortSignal.
+    const controller =
+      typeof AbortController !== 'undefined' ? new AbortController() : null;
+    let usedProvideContext = false;
+
+    // Every call funnels through the same executor the WS relay uses, and
+    // lands in the panel transcript so the user watches the agent work.
+    const makeExecute = (toolName) => async (args) => {
+      const id = `webmcp_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+      appendTranscript({
+        id,
+        channel: 'webmcp',
+        method: 'tools/call',
+        name: toolName,
+        args,
+        status: 'pending',
+        result: null,
+        timestamp: new Date()
+      });
+      try {
+        const content = await callToolAsMCPContent(toolName, args || {}, {
+          currentUser: userRef.current,
+          readOnly: readOnlyRef.current
+        });
+        updateTranscript(id, { status: 'success', result: content });
+        return { content };
+      } catch (err) {
+        const message = err?.message || String(err);
+        updateTranscript(id, { status: 'error', result: { message } });
+        // MCP-style tool error: readable by the model, not a protocol fault.
+        return {
+          content: [{ type: 'text', text: `Error: ${message}` }],
+          isError: true
+        };
+      }
+    };
+
+    const tools = listMCPTools().map((def) => ({
+      name: def.name,
+      description: def.description,
+      inputSchema: def.inputSchema,
+      execute: makeExecute(def.name)
+    }));
+
+    (async () => {
+      try {
+        if (typeof mc.provideContext === 'function') {
+          usedProvideContext = true;
+          await mc.provideContext({ tools });
+        } else if (typeof mc.registerTool === 'function') {
+          for (const tool of tools) {
+            // Older builds ignore the options bag; extra args are harmless.
+            await mc.registerTool(
+              tool,
+              controller ? { signal: controller.signal } : undefined
+            );
+          }
+        } else {
+          throw new Error(
+            'modelContext exposes neither provideContext nor registerTool'
+          );
+        }
+        if (!cancelled) {
+          setToolCount(tools.length);
+          setStatus('registered');
+        }
+      } catch (err) {
+        console.warn('[webmcp] tool registration failed:', err);
+        if (!cancelled) setStatus('error');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      try {
+        if (controller) controller.abort();
+        if (usedProvideContext) mc.provideContext({ tools: [] });
+      } catch (err) {
+        console.warn('[webmcp] cleanup failed:', err);
+      }
+    };
+  }, [appendTranscript, updateTranscript]);
+
+  return {
+    available: status !== 'unavailable',
+    status,
+    toolCount,
+    transcript
+  };
+}

--- a/src/shared/auth/components/SignInModal.jsx
+++ b/src/shared/auth/components/SignInModal.jsx
@@ -79,6 +79,17 @@ const SignInModal = ({
           <div className={styles.content}>
             <p className={styles.p1}>{message}</p>
           </div>
+          {typeof window !== 'undefined' && window.__webmcpAgentActive && (
+            <div className={styles.agentBrowserNote}>
+              ⚠️ Sign-in may not work inside AI agent browsers (WebMCP clients),
+              which often block third-party sign-in popups. This is a limitation
+              of the embedded browser that 3DStreet cannot fix — please report
+              it to the browser&apos;s developer. You can keep using 3DStreet
+              without an account; premium features stay locked, and scene
+              locations within California work without sign-in during the WebMCP
+              preview.
+            </div>
+          )}
           <div
             onClick={() => onSignInClick('google')}
             onKeyDown={(e) => e.key === 'Enter' && onSignInClick('google')}

--- a/src/shared/auth/components/SignInModal.module.scss
+++ b/src/shared/auth/components/SignInModal.module.scss
@@ -21,6 +21,17 @@
     font-size: 24px !important;
   }
 
+  .agentBrowserNote {
+    margin: -8px 24px 0;
+    padding: 10px 12px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: #ffcc77;
+    background: rgba(255, 170, 68, 0.12);
+    border: 1px solid rgba(255, 170, 68, 0.35);
+    border-radius: 8px;
+  }
+
   .content {
     display: flex;
     flex-direction: column;

--- a/test/editor/entityUpdateLLMValidation.test.js
+++ b/test/editor/entityUpdateLLMValidation.test.js
@@ -42,25 +42,26 @@ describe('EntityUpdateCommand.transformLLMArgs schema validation', () => {
     ...overrides
   });
 
+  // The registry pre-resolves entityId (through the editable-subtree guard)
+  // and hands the live element to the transform.
+  const transform = (a) =>
+    EntityUpdateCommand.transformLLMArgs(a, { entity: el });
+
   it('rejects a hallucinated property on a known component', () => {
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'managed-street', property: 'curve' })
-      )
+      transform(args({ component: 'managed-street', property: 'curve' }))
     ).toThrow(/no property 'curve'.*length, width, sourceType/);
   });
 
   it('rejects a hallucinated component', () => {
-    expect(() =>
-      EntityUpdateCommand.transformLLMArgs(args({ component: 'curve' }))
-    ).toThrow(/Unknown component 'curve'/);
+    expect(() => transform(args({ component: 'curve' }))).toThrow(
+      /Unknown component 'curve'/
+    );
   });
 
   it('accepts a valid property on a known component', () => {
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'managed-street', property: 'length' })
-      )
+      transform(args({ component: 'managed-street', property: 'length' }))
     ).not.toThrow();
   });
 
@@ -69,43 +70,31 @@ describe('EntityUpdateCommand.transformLLMArgs schema validation', () => {
       'managed-street': { schema: { length: {}, dynamicProp: {} } }
     };
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'managed-street', property: 'dynamicProp' })
-      )
+      transform(args({ component: 'managed-street', property: 'dynamicProp' }))
     ).not.toThrow();
   });
 
   it('allows x/y/z on position and rejects other properties', () => {
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'position', property: 'y' })
-      )
+      transform(args({ component: 'position', property: 'y' }))
     ).not.toThrow();
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'position', property: 'w' })
-      )
+      transform(args({ component: 'position', property: 'w' }))
     ).toThrow(/only has properties x, y, z/);
   });
 
   it('rejects a property arg on a single-property component', () => {
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'visible', property: 'value' })
-      )
+      transform(args({ component: 'visible', property: 'value' }))
     ).toThrow(/single-property/);
   });
 
   it('allows plain attributes and attributes the entity already carries', () => {
     for (const component of ['mixin', 'id', 'class', 'data-some-flag']) {
-      expect(() =>
-        EntityUpdateCommand.transformLLMArgs(args({ component }))
-      ).not.toThrow();
+      expect(() => transform(args({ component }))).not.toThrow();
     }
     el.setAttribute('src', '#old');
-    expect(() =>
-      EntityUpdateCommand.transformLLMArgs(args({ component: 'src' }))
-    ).not.toThrow();
+    expect(() => transform(args({ component: 'src' }))).not.toThrow();
   });
 
   it('allows multi-instance component names via the base definition', () => {
@@ -113,39 +102,30 @@ describe('EntityUpdateCommand.transformLLMArgs schema validation', () => {
       schema: { property: {}, to: {}, loop: {} }
     };
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'animation__spin' })
-      )
+      transform(args({ component: 'animation__spin' }))
     ).not.toThrow();
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'animation__spin', property: 'to' })
-      )
+      transform(args({ component: 'animation__spin', property: 'to' }))
     ).not.toThrow();
     expect(() =>
-      EntityUpdateCommand.transformLLMArgs(
-        args({ component: 'animation__spin', property: 'nope' })
-      )
+      transform(args({ component: 'animation__spin', property: 'nope' }))
     ).toThrow(/no property 'nope'/);
   });
 
   it('allows primitive attribute mappings not yet set on the entity', () => {
     el.mappings = { color: 'material.color' };
-    expect(() =>
-      EntityUpdateCommand.transformLLMArgs(args({ component: 'color' }))
-    ).not.toThrow();
+    expect(() => transform(args({ component: 'color' }))).not.toThrow();
   });
 
   it('rejects a missing component arg with a readable error', () => {
-    expect(() => EntityUpdateCommand.transformLLMArgs(args({}))).toThrow(
-      /'component' is required/
-    );
+    expect(() => transform(args({}))).toThrow(/'component' is required/);
   });
 
-  it('skips validation when the entity does not exist (registry throws later)', () => {
+  it('skips validation when no entity is supplied (registry throws first)', () => {
     expect(() =>
       EntityUpdateCommand.transformLLMArgs(
-        args({ entityId: 'nope', component: 'curve' })
+        args({ entityId: 'nope', component: 'curve' }),
+        { entity: null }
       )
     ).not.toThrow();
   });


### PR DESCRIPTION
## Summary

Adds WebMCP integration to expose the editor's AI tool surface directly to browser-embedded agents (ChatGPT's desktop browser, Chrome 149+ with the WebMCP flag) via `document.modelContext`, complementing the existing MCP relay for Claude Desktop/Code. Both transports share one implementation and tool registry, so behavior stays identical.

## Key Changes

- **New `useWebMCP` hook** (`src/editor/lib/mcp/useWebMCP.js`): Feature-detects `document.modelContext` (with deprecated `navigator.modelContext` fallback), registers all tools from the shared registry, and funnels tool execution through the same `callToolAsMCPContent` dispatcher used by the relay. Tool calls append to the chat panel transcript so users see the agent working.

- **Shared tool execution** (`src/editor/lib/mcp/dispatch.js`): Extracted `callToolAsMCPContent()` as a public export so both WebSocket relay and WebMCP paths execute tools identically, including the read-only gate.

- **LLM tool validation guards** (`src/editor/lib/commands/llmToolGuards.js`): New `getEditableEntity()` helper validates that tool calls target entities within the user-editable scene subtree (`#street-container`), preventing agents from modifying editor chrome or helper entities. Used by `ComponentAddCommand`, `ComponentRemoveCommand`, `EntityRemoveCommand`, and `EntityCloneCommand`.

- **Command LLM metadata** (`ComponentAddCommand.js`, `ComponentRemoveCommand.js`, `EntityRemoveCommand.js`, `EntityCloneCommand.js`): Added `static llmTool` definitions (name, description, inputSchema) and `static transformLLMArgs()` validation to four commands, making them discoverable and callable by both transports.

- **UI integration** (`AIChatPanel.jsx`): 
  - Mounts the WebMCP hook alongside the existing MCP relay
  - Renders a **WebMCP active (N tools)** status bar when the browser exposes the API
  - Shares the **Read-only** toggle between both transports
  - Interleaves WebMCP and relay tool calls in the chat transcript with a `channel` field to distinguish them
  - Updated `/mcp` help text to document both transports

- **Origin trial tokens** (`index.html`): Injected WebMCP origin trial tokens for `3dstreet.app` and `dev-3dstreet.web.app` (Chrome 149–156) so the feature works in stock Chrome without a flag on those origins.

- **Documentation** (`docs/webmcp.md`): Comprehensive guide covering how WebMCP works, the shared dispatch architecture, how to try it (flag, origin trial, ChatGPT desktop), and future notes.

## Implementation Details

- Registration prefers bulk `provideContext({ tools })` (idempotent across re-mounts) and falls back to per-tool `registerTool(tool, { signal })` per the current explainer.
- Tool handler failures return `{ content: [{type:'text', text}], isError: true }` rather than throwing, so agents can read errors and self-correct.
- Refs (`userRef`, `readOnlyRef`) ensure execute closures see live auth/read-only state without re-registering tools on every prop change.
- The hook is a no-op on browsers without `modelContext`, so no WebMCP UI appears for users without the feature.
- Both transports can be live simultaneously — they don't conflict.

https://claude.ai/code/session_01XWdfj3LjFJPEgPaCVHc1eX