### PR TITLE
AI tools: geo context, plan-view snapshot, managed-street validation

### DIFF
--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -79,6 +79,43 @@ WebMCP is **not in production browsers** — it's a Chrome origin trial
 
 `/mcp` in the chat console prints setup help for both transports.
 
+## Geospatial alignment tools
+
+An agent aligning a generated street with the real road under the Google 3D
+Tiles layer needs a machine-readable link between scene units and the map,
+and a camera view it can trust. Three additions cover that (all in the MCP
+read-tool list, so they work under the read-only gate):
+
+- **`getGeoContext`** (`src/editor/lib/geo/geoFrame.js`) — the scene origin's
+  lat/lon, the compass bearing of the scene +X/+Z axes, the camera pose, and
+  optionally one entity converted to lat/lon + heading (managed streets also
+  get both centerline endpoints) and/or a lat/lon converted to a scene world
+  position. Conversions go through the live `google-maps-aerial`
+  `TilesRenderer` (WGS84 `ellipsoid` + `tiles.group.matrixWorld`), the same
+  transform terrain flattening uses, so results match where tiles render.
+  Throws a `GeoFrameError` with a `reason` (`no-location`, `not-google3d`,
+  `not-activated`, `no-tiles`, `tiles-loading`) rather than guessing.
+- **`orientPlanView`** (`src/editor/lib/geo/cameraState.js`) — drives the
+  editor camera to top-down + north-up by calling the exact compass-body
+  action a user clicks (`controls.handleCompassBodyClick`, staged, tweened)
+  and judging "done" with the compass widget's own predicates
+  (`cameraTiltDegrees`, `needleScreenAngle`, shared tolerances). Perspective
+  camera, whole-scene framing; unavailable under `nav=classic` or an
+  orthographic camera.
+- **`takeSnapshot` `type: "plan"`** runs `orientPlanView` first. Every
+  snapshot now also returns `metadata.camera` (tilt, `isTopDown`,
+  `isNorthUp`, `screenUpBearingDeg`, lat/lon) as a text content block so a
+  picture is never the only evidence. `focusCamera`'s description warns that
+  it reframes and is not an orientation reference.
+
+`managedStreetCreate` / `managedStreetUpdate` validate segment `type`,
+`surface`, `direction`, boundary `variant`/`side`, stencil names and clone
+model ids against the live component schemas
+(`src/editor/lib/commands/managedStreetValidation.js`) and throw listing the
+valid values, so "created" means the content can actually render. Create
+also passes boundary `variant`/`side` through (previously dropped) and
+returns `{ entityId, segmentCount, width, warnings? }`.
+
 ## Notes / future
 
 - The relay remains the path for headless or out-of-browser clients (Claude

--- a/src/editor/components/scenegraph/AIChatPanel.jsx
+++ b/src/editor/components/scenegraph/AIChatPanel.jsx
@@ -1237,7 +1237,7 @@ function AIChatPanel() {
               const resultStr =
                 typeof result === 'object'
                   ? call.name === 'takeSnapshot'
-                    ? 'Snapshot taken successfully'
+                    ? `Snapshot taken successfully ${safeStringify(result.metadata || {})}`
                     : safeStringify(result)
                   : String(result ?? '');
 

--- a/src/editor/lib/commands/managedStreetValidation.js
+++ b/src/editor/lib/commands/managedStreetValidation.js
@@ -1,0 +1,115 @@
+/**
+ * Input validation for the managedStreetCreate / managedStreetUpdate tools.
+ *
+ * A-Frame silently ignores unknown enum values and unknown stencil / model
+ * names, so without this the tool reports "created" for content that never
+ * appears (a boundary variant that is dropped, a `bus-only` stencil that does
+ * not exist). Enums are read from the live component schemas so this can't
+ * drift from what actually renders; the pure `validateSegment` takes them as
+ * a parameter so it is unit-testable without A-Frame.
+ */
+
+const BOUNDARY_ONLY = ['variant', 'side'];
+
+function splitNames(value) {
+  if (Array.isArray(value)) return value.map((v) => String(v).trim());
+  return String(value ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function checkEnum(value, allowed, field, index) {
+  if (value === undefined || value === null) return;
+  if (!allowed.includes(value)) {
+    throw new Error(
+      `segments[${index}].${field}: '${value}' is not valid. Valid values: ${allowed.join(', ')}`
+    );
+  }
+}
+
+/**
+ * @param {object} segment  One segment as supplied by the model.
+ * @param {number} index    Position in the segments array (for messages).
+ * @param {object} enums    { types, surfaces, directions, variants, sides,
+ *                            stencils, mixins } — arrays of valid ids.
+ *                            `mixins` may be null to skip clone-model checks.
+ * @returns {string[]} non-fatal warnings (e.g. variant on a non-boundary).
+ */
+export function validateSegment(segment, index, enums) {
+  const warnings = [];
+  if (!segment || typeof segment !== 'object') {
+    throw new Error(`segments[${index}] must be an object`);
+  }
+  checkEnum(segment.type, enums.types, 'type', index);
+  checkEnum(segment.surface, enums.surfaces, 'surface', index);
+  checkEnum(segment.direction, enums.directions, 'direction', index);
+
+  if (segment.type === 'boundary') {
+    if (!segment.side) {
+      throw new Error(
+        `segments[${index}]: type 'boundary' requires side ('left' or 'right')`
+      );
+    }
+    checkEnum(segment.variant, enums.variants, 'variant', index);
+    checkEnum(segment.side, enums.sides, 'side', index);
+  } else {
+    for (const field of BOUNDARY_ONLY) {
+      if (segment[field] !== undefined) {
+        warnings.push(
+          `segments[${index}].${field} is only meaningful for type 'boundary' and was ignored`
+        );
+      }
+    }
+  }
+
+  const generated = segment.generated;
+  if (generated && typeof generated === 'object') {
+    const stencils = Array.isArray(generated.stencil) ? generated.stencil : [];
+    stencils.forEach((entry, i) => {
+      const bad = splitNames(entry?.modelsArray).filter(
+        (name) => !enums.stencils.includes(name)
+      );
+      if (bad.length) {
+        throw new Error(
+          `segments[${index}].generated.stencil[${i}].modelsArray: unknown stencil(s) ${bad.join(', ')}. Valid stencils: ${enums.stencils.join(', ')}`
+        );
+      }
+    });
+    if (enums.mixins) {
+      const clones = Array.isArray(generated.clones) ? generated.clones : [];
+      clones.forEach((entry, i) => {
+        const bad = splitNames(entry?.modelsArray).filter(
+          (name) => !enums.mixins.includes(name)
+        );
+        if (bad.length) {
+          throw new Error(
+            `segments[${index}].generated.clones[${i}].modelsArray: unknown model(s) ${bad.join(', ')}. Use listMixins to find valid model ids.`
+          );
+        }
+      });
+    }
+  }
+  return warnings;
+}
+
+/** Validate every segment; returns the combined warnings. */
+export function validateSegments(segments, enums) {
+  if (!Array.isArray(segments)) return [];
+  return segments.flatMap((segment, i) => validateSegment(segment, i, enums));
+}
+
+/** Read the valid-value lists from the live A-Frame component schemas. */
+export function readSegmentEnums({ mixins = null } = {}) {
+  const seg = AFRAME.components['street-segment']?.schema || {};
+  const stencil = AFRAME.components['street-generated-stencil']?.schema || {};
+  return {
+    types: seg.type?.oneOf || [],
+    surfaces: seg.surface?.oneOf || [],
+    directions: seg.direction?.oneOf || [],
+    variants: seg.variant?.oneOf || [],
+    sides: seg.side?.oneOf || [],
+    stencils: stencil.modelsArray?.oneOf || [],
+    mixins
+  };
+}

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -13,6 +13,11 @@
 
 import * as THREE from 'three';
 import Events from '../Events.js';
+import { describeCamera, orientPlanView } from '../geo/cameraState.js';
+import {
+  readSegmentEnums,
+  validateSegments
+} from './managedStreetValidation.js';
 import { GEO_SOURCES } from '@shared/constants/geoSources.js';
 
 /**
@@ -20,6 +25,7 @@ import { GEO_SOURCES } from '@shared/constants/geoSources.js';
  * via a single entitycreate command.
  */
 async function managedStreetCreateHandler(args) {
+  const warnings = validateSegments(args.segments, readSegmentEnums());
   const streetData = {
     name: args.name || 'New Managed Street',
     length: parseFloat(args.length || '60'),
@@ -35,6 +41,13 @@ async function managedStreetCreateHandler(args) {
       direction: segment.direction || 'none',
       color: segment.color || '#888888',
       surface: segment.surface || 'asphalt',
+      // Boundary land-use presets; parseStreetObject reads both keys.
+      ...(segment.type === 'boundary' && segment.variant
+        ? { variant: segment.variant }
+        : {}),
+      ...(segment.type === 'boundary' && segment.side
+        ? { side: segment.side }
+        : {}),
       ...(segment.generated ? { generated: segment.generated } : {})
     }));
   }
@@ -66,7 +79,13 @@ async function managedStreetCreateHandler(args) {
   };
 
   AFRAME.INSPECTOR.execute('entitycreate', definition);
-  return 'Managed street created successfully';
+  return {
+    message: 'Managed street created successfully',
+    entityId: uniqueId,
+    segmentCount: streetData.segments.length,
+    width: streetData.width,
+    ...(warnings.length ? { warnings } : {})
+  };
 }
 
 /**
@@ -89,6 +108,7 @@ async function managedStreetUpdateHandler(args) {
     if (!segment || !segment.type) {
       throw new Error('Segment must have at least a type property');
     }
+    validateSegments([segment], readSegmentEnums());
     if (
       segmentIndex !== undefined &&
       (segmentIndex < 0 || segmentIndex > segmentEntities.length)
@@ -117,6 +137,7 @@ async function managedStreetUpdateHandler(args) {
     if (segmentIndex < 0 || segmentIndex >= segmentEntities.length) {
       throw new Error(`Invalid segmentIndex: ${segmentIndex}`);
     }
+    validateSegments([segment], readSegmentEnums());
     const segmentEl = segmentEntities[segmentIndex];
     const label =
       segment.name ||
@@ -177,7 +198,10 @@ async function takeSnapshotHandler(args) {
     throw new Error('Camera element not found');
   }
 
-  if (snapshotType !== 'focus') {
+  if (snapshotType === 'plan') {
+    // Deterministic top-down north-up view via the compass action.
+    await orientPlanView();
+  } else if (snapshotType !== 'focus') {
     const streetEntity = document.querySelector('[managed-street]');
     if (!streetEntity) {
       throw new Error('Street entity not found. Cannot position camera.');
@@ -329,7 +353,15 @@ async function takeSnapshotHandler(args) {
           inspector.sceneHelpers.visible = true;
         }
 
-        resolve({ caption, imageData });
+        // Machine-readable pose so the picture is not the only evidence:
+        // tilt, north-up state, screen-up bearing, and lat/lon when geo is on.
+        let metadata;
+        try {
+          metadata = { type: snapshotType, camera: describeCamera() };
+        } catch (e) {
+          metadata = { type: snapshotType, cameraError: e.message };
+        }
+        resolve({ caption, imageData, metadata });
       } catch (error) {
         reject(error);
       }
@@ -631,8 +663,8 @@ export const nonCommandTools = [
         type: {
           type: 'string',
           description:
-            'Optional type of snapshot view: "focus" (default), "birdseye", "straightOn", or "closeup"',
-          enum: ['focus', 'birdseye', 'straightOn', 'closeup']
+            'Optional type of snapshot view: "focus" (default, current view or focusEntityId), "plan" (top-down, north-up, whole scene — the only view suitable for judging orientation/alignment), "birdseye", "straightOn", or "closeup". Every snapshot returns `metadata.camera` (tilt, isTopDown, isNorthUp, screenUpBearingDeg, lat/lon) alongside the image.',
+          enum: ['focus', 'plan', 'birdseye', 'straightOn', 'closeup']
         }
       },
       required: []

--- a/src/editor/lib/geo/cameraState.js
+++ b/src/editor/lib/geo/cameraState.js
@@ -1,0 +1,116 @@
+/**
+ * Camera orientation readout + plan-view action for LLM tools.
+ *
+ * Both use the *same* predicates and action as the on-screen Compass
+ * widget: `cameraTiltDegrees` / `needleScreenAngle` with the shared
+ * tolerance constants decide "top-down" and "north-up", and
+ * `handleCompassBodyClick` is the exact code path a user's click on the
+ * compass body runs (stage 1 tilts to top-down keeping heading, stage 2
+ * yaws to north). The view stays a perspective camera — there is no
+ * orthographic plan view in the UI, and the compass refuses ortho.
+ */
+import * as THREE from 'three';
+import {
+  cameraTiltDegrees,
+  needleScreenAngle,
+  COMPASS_TOPDOWN_TOLERANCE_DEGREES,
+  COMPASS_NORTH_TOLERANCE_DEGREES
+} from '../nav-experimental/index.js';
+import { GeoFrameError, getGeoFrame, worldToLatLon } from './geoFrame.js';
+
+function round(v, places = 2) {
+  const f = 10 ** places;
+  return Math.round(v * f) / f;
+}
+
+function inspectorCamera() {
+  const camera = AFRAME.INSPECTOR?.camera;
+  if (!camera) throw new Error('Editor camera not available');
+  return camera;
+}
+
+/**
+ * Structured camera state. `needleDeg` is the compass needle's screen angle
+ * (0 = north is straight up on screen); `headingDeg` is the compass bearing
+ * the top of the screen points to. Geographic position is included when the
+ * geo layer is live, else `geo: null` with the reason.
+ */
+export function describeCamera(camera = inspectorCamera()) {
+  camera.updateMatrixWorld(true);
+  const tiltDeg = cameraTiltDegrees(camera);
+  const needleDeg = needleScreenAngle(camera);
+  const pos = new THREE.Vector3();
+  camera.getWorldPosition(pos);
+  const state = {
+    projection: camera.type === 'OrthographicCamera' ? 'ortho' : 'perspective',
+    worldPosition: { x: round(pos.x), y: round(pos.y), z: round(pos.z) },
+    tiltDeg: round(tiltDeg),
+    isTopDown: 90 - tiltDeg <= COMPASS_TOPDOWN_TOLERANCE_DEGREES,
+    needleDeg: round(needleDeg),
+    isNorthUp: Math.abs(needleDeg) <= COMPASS_NORTH_TOLERANCE_DEGREES,
+    screenUpBearingDeg: round(((-needleDeg % 360) + 360) % 360),
+    geo: null
+  };
+  try {
+    const frame = getGeoFrame();
+    state.geo = worldToLatLon(pos, frame);
+  } catch (err) {
+    if (!(err instanceof GeoFrameError)) throw err;
+    state.geoUnavailableReason = err.reason;
+  }
+  return state;
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForCompass(controls, timeoutMs) {
+  const t0 = Date.now();
+  while (controls.isCompassAnimating()) {
+    if (Date.now() - t0 > timeoutMs) {
+      throw new Error('Timed out waiting for the camera to finish moving');
+    }
+    await wait(50);
+  }
+  // One extra frame so the camera matrices reflect the tween's final pose.
+  await wait(50);
+}
+
+/**
+ * Drive the camera to a top-down, north-up plan view via the compass body
+ * click, repeating until both predicates hold (at most two stages plus a
+ * safety margin). Resolves with `describeCamera()` of the final pose.
+ */
+export async function orientPlanView({ timeoutMs = 6000 } = {}) {
+  const controls = AFRAME.INSPECTOR?.controls;
+  if (
+    !controls ||
+    typeof controls.handleCompassBodyClick !== 'function' ||
+    typeof controls.isCompassAnimating !== 'function'
+  ) {
+    throw new Error(
+      'Plan view is unavailable: the editor is using the classic navigation scheme (nav=classic) which has no compass.'
+    );
+  }
+  const camera = inspectorCamera();
+  if (camera.type !== 'PerspectiveCamera') {
+    throw new Error(
+      'Plan view is unavailable while the camera is orthographic. Switch to the perspective camera first.'
+    );
+  }
+  await waitForCompass(controls, timeoutMs);
+  for (let stage = 0; stage < 3; stage++) {
+    const state = describeCamera(camera);
+    if (state.isTopDown && state.isNorthUp) return state;
+    controls.handleCompassBodyClick();
+    await waitForCompass(controls, timeoutMs);
+  }
+  const final = describeCamera(camera);
+  if (!(final.isTopDown && final.isNorthUp)) {
+    throw new Error(
+      `Plan view did not settle (tilt ${final.tiltDeg}°, needle ${final.needleDeg}°). The editor controls may be disabled (Play mode?).`
+    );
+  }
+  return final;
+}

--- a/src/editor/lib/geo/geoFrame.js
+++ b/src/editor/lib/geo/geoFrame.js
@@ -1,0 +1,208 @@
+/**
+ * Scene ↔ geographic conversion for LLM tools.
+ *
+ * Authoritative, not approximate: every conversion goes through the live
+ * `google-maps-aerial` TilesRenderer — its WGS84 `ellipsoid` plus the world
+ * matrix of `tiles.group` (which the ReorientationPlugin places from the
+ * scene's lat/lon/height/azimuth). This is the same transform the terrain-
+ * flattening code uses to move shapes into the tileset frame, so what a tool
+ * reports is exactly where the tiles render.
+ *
+ * Everything throws `GeoFrameError` with a distinct `reason` while the
+ * geospatial layer is off or not yet loaded, so an agent gets "call setLatLon"
+ * or "retry shortly" instead of a silent guess.
+ *
+ * Pure math (bearing normalization) is kept in exported helpers for tests.
+ */
+import * as THREE from 'three';
+
+export class GeoFrameError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'GeoFrameError';
+    this.reason = reason;
+  }
+}
+
+const RAD2DEG = 180 / Math.PI;
+const DEG2RAD = Math.PI / 180;
+
+/** Compass bearing (0..360, clockwise from north) of an east/north pair. */
+export function bearingFromEastNorth(east, north) {
+  const deg = Math.atan2(east, north) * RAD2DEG;
+  return ((deg % 360) + 360) % 360;
+}
+
+function round(v, places = 7) {
+  const f = 10 ** places;
+  return Math.round(v * f) / f;
+}
+
+/**
+ * Resolve the live geo frame or throw a GeoFrameError explaining what is
+ * missing. Returns { ellipsoid, groupMatrixWorld, groupMatrixWorldInverse,
+ * origin: { latitude, longitude, ellipsoidalHeight } }.
+ */
+export function getGeoFrame() {
+  const geoEl = document.querySelector('#reference-layers[street-geo]');
+  const geo = geoEl?.getAttribute('street-geo');
+  if (!geo) {
+    throw new GeoFrameError(
+      'no-location',
+      'The scene has no geographic location. Call setLatLon first.'
+    );
+  }
+  if (geo.maps !== 'google3d') {
+    throw new GeoFrameError(
+      'not-google3d',
+      `Geographic conversion needs the Google 3D Tiles layer (street-geo.maps is '${geo.maps}').`
+    );
+  }
+  if (!Number.isFinite(geo.ellipsoidalHeight)) {
+    throw new GeoFrameError(
+      'not-activated',
+      'Geospatial layer is not activated (elevation lookup has not completed). Call setLatLon and retry.'
+    );
+  }
+  const aerialEl = geoEl.querySelector('[google-maps-aerial]');
+  const aerial = aerialEl?.components?.['google-maps-aerial'];
+  const tiles = aerial?.tiles;
+  if (!tiles) {
+    throw new GeoFrameError(
+      'no-tiles',
+      'Google 3D Tiles layer is not mounted yet. Retry shortly.'
+    );
+  }
+  if (!tiles.root) {
+    throw new GeoFrameError(
+      'tiles-loading',
+      'Google 3D Tiles root has not loaded yet, so the tileset is not positioned. Retry shortly.'
+    );
+  }
+  tiles.group.updateMatrixWorld(true);
+  const groupMatrixWorld = tiles.group.matrixWorld.clone();
+  return {
+    ellipsoid: tiles.ellipsoid,
+    groupMatrixWorld,
+    groupMatrixWorldInverse: groupMatrixWorld.clone().invert(),
+    origin: {
+      latitude: geo.latitude,
+      longitude: geo.longitude,
+      ellipsoidalHeight: geo.ellipsoidalHeight
+    }
+  };
+}
+
+/** World-space THREE.Vector3 → { latitude, longitude, height } in degrees/m. */
+export function worldToLatLon(worldPos, frame = getGeoFrame()) {
+  const local = worldPos.clone().applyMatrix4(frame.groupMatrixWorldInverse);
+  const carto = {};
+  frame.ellipsoid.getPositionToCartographic(local, carto);
+  return {
+    latitude: round(carto.lat * RAD2DEG),
+    longitude: round(carto.lon * RAD2DEG),
+    height: round(carto.height, 2)
+  };
+}
+
+/** { latitude, longitude, height? } → world-space THREE.Vector3. */
+export function latLonToWorld(
+  latitude,
+  longitude,
+  height = null,
+  frame = getGeoFrame()
+) {
+  // Default height = the scene ground plane's ellipsoidal height at the origin,
+  // so a returned point sits on y≈0 instead of on the ellipsoid surface.
+  const h = Number.isFinite(height) ? height : frame.origin.ellipsoidalHeight;
+  const local = new THREE.Vector3();
+  frame.ellipsoid.getCartographicToPosition(
+    latitude * DEG2RAD,
+    longitude * DEG2RAD,
+    h,
+    local
+  );
+  return local.applyMatrix4(frame.groupMatrixWorld);
+}
+
+/**
+ * Compass bearing of a world-space direction at a world-space position.
+ * Projects the direction onto the ellipsoid's east/north axes at that point.
+ */
+export function bearingOfWorldDirection(
+  worldPos,
+  worldDir,
+  frame = getGeoFrame()
+) {
+  const local = worldPos.clone().applyMatrix4(frame.groupMatrixWorldInverse);
+  const carto = {};
+  frame.ellipsoid.getPositionToCartographic(local, carto);
+  const east = new THREE.Vector3();
+  const north = new THREE.Vector3();
+  const up = new THREE.Vector3();
+  frame.ellipsoid.getEastNorthUpAxes(carto.lat, carto.lon, east, north, up);
+  const dir = worldDir
+    .clone()
+    .transformDirection(frame.groupMatrixWorldInverse)
+    .normalize();
+  return round(bearingFromEastNorth(dir.dot(east), dir.dot(north)), 2);
+}
+
+/**
+ * Bearing of each scene axis at the origin, so an agent can confirm the
+ * local frame (+X north, +Z east, +Y up by construction) from the data.
+ */
+export function sceneAxisBearings(frame = getGeoFrame()) {
+  const o = new THREE.Vector3(0, 0, 0);
+  return {
+    '+x': bearingOfWorldDirection(o, new THREE.Vector3(1, 0, 0), frame),
+    '+z': bearingOfWorldDirection(o, new THREE.Vector3(0, 0, 1), frame)
+  };
+}
+
+/**
+ * Geographic description of one entity: world position → lat/lon, and the
+ * bearing of its local +Z axis (the axis a managed street runs along). For a
+ * managed street, also both endpoints of its centerline from the same
+ * length-alignment math the component uses (`computeZStart`).
+ */
+export function describeEntityGeo(el, frame = getGeoFrame()) {
+  const obj = el.object3D;
+  obj.updateMatrixWorld(true);
+  const worldPos = new THREE.Vector3();
+  obj.getWorldPosition(worldPos);
+  const forward = new THREE.Vector3(0, 0, 1).transformDirection(
+    obj.matrixWorld
+  );
+  const out = {
+    entityId: el.id,
+    worldPosition: {
+      x: round(worldPos.x, 3),
+      y: round(worldPos.y, 3),
+      z: round(worldPos.z, 3)
+    },
+    ...worldToLatLon(worldPos, frame),
+    headingDeg: bearingOfWorldDirection(worldPos, forward, frame)
+  };
+  const street = el.components?.['managed-street'];
+  if (street) {
+    const length = street.data.length;
+    const zStart = street.computeZStart(length);
+    const toWorld = (z) =>
+      new THREE.Vector3(0, 0, z).applyMatrix4(obj.matrixWorld);
+    const start = toWorld(zStart);
+    const end = toWorld(zStart + length);
+    const axis = new THREE.Vector3().subVectors(end, start).normalize();
+    const bearing = bearingOfWorldDirection(start, axis, frame);
+    out.managedStreet = {
+      length,
+      width: street.data.width,
+      // A road axis is undirected: both bearings describe the same line.
+      centerlineBearingDeg: bearing,
+      reverseBearingDeg: round((bearing + 180) % 360, 2),
+      start: worldToLatLon(start, frame),
+      end: worldToLatLon(end, frame)
+    };
+  }
+  return out;
+}

--- a/src/editor/lib/mcp/dispatch.js
+++ b/src/editor/lib/mcp/dispatch.js
@@ -84,6 +84,12 @@ function toMCPContent(toolName, value) {
     } else {
       content.push({ type: 'text', text: '[snapshot data unavailable]' });
     }
+    if (value.metadata) {
+      content.push({
+        type: 'text',
+        text: JSON.stringify(value.metadata, null, 2)
+      });
+    }
     return content;
   }
   if (value === undefined || value === null) {

--- a/src/editor/lib/mcp/readTools.js
+++ b/src/editor/lib/mcp/readTools.js
@@ -17,6 +17,14 @@ import { getGroupedMixinOptions } from '../mixinUtils.js';
 import Events from '../Events.js';
 import { resolveEntityId } from '../commands/llmToolGuards.js';
 import { getUserProfile } from '@shared/utils/username';
+import {
+  describeEntityGeo,
+  getGeoFrame,
+  latLonToWorld,
+  sceneAxisBearings,
+  worldToLatLon
+} from '../geo/geoFrame.js';
+import { describeCamera, orientPlanView } from '../geo/cameraState.js';
 
 // Guard for entity-id args: the relay forwards arbitrary strings from
 // Claude. Resolve to an A-Frame entity or throw a clean error so the
@@ -133,6 +141,53 @@ async function redoHandler() {
   return { redone: true, command: top.name || top.type || null };
 }
 
+/**
+ * Local ↔ geographic correspondence. Throws a GeoFrameError (with a reason
+ * the agent can act on) while the geo layer is off or still loading.
+ */
+async function getGeoContextHandler(args) {
+  const frame = getGeoFrame();
+  const out = {
+    origin: {
+      ...frame.origin,
+      note: 'Scene world origin (0, 0, 0) sits at this latitude/longitude on the ground plane (y = 0).'
+    },
+    axes: {
+      ...sceneAxisBearings(frame),
+      up: '+y',
+      note: 'Bearings (degrees clockwise from true north) of the scene +X and +Z axes at the origin. A managed street runs along its local +Z; segments are laid out across local X. 1 scene unit = 1 meter.'
+    },
+    camera: describeCamera()
+  };
+  if (args?.entityId) {
+    out.entity = describeEntityGeo(resolveEntity(args.entityId), frame);
+  }
+  if (args?.latitude !== undefined || args?.longitude !== undefined) {
+    const lat = parseFloat(args.latitude);
+    const lon = parseFloat(args.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+      throw new Error('latitude and longitude must both be finite numbers');
+    }
+    const world = latLonToWorld(lat, lon, null, frame);
+    out.point = {
+      latitude: lat,
+      longitude: lon,
+      worldPosition: {
+        x: Math.round(world.x * 1000) / 1000,
+        y: Math.round(world.y * 1000) / 1000,
+        z: Math.round(world.z * 1000) / 1000
+      },
+      // Round-trip so the agent can see the conversion is self-consistent.
+      roundTrip: worldToLatLon(world, frame)
+    };
+  }
+  return out;
+}
+
+async function orientPlanViewHandler() {
+  return orientPlanView();
+}
+
 async function focusCameraHandler(args) {
   const el = resolveEntity(args?.entityId);
   Events.emit('objectfocus', el.object3D);
@@ -238,9 +293,43 @@ export const mcpReadTools = [
     handler: redoHandler
   },
   {
+    name: 'getGeoContext',
+    description:
+      'Return the exact relationship between scene coordinates and geographic coordinates: the lat/lon at the scene origin, the compass bearing of the scene axes, the camera pose (tilt, north-up state, lat/lon), and optionally one entity converted to lat/lon + compass heading (for a managed street: centerline bearing and both endpoint coordinates), and/or a lat/lon converted to a scene world position. Conversions use the live Google 3D Tiles WGS84 frame, so they match where the map renders. Errors with a reason when the geo layer is off or still loading — call setLatLon or retry.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entityId: {
+          type: 'string',
+          description:
+            'Optional entity to describe geographically (position → lat/lon, heading → compass bearing; managed streets also get endpoint coordinates).'
+        },
+        latitude: {
+          type: 'number',
+          description:
+            'Optional latitude to convert to a scene world position (pair with longitude).'
+        },
+        longitude: {
+          type: 'number',
+          description:
+            'Optional longitude to convert to a scene world position (pair with latitude).'
+        }
+      },
+      required: []
+    },
+    handler: getGeoContextHandler
+  },
+  {
+    name: 'orientPlanView',
+    description:
+      'Move the editor camera to a top-down, north-up plan view using the same compass action a user clicks (perspective camera, framing the whole scene). Returns the resulting camera state (tilt, needle angle, isTopDown, isNorthUp, lat/lon). Use before takeSnapshot when judging alignment or orientation; focusCamera reframes around one entity and is NOT a reliable orientation reference.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    handler: orientPlanViewHandler
+  },
+  {
     name: 'focusCamera',
     description:
-      'Frame an entity in the viewport (same effect as double-clicking it in the scene graph).',
+      'Frame an entity in the viewport (same effect as double-clicking it in the scene graph). This reframes and rotates the view around that entity, so the result is NOT a north-up or alignment reference — use orientPlanView + takeSnapshot for that.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/editor/lib/nav-experimental/ExperimentalControls.js
+++ b/src/editor/lib/nav-experimental/ExperimentalControls.js
@@ -1025,6 +1025,12 @@ export class ExperimentalControls extends THREE.EventDispatcher {
     return this._compass.handleCompassRotate(sign);
   }
 
+  // True while a compass-initiated tween (plan view / align north / ±90°)
+  // is in flight. Lets callers (LLM orientPlanView tool) await the pose.
+  isCompassAnimating() {
+    return this._compass.isCompassAnimating();
+  }
+
   // Mouse gesture entry points. These stay named on the orchestrator (the
   // window listeners bind their identity) but are thin routers over the drag
   // controller: the orchestrator owns only the passive-input guard, the

--- a/test/editor/geoFrame.test.js
+++ b/test/editor/geoFrame.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { bearingFromEastNorth } from '../../src/editor/lib/geo/geoFrame.js';
+
+describe('bearingFromEastNorth', () => {
+  it('maps the cardinal directions to compass bearings', () => {
+    expect(bearingFromEastNorth(0, 1)).toBe(0); // north
+    expect(bearingFromEastNorth(1, 0)).toBe(90); // east
+    expect(bearingFromEastNorth(0, -1)).toBe(180); // south
+    expect(bearingFromEastNorth(-1, 0)).toBe(270); // west
+  });
+
+  it('never returns a negative bearing', () => {
+    expect(bearingFromEastNorth(-1, 1)).toBeCloseTo(315);
+  });
+});

--- a/test/editor/managedStreetValidation.test.js
+++ b/test/editor/managedStreetValidation.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  validateSegment,
+  validateSegments
+} from '../../src/editor/lib/commands/managedStreetValidation.js';
+
+// Mirrors the live street-segment / street-generated-stencil schemas.
+const enums = {
+  types: ['drive-lane', 'bike-lane', 'sidewalk', 'bus-lane', 'boundary'],
+  surfaces: ['asphalt', 'concrete', 'grass'],
+  directions: ['none', 'inbound', 'outbound'],
+  variants: ['brownstone', 'suburban', 'custom'],
+  sides: ['left', 'right'],
+  stencils: ['sharrow', 'bike-arrow', 'word-bus', 'word-only'],
+  mixins: ['sedan-rig', 'tree3']
+};
+
+describe('managed street segment validation', () => {
+  it('accepts a plain valid segment', () => {
+    expect(
+      validateSegment({ type: 'drive-lane', surface: 'asphalt' }, 0, enums)
+    ).toEqual([]);
+  });
+
+  it('rejects an unknown segment type listing the valid ones', () => {
+    expect(() => validateSegment({ type: 'brt-lane' }, 1, enums)).toThrow(
+      /segments\[1\]\.type: 'brt-lane' is not valid\. Valid values: drive-lane/
+    );
+  });
+
+  it('rejects unknown stencil names (the bike-symbol / bus-only case)', () => {
+    expect(() =>
+      validateSegment(
+        {
+          type: 'bus-lane',
+          generated: {
+            stencil: [{ modelsArray: 'bus-only, word-bus', spacing: 20 }]
+          }
+        },
+        0,
+        enums
+      )
+    ).toThrow(/unknown stencil\(s\) bus-only\. Valid stencils: sharrow/);
+  });
+
+  it('accepts comma-separated known stencils and array form', () => {
+    expect(
+      validateSegment(
+        {
+          type: 'bike-lane',
+          generated: {
+            stencil: [{ modelsArray: ['bike-arrow', 'sharrow'], spacing: 20 }]
+          }
+        },
+        0,
+        enums
+      )
+    ).toEqual([]);
+  });
+
+  it('rejects unknown clone models when a mixin list is provided', () => {
+    expect(() =>
+      validateSegment(
+        {
+          type: 'drive-lane',
+          generated: {
+            clones: [{ mode: 'random', modelsArray: 'sedan-rig, bus-x' }]
+          }
+        },
+        0,
+        enums
+      )
+    ).toThrow(/unknown model\(s\) bus-x/);
+  });
+
+  it('skips clone-model checks when mixins is null', () => {
+    expect(
+      validateSegment(
+        {
+          type: 'drive-lane',
+          generated: { clones: [{ mode: 'random', modelsArray: 'anything' }] }
+        },
+        0,
+        { ...enums, mixins: null }
+      )
+    ).toEqual([]);
+  });
+
+  it('requires side on a boundary and validates variant', () => {
+    expect(() =>
+      validateSegment({ type: 'boundary', variant: 'brownstone' }, 2, enums)
+    ).toThrow(/requires side/);
+    expect(() =>
+      validateSegment(
+        { type: 'boundary', variant: 'mixed-use', side: 'left' },
+        2,
+        enums
+      )
+    ).toThrow(/variant: 'mixed-use' is not valid/);
+    expect(
+      validateSegment(
+        { type: 'boundary', variant: 'brownstone', side: 'left' },
+        2,
+        enums
+      )
+    ).toEqual([]);
+  });
+
+  it('warns (does not throw) for variant/side on a non-boundary', () => {
+    const warnings = validateSegments(
+      [{ type: 'sidewalk', variant: 'brownstone', side: 'left' }],
+      enums
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toMatch(/only meaningful for type 'boundary'/);
+  });
+
+  it('tolerates a missing segments array', () => {
+    expect(validateSegments(undefined, enums)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

A run-through with an OpenAI WebMCP agent trying to align a generated Geary Blvd street with the Google 3D Tiles road surfaced that the tool surface gives no machine-readable link between scene coordinates and geographic coordinates, no trustworthy north-up camera reference, and reports "created" for content that never renders. This PR addresses the top three findings.

## What

**`getGeoContext` read tool** (`src/editor/lib/geo/geoFrame.js`)
- Scene origin lat/lon, compass bearing of the scene +X / +Z axes, camera pose.
- Optional `entityId`: world position → lat/lon, local +Z heading → compass bearing; managed streets also get centerline bearing and both endpoint coordinates (from the component's own `computeZStart`).
- Optional `latitude`/`longitude`: → scene world position, with a round-trip check.
- Conversions run through the live `google-maps-aerial` `TilesRenderer` (WGS84 `ellipsoid` + `tiles.group.matrixWorld`), the same transform terrain flattening uses. Throws `GeoFrameError` with a `reason` (`no-location`, `not-google3d`, `not-activated`, `no-tiles`, `tiles-loading`) instead of guessing.

**`orientPlanView` read tool + `takeSnapshot` `type: "plan"`** (`src/editor/lib/geo/cameraState.js`)
- Calls the exact compass-body action a user clicks (`controls.handleCompassBodyClick`, staged + tweened, perspective camera) and judges done with the Compass widget's own predicates and tolerances.
- Every snapshot now returns `metadata.camera` (tilt, `isTopDown`, `isNorthUp`, `screenUpBearingDeg`, lat/lon) as a text content block (MCP/WebMCP) and in the Gemini function response.
- `focusCamera` description now warns it reframes and is not an orientation reference.
- Adds an `isCompassAnimating()` delegate on `ExperimentalControls`.

**Managed-street input validation** (`src/editor/lib/commands/managedStreetValidation.js`)
- `managedStreetCreate` / `managedStreetUpdate` validate `type`, `surface`, `direction`, boundary `variant`/`side`, stencil names and clone model ids against the live component schemas and throw listing valid values.
- Create passes boundary `variant`/`side` through (previously dropped, which is why the agent's mixed-use frontage never appeared) and returns `{ entityId, segmentCount, width, warnings? }`.

Docs: new "Geospatial alignment tools" section in `docs/webmcp.md`.

## Verified

Playwright against the dev server (headless Chromium, geo layer mounted directly):
- `getGeoContext` without location → "The scene has no geographic location. Call setLatLon first."
- At 37.7749, -122.4194: origin matches; axes `+x: 0°`, `+z: 90°`; a 100 m straight street reports centerline bearing 90° with endpoints ±0.00057° lon; origin lat/lon → world `0,0,0`; a point 100 m north → world x ≈ 99.7.
- `orientPlanView` → `isTopDown: true, isNorthUp: true, tiltDeg: 90, needleDeg: 0`.
- `takeSnapshot {type:'plan'}` → image + the same metadata.
- `managedStreetCreate` with stencil `bus-only` → throws listing the 25 valid stencils; boundary `{variant:'brownstone', side:'left'}` → retained in the serialized street.

Unit tests: `test/editor/managedStreetValidation.test.js`, `test/editor/geoFrame.test.js`. Full vitest suite green (61 files / 1041 tests).

## Not in this PR

Findings 1 (WebMCP edit opt-in) and 2 (Play-mode tool drop) from the earlier review were discussed and left as-is; road-centerline lookup (Overpass) and group transforms are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)