### PR TITLE
fix: serve JS bundles and HTML with no-cache so deploys bust browser …

### DIFF
--- a/public/firebase.json
+++ b/public/firebase.json
@@ -12,6 +12,20 @@
       "firestore.indexes.json",
       "*.log"
     ],
+    "headers": [
+      {
+        "source": "/dist/**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "**/*.html",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "/",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      }
+    ],
     "rewrites": [
       {
         "source": "scenes/*.json",

--- a/public/firebase.json
+++ b/public/firebase.json
@@ -24,6 +24,10 @@
       {
         "source": "/",
         "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "**/",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
       }
     ],
     "rewrites": [


### PR DESCRIPTION
…caches (#574)

Firebase Hosting's default Cache-Control (max-age=3600) let browsers keep serving hour-old bundles after a deploy, since the dist filenames never change. Cache-Control: no-cache keeps files in the browser cache but forces an ETag revalidation on every load: unchanged files answer 304, and a fresh deploy is picked up on the very next page load — no build or HTML changes needed.


Claude-Session: https://claude.ai/code/session_01DitVDTTC3wMZzLheP2GRf1