### PR TITLE
AI tools: segment presets, catalog generator tags, create readback, edge bearings

### DIFF
--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -117,6 +117,22 @@ read-tool list, so they work under the read-only gate):
   picture is never the only evidence. `focusCamera`'s description warns that
   it reframes and is not an orientation reference.
 
+**Segment presets and the catalog.** `managedStreetCreate` /
+`managedStreetUpdate` apply the same `STREET.types` preset the sidebar applies
+when a user picks a segment type (surface, color, elevation, default
+direction, stencils, clones, pedestrians) to every field the model omits
+(`src/editor/lib/commands/segmentPresets.js`), and report `presetsApplied`.
+`listSegmentPresets` shows the table. `listMixins` tags every id with the
+generator that accepts it (`clones` for 3D models, `stencil` for painted
+markings) and appends the stencil ids that are not catalog mixins, and the
+`generated` schema copy says which system is for what — the agent no longer
+guesses `bus` as a stencil. `managedStreetCreate` also waits for the street
+to settle (segments mounted, generated children stable, bounded at ~4 s) and
+returns a `readBack` with per-segment generators and placed-model counts.
+`getGeoContext` reports `crossSection` edge bearings (segments[0] at the
+local -X edge; boundary `side: left` = inbound side, `right` = outbound,
+right-hand-drive convention).
+
 `managedStreetCreate` / `managedStreetUpdate` validate segment `type`,
 `surface`, `direction`, boundary `variant`/`side`, stencil names and clone
 model ids against the live component schemas

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -18,6 +18,60 @@ import {
   readSegmentEnums,
   validateSegments
 } from './managedStreetValidation.js';
+import { applySegmentPreset } from './segmentPresets.js';
+
+/**
+ * Wait for a freshly created managed street to settle — segments mounted
+ * and generated children (clones, stencils) no longer changing — then
+ * report what actually exists, so "created" is backed by evidence. Bounded;
+ * models may still be streaming in after this returns.
+ */
+async function readBackStreet(entityId, expectedSegments, timeoutMs = 4000) {
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const t0 = Date.now();
+  let lastCount = -1;
+  let stableTicks = 0;
+  let el = null;
+  while (Date.now() - t0 < timeoutMs) {
+    el = document.getElementById(entityId);
+    const segments = el
+      ? Array.from(el.children).filter((c) => c.hasAttribute('street-segment'))
+      : [];
+    const descendants = el ? el.querySelectorAll('*').length : 0;
+    if (segments.length >= expectedSegments && descendants === lastCount) {
+      stableTicks++;
+      if (stableTicks >= 3) break;
+    } else {
+      stableTicks = 0;
+    }
+    lastCount = descendants;
+    await sleep(150);
+  }
+  if (!el) return { settled: false, segments: [] };
+  const segments = Array.from(el.children)
+    .filter((c) => c.hasAttribute('street-segment'))
+    .map((segEl, index) => {
+      const data = segEl.getAttribute('street-segment') || {};
+      const generators = Object.keys(segEl.components || {}).filter((n) =>
+        n.startsWith('street-generated-')
+      );
+      return {
+        index,
+        type: data.type,
+        width: data.width,
+        direction: data.direction,
+        generators,
+        placedModels: segEl.querySelectorAll(
+          '[data-layer-name^="Cloned Model"]'
+        ).length
+      };
+    });
+  return {
+    settled: stableTicks >= 3,
+    segmentCount: segments.length,
+    segments
+  };
+}
 import { GEO_SOURCES } from '@shared/constants/geoSources.js';
 
 /**
@@ -31,25 +85,37 @@ async function managedStreetCreateHandler(args) {
     length: parseFloat(args.length || '60'),
     segments: []
   };
+  const presetsApplied = [];
 
   if (args.segments && Array.isArray(args.segments)) {
-    streetData.segments = args.segments.map((segment) => ({
-      name: segment.name || `${segment.type || 'segment'} • default`,
-      type: segment.type || 'drive-lane',
-      width: typeof segment.width === 'number' ? segment.width : 3,
-      elevation: typeof segment.elevation === 'number' ? segment.elevation : 0,
-      direction: segment.direction || 'none',
-      color: segment.color || '#888888',
-      surface: segment.surface || 'asphalt',
-      // Boundary land-use presets; parseStreetObject reads both keys.
-      ...(segment.type === 'boundary' && segment.variant
-        ? { variant: segment.variant }
-        : {}),
-      ...(segment.type === 'boundary' && segment.side
-        ? { side: segment.side }
-        : {}),
-      ...(segment.generated ? { generated: segment.generated } : {})
-    }));
+    streetData.segments = args.segments.map((input, index) => {
+      // Same preset table the sidebar applies when a user picks a type:
+      // omitted surface/color/elevation/direction/generated come from it.
+      const { segment, applied } = applySegmentPreset(
+        { ...input, type: input.type || 'drive-lane' },
+        window.STREET?.types
+      );
+      if (applied.length) presetsApplied.push({ index, fields: applied });
+      return {
+        name: segment.name || `${segment.type} • default`,
+        type: segment.type,
+        width: typeof segment.width === 'number' ? segment.width : 3,
+        elevation:
+          typeof segment.elevation === 'number' ? segment.elevation : 0,
+        direction: segment.direction || 'none',
+        color: segment.color || '#888888',
+        surface: segment.surface || 'asphalt',
+        // Boundary land-use presets; parseStreetObject reads both keys.
+        ...(segment.type === 'boundary' && segment.variant
+          ? { variant: segment.variant }
+          : {}),
+        ...(segment.type === 'boundary' && segment.side
+          ? { side: segment.side }
+          : {}),
+        ...(segment.variants ? { variants: segment.variants } : {}),
+        ...(segment.generated ? { generated: segment.generated } : {})
+      };
+    });
   }
 
   streetData.width = streetData.segments.reduce(
@@ -79,12 +145,16 @@ async function managedStreetCreateHandler(args) {
   };
 
   AFRAME.INSPECTOR.execute('entitycreate', definition);
+  const readBack = await readBackStreet(uniqueId, streetData.segments.length);
   return {
-    message: 'Managed street created successfully',
+    message: readBack.settled
+      ? 'Managed street created and settled'
+      : 'Managed street created; content may still be loading',
     entityId: uniqueId,
-    segmentCount: streetData.segments.length,
     width: streetData.width,
-    ...(warnings.length ? { warnings } : {})
+    ...(presetsApplied.length ? { presetsApplied } : {}),
+    ...(warnings.length ? { warnings } : {}),
+    readBack
   };
 }
 
@@ -115,6 +185,10 @@ async function managedStreetUpdateHandler(args) {
     ) {
       throw new Error(`Invalid segmentIndex: ${segmentIndex}`);
     }
+    const { segment: presetSegment, applied } = applySegmentPreset(
+      segment,
+      window.STREET?.types
+    );
     const label = segment.name || `${segment.type} • default`;
     // segmentadd takes streetId (string), not the resolved element, because
     // its execute() runs on redo too — the parent DOM may have been recreated
@@ -122,10 +196,12 @@ async function managedStreetUpdateHandler(args) {
     // already hold the segment element and don't need that.
     AFRAME.INSPECTOR.execute(
       'segmentadd',
-      { streetId: entityId, segment, segmentIndex },
+      { streetId: entityId, segment: presetSegment, segmentIndex },
       `Add ${label}`
     );
-    return `Added segment: ${label}`;
+    return applied.length
+      ? `Added segment: ${label} (preset supplied ${applied.join(', ')})`
+      : `Added segment: ${label}`;
   }
 
   if (operation === 'update-segment') {
@@ -407,7 +483,7 @@ async function setLatLonHandler(args, currentUser) {
 
   if (!currentUser && !isAnonGeoDemoAllowed(latitude, longitude)) {
     throw new Error(
-      'Setting this location requires a signed-in 3DStreet account. Without sign-in, only locations within California work (demo period). Either pick California coordinates (e.g. 37.7749, -122.4194 for San Francisco), or ask the user to sign in using the 3DStreet page UI — note that sign-in may not work inside agent-embedded browsers.'
+      'Setting this location requires a signed-in 3DStreet account. Without sign-in, only locations within California work (demo period). Either pick California coordinates (e.g. 37.7749, -122.4194 for San Francisco), or ask the user to sign in using the 3DStreet page UI.'
     );
   }
 
@@ -469,12 +545,13 @@ const segmentSchema = {
     side: {
       type: 'string',
       description:
-        'Side of the street the segment sits on. Required for `type: "boundary"` (controls placement outside the travelled way edge and which direction the models face). Valid values: "left", "right".',
+        'Side of the street the segment sits on. Required for `type: "boundary"` (controls placement outside the travelled way edge and which direction the models face). Valid values: "left", "right". Frame of reference is the street\'s own cross-section, not the camera: "left" is the inbound side and "right" the outbound side (right-hand-drive convention; swap for left-hand-drive countries). segments[0] sits at the first edge; getGeoContext reports the compass bearing of each edge.',
       enum: ['left', 'right']
     },
     generated: {
       type: 'object',
-      description: 'Optional generated content',
+      description:
+        'Optional generated content — omit to receive the type preset. Two different systems: `clones` places 3D models (vehicles, cyclists, trees, lamps, furniture — any listMixins id with generator "clones"); `stencil` paints flat road markings (arrows, sharrows, words like BUS ONLY — only ids with generator "stencil"). Never put a vehicle in `stencil` or a marking in `clones`.',
       properties: {
         clones: {
           type: 'array',
@@ -488,7 +565,8 @@ const segmentSchema = {
               },
               modelsArray: {
                 type: 'string',
-                description: 'Comma-separated list of model names'
+                description:
+                  'Comma-separated 3D model ids from listMixins (generator "clones"), e.g. "sedan-rig, box-truck-rig" or "bus". Unknown ids are rejected.'
               },
               spacing: {
                 type: 'number',
@@ -516,7 +594,8 @@ const segmentSchema = {
             properties: {
               modelsArray: {
                 type: 'string',
-                description: 'Stencil model names'
+                description:
+                  'Comma-separated painted-marking ids (generator "stencil"), e.g. "bike-arrow", "sharrow", "word-bus, word-only". Unknown ids are rejected — use listMixins.'
               },
               spacing: {
                 type: 'number',
@@ -586,7 +665,7 @@ export const nonCommandTools = [
   {
     name: 'managedStreetCreate',
     description:
-      'Create a new managed street with specified segments and properties',
+      "Create a new managed street from a cross-section (array of segments, listed from one edge to the other). For each segment, omit surface/color/elevation/direction/generated to receive the type's preset — the same content a user gets by picking that type in the sidebar (e.g. bike-lane → green asphalt, bike-arrow stencils, cyclists; bus-lane → BUS ONLY stencil, buses; sidewalk → pedestrians). Call listSegmentPresets to see them. Only supply `generated` to override a preset. Returns entityId, width, presetsApplied, warnings and a readBack of what actually mounted.",
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/editor/lib/commands/nonCommandTools.js
+++ b/src/editor/lib/commands/nonCommandTools.js
@@ -19,6 +19,8 @@ import {
   validateSegments
 } from './managedStreetValidation.js';
 import { applySegmentPreset } from './segmentPresets.js';
+import { GEO_SOURCES } from '@shared/constants/geoSources.js';
+import { TRANSFORM_REFUSED } from '../transformGuard.js';
 
 /**
  * Wait for a freshly created managed street to settle — segments mounted
@@ -47,7 +49,7 @@ async function readBackStreet(entityId, expectedSegments, timeoutMs = 4000) {
     lastCount = descendants;
     await sleep(150);
   }
-  if (!el) return { settled: false, segments: [] };
+  if (!el) return { settled: false, segmentCount: 0, segments: [] };
   const segments = Array.from(el.children)
     .filter((c) => c.hasAttribute('street-segment'))
     .map((segEl, index) => {
@@ -72,7 +74,6 @@ async function readBackStreet(entityId, expectedSegments, timeoutMs = 4000) {
     segments
   };
 }
-import { GEO_SOURCES } from '@shared/constants/geoSources.js';
 
 /**
  * Compose a managed-street entity from a flat segments array and create it
@@ -144,7 +145,13 @@ async function managedStreetCreateHandler(args) {
     }
   };
 
-  AFRAME.INSPECTOR.execute('entitycreate', definition);
+  const created = AFRAME.INSPECTOR.execute('entitycreate', definition);
+  if (created === TRANSFORM_REFUSED) {
+    throw new Error('entitycreate refused: the target does not permit it');
+  }
+  if (!document.getElementById(uniqueId)) {
+    throw new Error('Managed street entity was not created');
+  }
   const readBack = await readBackStreet(uniqueId, streetData.segments.length);
   return {
     message: readBack.settled

--- a/src/editor/lib/commands/segmentPresets.js
+++ b/src/editor/lib/commands/segmentPresets.js
@@ -1,0 +1,70 @@
+/**
+ * Segment type presets for the LLM tools.
+ *
+ * `STREET.types` (TYPES in street-segment.js) is what the editor applies
+ * when a user picks a segment type in the sidebar: surface, color,
+ * elevation, default direction, and the generated content (stencils,
+ * vehicles, pedestrians…). The tools apply the same table for every field
+ * the model leaves out, so an agent's bike lane gets bike arrows and
+ * cyclists exactly like a human's — no special powers, no bare grey slabs.
+ *
+ * Pure so it can be unit-tested without A-Frame; callers pass `STREET.types`.
+ */
+
+const PRESET_SCALARS = ['color', 'surface', 'elevation', 'direction'];
+
+/**
+ * @returns {{ segment: object, applied: string[] }} a new segment with
+ *   preset values filled in for omitted fields, and which fields came from
+ *   the preset.
+ */
+export function applySegmentPreset(segment, types) {
+  const out = { ...segment };
+  const preset = types?.[segment?.type];
+  const applied = [];
+  if (!preset) return { segment: out, applied };
+  for (const key of PRESET_SCALARS) {
+    if (out[key] === undefined && preset[key] !== undefined) {
+      out[key] = preset[key];
+      applied.push(key);
+    }
+  }
+  if (out.generated === undefined && preset.generated) {
+    out.generated = JSON.parse(JSON.stringify(preset.generated));
+    applied.push('generated');
+  }
+  // Boundary presets carry per-variant model overrides that the segment
+  // component reads off the same object it generates from.
+  if (out.variants === undefined && preset.variants) {
+    out.variants = preset.variants;
+  }
+  return { segment: out, applied };
+}
+
+/** Compact, model-facing summary of every preset (for listSegmentPresets). */
+export function summarizePresets(types) {
+  return Object.entries(types || {}).map(([type, preset]) => {
+    const generated = {};
+    for (const [kind, entries] of Object.entries(preset.generated || {})) {
+      generated[kind] = (entries || []).map((e) =>
+        e.modelsArray !== undefined
+          ? e.modelsArray
+          : e.density !== undefined
+            ? `density: ${e.density}`
+            : e.striping !== undefined
+              ? e.striping
+              : JSON.stringify(e)
+      );
+    }
+    const out = {
+      type,
+      surface: preset.surface,
+      color: preset.color,
+      elevation: preset.elevation ?? 0,
+      direction: preset.direction,
+      generated
+    };
+    if (preset.variants) out.variants = Object.keys(preset.variants);
+    return out;
+  });
+}

--- a/src/editor/lib/commands/segmentPresets.js
+++ b/src/editor/lib/commands/segmentPresets.js
@@ -34,9 +34,11 @@ export function applySegmentPreset(segment, types) {
     applied.push('generated');
   }
   // Boundary presets carry per-variant model overrides that the segment
-  // component reads off the same object it generates from.
+  // component reads off the same object it generates from. Deep-cloned so a
+  // downstream mutation can't leak back into STREET.types.
   if (out.variants === undefined && preset.variants) {
-    out.variants = preset.variants;
+    out.variants = JSON.parse(JSON.stringify(preset.variants));
+    applied.push('variants');
   }
   return { segment: out, applied };
 }

--- a/src/editor/lib/geo/geoFrame.js
+++ b/src/editor/lib/geo/geoFrame.js
@@ -194,7 +194,21 @@ export function describeEntityGeo(el, frame = getGeoFrame()) {
     const end = toWorld(zStart + length);
     const axis = new THREE.Vector3().subVectors(end, start).normalize();
     const bearing = bearingOfWorldDirection(start, axis, frame);
+    // Cross-section frame: street-align lays segments[0] at the local -X
+    // edge and the last segment at +X. Report both edge bearings so
+    // "left"/"right"/"north side" questions have a numeric answer.
+    const toEdge = (sign) =>
+      bearingOfWorldDirection(
+        worldPos,
+        new THREE.Vector3(sign, 0, 0).transformDirection(obj.matrixWorld),
+        frame
+      );
     out.managedStreet = {
+      crossSection: {
+        firstSegmentEdgeBearingDeg: toEdge(-1),
+        lastSegmentEdgeBearingDeg: toEdge(1),
+        note: 'segments[0] lies toward firstSegmentEdgeBearingDeg from the centerline; the last segment toward lastSegmentEdgeBearingDeg.'
+      },
       length,
       width: street.data.width,
       // A road axis is undirected: both bearings describe the same line.

--- a/src/editor/lib/mcp/readTools.js
+++ b/src/editor/lib/mcp/readTools.js
@@ -79,6 +79,13 @@ async function listMixinsHandler(args) {
     AFRAME.components['street-generated-stencil']?.schema?.modelsArray?.oneOf ||
       []
   );
+  if (stencilIds.size === 0) {
+    // Every id would be tagged 'clones' — the silent misclassification the
+    // tag exists to prevent. Loud, so a registration-order regression shows.
+    console.warn(
+      '[mcp] street-generated-stencil schema unavailable; generator tags may be wrong'
+    );
+  }
   const groups = getGroupedMixinOptions(true).map((g) => ({
     category: g.label,
     mixins: g.options.map((o) => ({

--- a/src/editor/lib/mcp/readTools.js
+++ b/src/editor/lib/mcp/readTools.js
@@ -25,6 +25,7 @@ import {
   worldToLatLon
 } from '../geo/geoFrame.js';
 import { describeCamera, orientPlanView } from '../geo/cameraState.js';
+import { summarizePresets } from '../commands/segmentPresets.js';
 
 // Guard for entity-id args: the relay forwards arbitrary strings from
 // Claude. Resolve to an A-Frame entity or throw a clean error so the
@@ -74,18 +75,38 @@ async function selectEntityHandler(args) {
 }
 
 async function listMixinsHandler(args) {
-  const groups = getGroupedMixinOptions(true);
-  const requested = args?.category;
-  const filtered = requested
-    ? groups.filter((g) => g.label === requested)
-    : groups;
-  return filtered.map((g) => ({
+  const stencilIds = new Set(
+    AFRAME.components['street-generated-stencil']?.schema?.modelsArray?.oneOf ||
+      []
+  );
+  const groups = getGroupedMixinOptions(true).map((g) => ({
     category: g.label,
     mixins: g.options.map((o) => ({
       id: o.value,
-      label: o.label
+      label: o.label,
+      // Which managed-street generator accepts this id: 3D models go in
+      // `generated.clones`, flat painted markings in `generated.stencil`.
+      generator: stencilIds.has(o.value) ? 'stencil' : 'clones'
     }))
   }));
+  const seen = new Set(groups.flatMap((g) => g.mixins.map((m) => m.id)));
+  const missingStencils = [...stencilIds].filter((id) => !seen.has(id));
+  if (missingStencils.length) {
+    groups.push({
+      category: 'Road markings (stencils)',
+      mixins: missingStencils.map((id) => ({
+        id,
+        label: id,
+        generator: 'stencil'
+      }))
+    });
+  }
+  const requested = args?.category;
+  return requested ? groups.filter((g) => g.category === requested) : groups;
+}
+
+async function listSegmentPresetsHandler() {
+  return summarizePresets(window.STREET?.types);
 }
 
 async function getSessionInfoHandler(args, currentUser) {
@@ -256,6 +277,13 @@ export const mcpReadTools = [
       required: []
     },
     handler: listMixinsHandler
+  },
+  {
+    name: 'listSegmentPresets',
+    description:
+      'List the per-type segment presets (surface, color, elevation, default direction, and the generated stencils/clones/pedestrians) that managedStreetCreate and managedStreetUpdate apply when a segment omits those fields — identical to picking the type in the editor sidebar. Read this before composing a cross-section so you only override what you need.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    handler: listSegmentPresetsHandler
   },
   {
     name: 'getSessionInfo',

--- a/src/editor/lib/mcp/useWebMCP.js
+++ b/src/editor/lib/mcp/useWebMCP.js
@@ -83,12 +83,6 @@ export function useWebMCP({ currentUser, readOnly }) {
     // Every call funnels through the same executor the WS relay uses, and
     // lands in the panel transcript so the user watches the agent work.
     const makeExecute = (toolName) => async (args) => {
-      // Mark this session as actively agent-driven. Mere presence of
-      // `modelContext` doesn't mean an agent is here — the origin trial
-      // gives every stock Chrome 149+ user the API — but a tool call does.
-      // SignInModal reads this to show its agent-browser sign-in caveat
-      // only where it applies.
-      window.__webmcpAgentActive = true;
       const id = `webmcp_${Date.now()}_${Math.random().toString(16).slice(2)}`;
       appendTranscript({
         id,

--- a/src/shared/auth/components/SignInModal.jsx
+++ b/src/shared/auth/components/SignInModal.jsx
@@ -79,17 +79,6 @@ const SignInModal = ({
           <div className={styles.content}>
             <p className={styles.p1}>{message}</p>
           </div>
-          {typeof window !== 'undefined' && window.__webmcpAgentActive && (
-            <div className={styles.agentBrowserNote}>
-              ⚠️ Sign-in may not work inside AI agent browsers (WebMCP clients),
-              which often block third-party sign-in popups. This is a limitation
-              of the embedded browser that 3DStreet cannot fix — please report
-              it to the browser&apos;s developer. You can keep using 3DStreet
-              without an account; premium features stay locked, and scene
-              locations within California work without sign-in during the WebMCP
-              preview.
-            </div>
-          )}
           <div
             onClick={() => onSignInClick('google')}
             onKeyDown={(e) => e.key === 'Enter' && onSignInClick('google')}

--- a/src/shared/auth/components/SignInModal.module.scss
+++ b/src/shared/auth/components/SignInModal.module.scss
@@ -21,17 +21,6 @@
     font-size: 24px !important;
   }
 
-  .agentBrowserNote {
-    margin: -8px 24px 0;
-    padding: 10px 12px;
-    font-size: 12px;
-    line-height: 1.5;
-    color: #ffcc77;
-    background: rgba(255, 170, 68, 0.12);
-    border: 1px solid rgba(255, 170, 68, 0.35);
-    border-radius: 8px;
-  }
-
   .content {
     display: flex;
     flex-direction: column;

--- a/test/editor/segmentPresets.test.js
+++ b/test/editor/segmentPresets.test.js
@@ -65,7 +65,8 @@ describe('applySegmentPreset', () => {
       { type: 'boundary', variant: 'brownstone', side: 'left' },
       types
     );
-    expect(segment.variants).toBe(types.boundary.variants);
+    expect(segment.variants).toEqual(types.boundary.variants);
+    expect(segment.variants).not.toBe(types.boundary.variants);
     expect(segment.variant).toBe('brownstone');
   });
 

--- a/test/editor/segmentPresets.test.js
+++ b/test/editor/segmentPresets.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applySegmentPreset,
+  summarizePresets
+} from '../../src/editor/lib/commands/segmentPresets.js';
+
+const types = {
+  'bike-lane': {
+    type: 'bike-lane',
+    color: '#00ff00',
+    surface: 'asphalt',
+    elevation: 0,
+    generated: {
+      stencil: [{ modelsArray: 'bike-arrow', spacing: 20 }],
+      clones: [{ mode: 'random', modelsArray: 'cyclist1, cyclist2', count: 4 }]
+    }
+  },
+  sidewalk: {
+    type: 'sidewalk',
+    surface: 'sidewalk',
+    color: '#ffffff',
+    elevation: 0.15,
+    direction: 'none',
+    generated: { pedestrians: [{ density: 'normal' }] }
+  },
+  boundary: {
+    type: 'boundary',
+    surface: 'none',
+    generated: { clones: [{ mode: 'fixed', modelsArray: 'block-a' }] },
+    variants: { brownstone: { modelsArray: 'block-b' } }
+  }
+};
+
+describe('applySegmentPreset', () => {
+  it('fills every omitted field from the type preset and reports them', () => {
+    const { segment, applied } = applySegmentPreset(
+      { type: 'bike-lane', width: 2 },
+      types
+    );
+    expect(segment.color).toBe('#00ff00');
+    expect(segment.surface).toBe('asphalt');
+    expect(segment.generated.stencil[0].modelsArray).toBe('bike-arrow');
+    expect(segment.generated.clones[0].modelsArray).toBe('cyclist1, cyclist2');
+    expect(applied).toEqual(['color', 'surface', 'elevation', 'generated']);
+  });
+
+  it('keeps explicit values and an explicit generated override', () => {
+    const { segment, applied } = applySegmentPreset(
+      { type: 'bike-lane', color: '#123456', generated: { stencil: [] } },
+      types
+    );
+    expect(segment.color).toBe('#123456');
+    expect(segment.generated).toEqual({ stencil: [] });
+    expect(applied).toEqual(['surface', 'elevation']);
+  });
+
+  it('deep-copies the preset so later mutation cannot leak back', () => {
+    const { segment } = applySegmentPreset({ type: 'sidewalk' }, types);
+    segment.generated.pedestrians[0].density = 'dense';
+    expect(types.sidewalk.generated.pedestrians[0].density).toBe('normal');
+  });
+
+  it('carries boundary variants through for the segment component', () => {
+    const { segment } = applySegmentPreset(
+      { type: 'boundary', variant: 'brownstone', side: 'left' },
+      types
+    );
+    expect(segment.variants).toBe(types.boundary.variants);
+    expect(segment.variant).toBe('brownstone');
+  });
+
+  it('is a no-op for an unknown type or missing table', () => {
+    expect(applySegmentPreset({ type: 'weird' }, types).applied).toEqual([]);
+    expect(applySegmentPreset({ type: 'sidewalk' }, undefined).applied).toEqual(
+      []
+    );
+  });
+});
+
+describe('summarizePresets', () => {
+  it('produces a compact model-facing summary', () => {
+    const out = summarizePresets(types);
+    const bike = out.find((p) => p.type === 'bike-lane');
+    expect(bike.generated).toEqual({
+      stencil: ['bike-arrow'],
+      clones: ['cyclist1, cyclist2']
+    });
+    const walk = out.find((p) => p.type === 'sidewalk');
+    expect(walk.generated.pedestrians).toEqual(['density: normal']);
+    expect(walk.elevation).toBe(0.15);
+    expect(out.find((p) => p.type === 'boundary').variants).toEqual([
+      'brownstone'
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

Second WebMCP testing round (Geary Blvd BRT): the agent rebuilt every lane from scratch with grey slabs, put a `bus` model into the stencil generator (sideways buses), guessed `bike` as a model id (box), and could not tell which cross-section side was north.

## What

**Segment presets** (`src/editor/lib/commands/segmentPresets.js`)
`managedStreetCreate` and `managedStreetUpdate add-segment` apply the same `STREET.types` table the sidebar applies when a user picks a segment type — surface, color, elevation, default direction, stencils, clones, pedestrians — to every field the model omits, and return `presetsApplied`. No special powers: it is exactly what a human gets from the type dropdown. New `listSegmentPresets` read tool exposes the table.

**Catalog** `listMixins` now tags each id with `generator: "clones" | "stencil"` and appends the stencil ids that aren't catalog mixins. The `generated` / `modelsArray` schema copy states which system places 3D models vs paints markings.

**Readback** `managedStreetCreate` waits for the street to settle (segments mounted, descendant count stable, bounded ~4 s) and returns `readBack` with per-segment generators and placed-model counts, so "created" is backed by what mounted.

**Sides** `getGeoContext` managed-street block adds `crossSection.firstSegmentEdgeBearingDeg` / `lastSegmentEdgeBearingDeg`; the boundary `side` description now says left = inbound side, right = outbound (right-hand-drive convention; swap for left-hand-drive).

**Auth warning removed** from SignInModal and the `setLatLon` description: WebMCP sign-in verified working on prod.

## Verified (headless, dev server)

- `listSegmentPresets`: bus-lane → clones `bus`, stencil `word-only, word-taxi, word-bus`; bike-lane → `bike-arrow` + cyclists.
- `listMixins`: 231 clones ids, 25 stencil ids; `bus` → clones, `word-bus` → stencil.
- Create with 5 segments omitting generated: ~800 ms, `readBack.settled: true`, bike lane 7 placed models + stencil generator, bus lane 4 buses + stencil + striping, boundary brownstone 9 blocks. Explicit `color` on a segment survives (only surface/elevation/generated applied).
- `add-segment` parking-lane reports "preset supplied color, surface, elevation, generated".
- `crossSection` for a street along +Z at SF: first edge 180°, last edge 0°.

Unit tests: `test/editor/segmentPresets.test.js`; full suite 62 files / 1047 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)