### PR TITLE
Localize .gltf upload rejection messages

### DIFF
--- a/src/shared/asset-upload/analyzeGltf.js
+++ b/src/shared/asset-upload/analyzeGltf.js
@@ -14,12 +14,14 @@
  *                      packed in a bufferView. Safe to upload; the optimize
  *                      worker converts it to GLB when it can.
  *   'external-refs'  — references sibling files. Rejected with conversion
- *                      instructions (the listed refs go into the message).
+ *                      instructions.
  *   'binary'         — GLB bytes with a `.gltf` name. Treated as a GLB.
  *   'invalid'        — not parseable as glTF JSON or GLB.
  *
  * `.glb` files never come through here — callers gate on isGltfJsonFile().
  */
+
+import { formatSharedMessage } from '../i18n/sharedMessages';
 
 const GLB_MAGIC = 0x46546c67; // 'glTF' little-endian
 
@@ -91,19 +93,11 @@ export async function analyzeGltfFile(file) {
 /**
  * User-facing rejection message for a `.gltf` that can't be uploaded.
  * Shared by the editor drop flow and the scene-free upload flow so both
- * surfaces give the same conversion instructions.
+ * surfaces give the same conversion instructions. Localized via the
+ * hand-maintained shared message table (no react-intl context here).
  */
 export function gltfRejectionMessage(filename, analysis) {
-  if (analysis?.status === 'external-refs') {
-    const refs = analysis.externalRefs.slice(0, 3).join(', ');
-    const more =
-      analysis.externalRefs.length > 3
-        ? ` +${analysis.externalRefs.length - 3} more`
-        : '';
-    return (
-      `${filename} references separate files (${refs}${more}) that can't be uploaded together. ` +
-      `Export a single .glb file instead — in Blender: File → Export → glTF 2.0, format "glTF Binary" — or convert at gltf.report.`
-    );
-  }
-  return `${filename} is not a valid glTF file. Export a single .glb file and try again.`;
+  const id =
+    analysis?.status === 'external-refs' ? 'gltfExternalRefs' : 'gltfInvalid';
+  return formatSharedMessage(id, { filename });
 }

--- a/src/shared/i18n/sharedMessages.js
+++ b/src/shared/i18n/sharedMessages.js
@@ -940,6 +940,22 @@ const SHARED_MESSAGES = {
     es: 'o escanea el código QR de arriba para usar la versión web.',
     'pt-BR': 'ou escaneie o QR code acima para usar a versão web.',
     fr: 'ou scannez le code QR ci-dessus pour utiliser la version web.'
+  },
+
+  // .gltf upload rejection (shared/asset-upload/analyzeGltf.js, #1951)
+  gltfExternalRefs: {
+    en: "{filename} references separate files that can't be uploaded together. Export a single .glb file instead, convert at https://gltf.report.",
+    es: '{filename} hace referencia a archivos separados que no se pueden subir juntos. Exporta un solo archivo .glb en su lugar, o conviértelo en https://gltf.report.',
+    'pt-BR':
+      '{filename} faz referência a arquivos separados que não podem ser enviados juntos. Em vez disso, exporte um único arquivo .glb ou converta em https://gltf.report.',
+    fr: '{filename} fait référence à des fichiers séparés qui ne peuvent pas être téléversés ensemble. Exportez plutôt un seul fichier .glb, ou convertissez-le sur https://gltf.report.'
+  },
+  gltfInvalid: {
+    en: '{filename} is not a valid glTF file. Export a single .glb file and try again.',
+    es: '{filename} no es un archivo glTF válido. Exporta un solo archivo .glb e inténtalo de nuevo.',
+    'pt-BR':
+      '{filename} não é um arquivo glTF válido. Exporte um único arquivo .glb e tente novamente.',
+    fr: "{filename} n'est pas un fichier glTF valide. Exportez un seul fichier .glb et réessayez."
   }
 };
 

--- a/test/shared/asset-upload/analyzeGltf.test.js
+++ b/test/shared/asset-upload/analyzeGltf.test.js
@@ -5,6 +5,7 @@ import {
   analyzeGltfFile,
   gltfRejectionMessage
 } from '../../../src/shared/asset-upload/analyzeGltf.js';
+import { formatSharedMessage } from '../../../src/shared/i18n/sharedMessages';
 
 const encode = (obj) => new TextEncoder().encode(JSON.stringify(obj)).buffer;
 const asFile = (buffer) => ({ arrayBuffer: async () => buffer });
@@ -103,23 +104,14 @@ describe('analyzeGltfFile', () => {
 });
 
 describe('gltfRejectionMessage', () => {
-  it('names the file and the missing sibling files', () => {
+  it('names the file and points to a .glb export', () => {
     const msg = gltfRejectionMessage('scene.gltf', {
       status: 'external-refs',
       externalRefs: ['scene.bin', 'textures/a.png']
     });
     expect(msg).toContain('scene.gltf');
-    expect(msg).toContain('scene.bin');
     expect(msg).toContain('.glb');
-  });
-
-  it('truncates long ref lists', () => {
-    const msg = gltfRejectionMessage('scene.gltf', {
-      status: 'external-refs',
-      externalRefs: ['a.bin', 'b.png', 'c.png', 'd.png', 'e.png']
-    });
-    expect(msg).toContain('+2 more');
-    expect(msg).not.toContain('d.png');
+    expect(msg).toContain('gltf.report');
   });
 
   it('falls back to an invalid-file message', () => {
@@ -127,6 +119,17 @@ describe('gltfRejectionMessage', () => {
       status: 'invalid',
       externalRefs: []
     });
+    expect(msg).toContain('scene.gltf');
     expect(msg).toContain('not a valid glTF');
+  });
+
+  it('localizes via the shared message table', () => {
+    const msg = formatSharedMessage(
+      'gltfInvalid',
+      { filename: 'scene.gltf' },
+      { locale: 'es' }
+    );
+    expect(msg).toContain('scene.gltf');
+    expect(msg).toContain('glTF válido');
   });
 });


### PR DESCRIPTION
Follow-up to #1953. Moves the two `.gltf` rejection messages (`gltfRejectionMessage` in `analyzeGltf.js`) into the hand-maintained shared message table (`@shared/i18n/sharedMessages`) with es / pt-BR / fr translations, since this code runs in `src/shared` with no react-intl context (same pattern as the pricing strings). Also simplifies the external-refs copy and drops the truncated ref list from the message.

No change to the formatjs catalogs, so `i18n:check` is unaffected.

**Test plan**
- [x] `npx vitest run test/shared/asset-upload/analyzeGltf.test.js` (13 pass)
- [x] eslint + prettier clean on touched files
- [ ] Drop a Sketchfab-style `.gltf` with the editor language set to Spanish; toast shows the localized message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196R6XxRWi6JX7wX8nRuSgF