### PR TITLE
Handle .gltf uploads: sniff external refs, convert self-contained to GLB

### DIFF
--- a/src/editor/components/elements/useAssetUploadStatus.js
+++ b/src/editor/components/elements/useAssetUploadStatus.js
@@ -25,6 +25,8 @@ export const REASON_TEXT = {
     "Larger than your plan's per-file limit: upgrade to sync this model.",
   not_signed_in: 'Sign in to save this model to your cloud.',
   upload_blocked: 'Cloud upload was blocked.',
+  load_failed:
+    "Couldn't be loaded as a 3D model, so it wasn't uploaded. The file may be invalid or incomplete.",
   asset_deleted:
     'Marked for deletion: will be permanently purged on the next cleanup pass.',
   asset_not_found:

--- a/src/editor/lib/asset-upload/uploadAndPlaceAsset.js
+++ b/src/editor/lib/asset-upload/uploadAndPlaceAsset.js
@@ -2,10 +2,12 @@
  * Inline drop / upload.
  *
  * Flow:
- *   1. Validate file type & per-file size cap (50MB GLB / 10MB image)
+ *   1. Validate file type & per-file size cap (50MB GLB / 10MB image);
+ *      .gltf JSON is sniffed and rejected when it references sibling files
  *   2. Pre-flight quota check via callable Cloud Function
- *   3. Create entity at drop position with local blob URL
- *   4. (GLB only) optimize via gltf-transform
+ *   3. Create entity at drop position with local blob URL; a GLB that fails
+ *      to load locally (model-error) is kept as local_error, never uploaded
+ *   4. (GLB only) optimize via gltf-transform (also converts .gltf → GLB)
  *   5. Upload via assetsService.addAsset
  *   6. On success: write data-asset-id + data-asset-owner-uid (the only
  *      persistent identity attrs), swap blob URL for cloud URL, revoke blob.
@@ -29,7 +31,10 @@ import {
   isAcceptedAssetFile,
   extractGlbAttribution,
   buildStoredAttribution,
-  optimizeGlb
+  optimizeGlb,
+  isGltfJsonFile,
+  analyzeGltfFile,
+  gltfRejectionMessage
 } from '@shared/asset-upload';
 import useAssetUploadStore from '@/editor/state/assetUploadStore.js';
 
@@ -273,6 +278,28 @@ export async function uploadAndPlaceAsset(file, position, existingEntity) {
     return { entity: null, assetId: null, kind: null };
   }
 
+  // A .gltf that references sibling files (scene.bin, textures/) can never
+  // render from a single-file drop — the browser only hands us this one File.
+  // Reject before creating a placeholder or spending quota, with conversion
+  // instructions (#1951). Self-contained .gltf (embedded data: URIs) proceeds
+  // and the optimize worker converts it to GLB when it can.
+  if (kind === 'glb' && isGltfJsonFile(file)) {
+    const analysis = await analyzeGltfFile(file);
+    if (analysis.status === 'external-refs' || analysis.status === 'invalid') {
+      captureUploadBlockedEvent(
+        kind,
+        `gltf_${analysis.status.replace('-', '_')}`,
+        {
+          file_size: file.size,
+          filename: file.name,
+          external_ref_count: analysis.externalRefs.length
+        }
+      );
+      notifyError(gltfRejectionMessage(file.name, analysis));
+      return { entity: null, assetId: null, kind: null };
+    }
+  }
+
   // Enforce one-at-a-time across all upload surfaces. The gallery's pending
   // card is the single source of truth for "an upload is happening" — drops
   // and Upload-button clicks are blocked until it clears.
@@ -309,6 +336,10 @@ export async function uploadAndPlaceAsset(file, position, existingEntity) {
   } else {
     ({ entity, blobUrl } = await createPlaceholderEntity(file, position, kind));
   }
+  // Start watching the local preview's load outcome immediately — before any
+  // awaits — so a fast model-error can't slip past. Consumed below (after the
+  // quota check) to refuse uploading a model that can't even render locally.
+  const modelLoadGate = kind === 'glb' ? watchModelLoad(entity) : null;
   const entityId = entity.id;
   const { setUpload, clearUpload } = useAssetUploadStore.getState();
 
@@ -425,6 +456,30 @@ export async function uploadAndPlaceAsset(file, position, existingEntity) {
     }
     currentUploadStore.clear();
     return { entity, assetId: null, kind };
+  }
+
+  // Refuse to upload a model the local preview couldn't load (#1951): if the
+  // blob URL fired model-error, the cloud copy would be just as broken — a
+  // permanently dead asset that still counts against quota. A load timeout
+  // passes (benefit of the doubt for huge meshes); a real error blocks.
+  if (modelLoadGate) {
+    const loadResult = await modelLoadGate;
+    if (!loadResult.loaded) {
+      captureUploadBlockedEvent(kind, 'model_load_failed', {
+        file_size: file.size,
+        filename: file.name
+      });
+      notifyError(
+        `${file.name} couldn't be loaded as a 3D model, so it wasn't uploaded. The file may be invalid or incomplete.`
+      );
+      setUpload(entityId, {
+        status: 'local_error',
+        reason: 'load_failed',
+        progress: 0
+      });
+      currentUploadStore.clear();
+      return { entity, assetId: null, kind };
+    }
   }
 
   const uploadStartTime = Date.now();
@@ -664,6 +719,43 @@ export async function uploadAndPlaceAsset(file, position, existingEntity) {
     // indicators retain their failed/local_error status.
     currentUploadStore.clear();
   }
+}
+
+// How long the pre-upload gate waits for the local preview to finish loading
+// before giving the file the benefit of the doubt. Heavy photogrammetry GLBs
+// can legitimately parse for a long time; only an explicit model-error blocks.
+const MODEL_LOAD_GATE_TIMEOUT_MS = 30000;
+
+/**
+ * Resolve with the placeholder entity's local load outcome:
+ * `{ loaded: true }` on model-loaded (or an already-present mesh, e.g. the
+ * retry path), `{ loaded: false }` on model-error, `{ loaded: true }` on
+ * timeout so a slow parse never blocks an upload.
+ */
+function watchModelLoad(entity, timeoutMs = MODEL_LOAD_GATE_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    if (entity.getObject3D('mesh')) {
+      resolve({ loaded: true });
+      return;
+    }
+    let done = false;
+    const finish = (result) => {
+      if (done) return;
+      done = true;
+      entity.removeEventListener('model-loaded', onLoaded);
+      entity.removeEventListener('model-error', onError);
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const onLoaded = () => finish({ loaded: true });
+    const onError = () => finish({ loaded: false });
+    entity.addEventListener('model-loaded', onLoaded);
+    entity.addEventListener('model-error', onError);
+    const timer = setTimeout(
+      () => finish({ loaded: true, timedOut: true }),
+      timeoutMs
+    );
+  });
 }
 
 /**

--- a/src/shared/asset-upload/analyzeGltf.js
+++ b/src/shared/asset-upload/analyzeGltf.js
@@ -1,0 +1,109 @@
+/**
+ * Pre-upload sniff for `.gltf` (JSON) files.
+ *
+ * A `.gltf` is plain JSON that may reference sibling files (`scene.bin`,
+ * `textures/*.png`) by relative URI — the standard shape of a Sketchfab
+ * "glTF" download. Browsers hand us a single File on drop/pick, so those
+ * siblings are unreachable: the model can't render locally and uploading
+ * the JSON alone would store a permanently broken asset (#1951).
+ *
+ * This module classifies a `.gltf` before any placeholder entity or upload
+ * happens:
+ *
+ *   'self-contained' — every buffer/image is embedded (`data:` URI) or
+ *                      packed in a bufferView. Safe to upload; the optimize
+ *                      worker converts it to GLB when it can.
+ *   'external-refs'  — references sibling files. Rejected with conversion
+ *                      instructions (the listed refs go into the message).
+ *   'binary'         — GLB bytes with a `.gltf` name. Treated as a GLB.
+ *   'invalid'        — not parseable as glTF JSON or GLB.
+ *
+ * `.glb` files never come through here — callers gate on isGltfJsonFile().
+ */
+
+const GLB_MAGIC = 0x46546c67; // 'glTF' little-endian
+
+export function isGltfJsonFile(file) {
+  return (file?.name || '').toLowerCase().endsWith('.gltf');
+}
+
+function isDataUri(uri) {
+  return /^data:/i.test(uri.trim());
+}
+
+/**
+ * Classify parsed glTF JSON. Exported for tests.
+ * @returns {{ selfContained: boolean, externalRefs: string[] }}
+ */
+export function analyzeGltfJson(json) {
+  const externalRefs = [];
+  for (const buffer of json?.buffers ?? []) {
+    // A buffer with no uri is GLB-only (BIN chunk); in a standalone .gltf
+    // it's unresolvable, same as an external file.
+    if (typeof buffer?.uri !== 'string') {
+      externalRefs.push('(binary buffer)');
+    } else if (!isDataUri(buffer.uri)) {
+      externalRefs.push(buffer.uri);
+    }
+  }
+  for (const image of json?.images ?? []) {
+    // Images may pack pixels into a bufferView instead of a uri — fine.
+    if (typeof image?.uri === 'string' && !isDataUri(image.uri)) {
+      externalRefs.push(image.uri);
+    }
+  }
+  return { selfContained: externalRefs.length === 0, externalRefs };
+}
+
+/**
+ * Classify a `.gltf` File/Blob.
+ * @param {File | Blob} file
+ * @returns {Promise<{ status: 'self-contained'|'external-refs'|'binary'|'invalid', externalRefs: string[] }>}
+ */
+export async function analyzeGltfFile(file) {
+  let buffer;
+  try {
+    buffer = await file.arrayBuffer();
+  } catch (err) {
+    console.warn('[asset-upload] could not read .gltf file', err);
+    return { status: 'invalid', externalRefs: [] };
+  }
+  const view = new DataView(buffer);
+  if (view.byteLength >= 4 && view.getUint32(0, true) === GLB_MAGIC) {
+    return { status: 'binary', externalRefs: [] };
+  }
+  let json;
+  try {
+    json = JSON.parse(new TextDecoder().decode(buffer));
+  } catch {
+    return { status: 'invalid', externalRefs: [] };
+  }
+  if (!json || typeof json !== 'object' || !json.asset) {
+    return { status: 'invalid', externalRefs: [] };
+  }
+  const { selfContained, externalRefs } = analyzeGltfJson(json);
+  return {
+    status: selfContained ? 'self-contained' : 'external-refs',
+    externalRefs
+  };
+}
+
+/**
+ * User-facing rejection message for a `.gltf` that can't be uploaded.
+ * Shared by the editor drop flow and the scene-free upload flow so both
+ * surfaces give the same conversion instructions.
+ */
+export function gltfRejectionMessage(filename, analysis) {
+  if (analysis?.status === 'external-refs') {
+    const refs = analysis.externalRefs.slice(0, 3).join(', ');
+    const more =
+      analysis.externalRefs.length > 3
+        ? ` +${analysis.externalRefs.length - 3} more`
+        : '';
+    return (
+      `${filename} references separate files (${refs}${more}) that can't be uploaded together. ` +
+      `Export a single .glb file instead — in Blender: File → Export → glTF 2.0, format "glTF Binary" — or convert at gltf.report.`
+    );
+  }
+  return `${filename} is not a valid glTF file. Export a single .glb file and try again.`;
+}

--- a/src/shared/asset-upload/extractGlbAttribution.js
+++ b/src/shared/asset-upload/extractGlbAttribution.js
@@ -38,9 +38,13 @@ const CHUNK_JSON = 0x4e4f534a; // 'JSON' little-endian
 
 function readGlbJsonChunk(buffer) {
   const view = new DataView(buffer);
+  const magic = view.byteLength >= 4 ? view.getUint32(0, true) : 0;
+  if (magic !== GLB_MAGIC) {
+    // Not GLB binary — self-contained .gltf uploads pass their JSON straight
+    // through here. Throws on non-JSON input, caught by the caller.
+    return JSON.parse(new TextDecoder().decode(buffer));
+  }
   if (view.byteLength < 20) throw new Error('GLB too short');
-  const magic = view.getUint32(0, true);
-  if (magic !== GLB_MAGIC) throw new Error('Not a GLB file');
 
   const jsonChunkLen = view.getUint32(12, true);
   const jsonChunkType = view.getUint32(16, true);

--- a/src/shared/asset-upload/index.js
+++ b/src/shared/asset-upload/index.js
@@ -11,6 +11,12 @@ export {
 } from './captureThumbnail.js';
 export { optimizeGlb } from './optimizeGlb.js';
 export {
+  isGltfJsonFile,
+  analyzeGltfFile,
+  analyzeGltfJson,
+  gltfRejectionMessage
+} from './analyzeGltf.js';
+export {
   extractGlbAttribution,
   composeAttributionString,
   normalizeAttributionFromGltfJson,

--- a/src/shared/asset-upload/optimizeGlb.worker.js
+++ b/src/shared/asset-upload/optimizeGlb.worker.js
@@ -20,6 +20,14 @@
  * applies to worker bundles too.
  */
 
+const GLB_MAGIC = 0x46546c67; // 'glTF' little-endian
+
+function isGlbBytes(bytes) {
+  if (bytes.byteLength < 4) return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return view.getUint32(0, true) === GLB_MAGIC;
+}
+
 let depsPromise = null;
 
 async function loadDeps() {
@@ -80,7 +88,18 @@ async function optimize(originalBytes) {
       'draco3d.encoder': encoderModule
     });
 
-  const document = await io.readBinary(originalBytes);
+  // Input is either GLB binary or self-contained .gltf JSON (external-ref
+  // .gltf is rejected at intake; see analyzeGltf.js). readJSON inlines
+  // data: URIs itself, and writeBinary below emits GLB either way — so a
+  // .gltf that survives this pipeline uploads as a real GLB.
+  let document;
+  const wasJson = !isGlbBytes(originalBytes);
+  if (wasJson) {
+    const json = JSON.parse(new TextDecoder().decode(originalBytes));
+    document = await io.readJSON({ json, resources: {} });
+  } else {
+    document = await io.readBinary(originalBytes);
+  }
 
   const extensionsUsed = document
     .getRoot()
@@ -88,7 +107,10 @@ async function optimize(originalBytes) {
     .map((e) => e.extensionName);
   const hasDraco = extensionsUsed.includes('KHR_draco_mesh_compression');
   const hasWebP = extensionsUsed.includes('EXT_texture_webp');
-  if (hasDraco && hasWebP) {
+  // The skip paths hand the ORIGINAL bytes back to the caller, which is only
+  // acceptable when the original is already a GLB. A .gltf JSON input must
+  // always come out as converted GLB bytes, so it never takes them.
+  if (hasDraco && hasWebP && !wasJson) {
     return {
       skipped: true,
       reason: 'already_optimized',
@@ -119,7 +141,7 @@ async function optimize(originalBytes) {
   const output = await io.writeBinary(document);
   const outputBytes = output.byteLength;
 
-  if (outputBytes >= inputBytes) {
+  if (outputBytes >= inputBytes && !wasJson) {
     return {
       skipped: true,
       reason: 'not_smaller',

--- a/src/shared/asset-upload/uploadAsset.js
+++ b/src/shared/asset-upload/uploadAsset.js
@@ -22,6 +22,11 @@ import {
   buildStoredAttribution
 } from './extractGlbAttribution.js';
 import { optimizeGlb } from './optimizeGlb.js';
+import {
+  isGltfJsonFile,
+  analyzeGltfFile,
+  gltfRejectionMessage
+} from './analyzeGltf.js';
 
 // Absolute client-side per-file ceiling = the top plan's per-file cap (MAX,
 // 5 GB). Type-agnostic; this is only the fast synchronous "obviously too big"
@@ -78,6 +83,18 @@ async function preflightQuota(proposedBytes) {
 export async function uploadAsset(file, { onStatus, onProgress } = {}) {
   const kind = getAssetKind(file);
   if (!kind) return { ok: false, error: `Unsupported file type: ${file.name}` };
+
+  // A .gltf that references sibling files (scene.bin, textures/) can never
+  // render from a single-file upload — reject it up front with conversion
+  // instructions instead of storing a broken asset (#1951). Self-contained
+  // .gltf (embedded data: URIs) proceeds; the optimize worker converts it
+  // to GLB when it can.
+  if (kind === 'glb' && isGltfJsonFile(file)) {
+    const analysis = await analyzeGltfFile(file);
+    if (analysis.status === 'external-refs' || analysis.status === 'invalid') {
+      return { ok: false, error: gltfRejectionMessage(file.name, analysis) };
+    }
+  }
 
   // Enforce one-at-a-time across all upload surfaces (editor + generator).
   const uploadStore = useCurrentUploadStore.getState();

--- a/test/shared/asset-upload/analyzeGltf.test.js
+++ b/test/shared/asset-upload/analyzeGltf.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isGltfJsonFile,
+  analyzeGltfJson,
+  analyzeGltfFile,
+  gltfRejectionMessage
+} from '../../../src/shared/asset-upload/analyzeGltf.js';
+
+const encode = (obj) => new TextEncoder().encode(JSON.stringify(obj)).buffer;
+const asFile = (buffer) => ({ arrayBuffer: async () => buffer });
+
+// Minimal Sketchfab-shaped .gltf: JSON referencing sibling files.
+const externalRefGltf = {
+  asset: { version: '2.0' },
+  buffers: [{ uri: 'scene.bin', byteLength: 1234 }],
+  images: [{ uri: 'textures/material_baseColor.png' }]
+};
+
+// Fully embedded .gltf: data: URI buffer, bufferView-packed image.
+const selfContainedGltf = {
+  asset: { version: '2.0' },
+  buffers: [
+    { uri: 'data:application/octet-stream;base64,AAAA', byteLength: 3 }
+  ],
+  images: [{ bufferView: 0, mimeType: 'image/png' }]
+};
+
+describe('isGltfJsonFile', () => {
+  it('matches .gltf only, case-insensitively', () => {
+    expect(isGltfJsonFile({ name: 'scene.gltf' })).toBe(true);
+    expect(isGltfJsonFile({ name: 'SCENE.GLTF' })).toBe(true);
+    expect(isGltfJsonFile({ name: 'model.glb' })).toBe(false);
+    expect(isGltfJsonFile({})).toBe(false);
+  });
+});
+
+describe('analyzeGltfJson', () => {
+  it('flags external buffer and image URIs', () => {
+    const { selfContained, externalRefs } = analyzeGltfJson(externalRefGltf);
+    expect(selfContained).toBe(false);
+    expect(externalRefs).toEqual([
+      'scene.bin',
+      'textures/material_baseColor.png'
+    ]);
+  });
+
+  it('accepts embedded data: URIs and bufferView images', () => {
+    const { selfContained, externalRefs } = analyzeGltfJson(selfContainedGltf);
+    expect(selfContained).toBe(true);
+    expect(externalRefs).toEqual([]);
+  });
+
+  it('treats a uri-less buffer as unresolvable in a standalone .gltf', () => {
+    const { selfContained, externalRefs } = analyzeGltfJson({
+      asset: { version: '2.0' },
+      buffers: [{ byteLength: 10 }]
+    });
+    expect(selfContained).toBe(false);
+    expect(externalRefs).toEqual(['(binary buffer)']);
+  });
+
+  it('is self-contained when there are no buffers or images at all', () => {
+    expect(analyzeGltfJson({ asset: { version: '2.0' } }).selfContained).toBe(
+      true
+    );
+  });
+});
+
+describe('analyzeGltfFile', () => {
+  it('classifies external-ref .gltf', async () => {
+    const result = await analyzeGltfFile(asFile(encode(externalRefGltf)));
+    expect(result.status).toBe('external-refs');
+    expect(result.externalRefs).toContain('scene.bin');
+  });
+
+  it('classifies self-contained .gltf', async () => {
+    const result = await analyzeGltfFile(asFile(encode(selfContainedGltf)));
+    expect(result.status).toBe('self-contained');
+  });
+
+  it('detects GLB bytes behind a .gltf name', async () => {
+    // 'glTF' magic + version 2 + length header.
+    const buffer = new ArrayBuffer(12);
+    const view = new DataView(buffer);
+    view.setUint32(0, 0x46546c67, true);
+    view.setUint32(4, 2, true);
+    view.setUint32(8, 12, true);
+    const result = await analyzeGltfFile(asFile(buffer));
+    expect(result.status).toBe('binary');
+  });
+
+  it('classifies unparseable input as invalid', async () => {
+    const result = await analyzeGltfFile(
+      asFile(new TextEncoder().encode('not json at all').buffer)
+    );
+    expect(result.status).toBe('invalid');
+  });
+
+  it('classifies JSON without an asset field as invalid', async () => {
+    const result = await analyzeGltfFile(asFile(encode({ foo: 'bar' })));
+    expect(result.status).toBe('invalid');
+  });
+});
+
+describe('gltfRejectionMessage', () => {
+  it('names the file and the missing sibling files', () => {
+    const msg = gltfRejectionMessage('scene.gltf', {
+      status: 'external-refs',
+      externalRefs: ['scene.bin', 'textures/a.png']
+    });
+    expect(msg).toContain('scene.gltf');
+    expect(msg).toContain('scene.bin');
+    expect(msg).toContain('.glb');
+  });
+
+  it('truncates long ref lists', () => {
+    const msg = gltfRejectionMessage('scene.gltf', {
+      status: 'external-refs',
+      externalRefs: ['a.bin', 'b.png', 'c.png', 'd.png', 'e.png']
+    });
+    expect(msg).toContain('+2 more');
+    expect(msg).not.toContain('d.png');
+  });
+
+  it('falls back to an invalid-file message', () => {
+    const msg = gltfRejectionMessage('scene.gltf', {
+      status: 'invalid',
+      externalRefs: []
+    });
+    expect(msg).toContain('not a valid glTF');
+  });
+});


### PR DESCRIPTION
Fixes #1951.

A `.gltf` is JSON that may reference sibling files (`scene.bin`, `textures/`) by relative URI — the standard shape of a Sketchfab "glTF" download. Browsers hand us a single File on drop, so those siblings are unreachable: the model couldn't render locally, yet the pipeline accepted the file, uploaded the orphaned JSON, and stored a permanently broken asset that still counted against quota.

## Changes

- **New `analyzeGltf` module** (`src/shared/asset-upload/analyzeGltf.js`) classifies a `.gltf` before any placeholder entity or upload: `external-refs`, `self-contained` (embedded `data:` URIs), `binary` (GLB bytes behind a `.gltf` name), or `invalid`. Wired into both upload surfaces — the editor drop/pick flow (`uploadAndPlaceAsset.js`) and the scene-free `uploadAsset.js`.
- **External-ref / invalid `.gltf` rejected up front** with a toast naming the missing sibling files and giving conversion instructions (Blender "glTF Binary" export, or gltf.report). Captured as `gltf_external_refs` / `gltf_invalid` `asset_upload_blocked` events.
- **Self-contained `.gltf` now uploads as a real GLB**: the optimize worker detects JSON input by magic bytes, reads it via gltf-transform `readJSON` (which inlines `data:` URIs), and always emits GLB for JSON input — the skip paths that hand original bytes back are GLB-only now.
- **Attribution extraction reads plain glTF JSON** too, so Sketchfab-style `asset.extras` metadata survives a `.gltf` upload.
- **Pre-upload load gate**: a listener attaches to the placeholder at creation; if the local blob preview fires `model-error`, the entity is kept as `local_error` (new `load_failed` reason in the properties panel) and never uploaded. A slow parse passes after a 30s timeout — only an explicit load error blocks. This closes the broken-cloud-asset hole for any unparseable model file, not just `.gltf`.

Follow-up for making the Sketchfab zip journey work end-to-end (zip/folder drop → pack to GLB client-side): #1952.

## Testing

- 13 new unit tests in `test/shared/asset-upload/analyzeGltf.test.js` (classification, GLB-magic detection, rejection message copy).
- Full `test:modern` (1069 tests) and `test:core` (196 tests) suites pass; prettier/eslint clean.
- Verified against gltf-transform 4.x that `readJSON({ json, resources: {} })` inlines `data:` URIs and `writeBinary` emits a valid GLB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7h3ox4ae4JkDZCa5kdmNW

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7h3ox4ae4JkDZCa5kdmNW)_