### PR TITLE
Seed lane direction into manually added stencils/clones

### DIFF
--- a/src/aframe-components/street-generated-stencil.js
+++ b/src/aframe-components/street-generated-stencil.js
@@ -72,7 +72,8 @@ AFRAME.registerComponent('street-generated-stencil', {
       type: 'number'
     },
     direction: {
-      // specifying inbound/outbound directions will overwrite facing/randomFacing
+      // 'none' = fixed absolute orientation via `facing`; 'inbound'/'outbound'
+      // make the stencil follow the segment's travel direction (and its flips)
       type: 'string',
       default: 'none',
       oneOf: ['none', 'inbound', 'outbound']

--- a/src/editor/components/elements/AddGeneratorComponent.js
+++ b/src/editor/components/elements/AddGeneratorComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
+import { seedLaneDirection } from '../../lib/segmentPanel';
 
 export default class AddGeneratorComponent extends React.Component {
   static propTypes = {
@@ -30,6 +31,16 @@ export default class AddGeneratorComponent extends React.Component {
 
     const entity = this.props.entity;
 
+    // Match the import/type-change creation paths: a stencil/clones component
+    // added to a lane must start out following the lane's travel direction,
+    // or it renders outbound-facing on an inbound lane and — since direction
+    // propagation skips 'none' — never follows later flips (#1959).
+    const attrValue = seedLaneDirection(
+      componentName,
+      value.attrValue || '',
+      entity.components['street-segment']?.data?.direction
+    );
+
     if (AFRAME.components[componentName].multiple) {
       // Auto-assign the lowest unused numeric modifier instead of prompting
       // the user to invent a name before they've defined the component (#1752).
@@ -50,7 +61,7 @@ export default class AddGeneratorComponent extends React.Component {
     AFRAME.INSPECTOR.execute('componentadd', {
       entity,
       component: componentName,
-      value: value.attrValue || ''
+      value: attrValue
     });
   };
 

--- a/src/editor/components/elements/StreetSegmentComponent.jsx
+++ b/src/editor/components/elements/StreetSegmentComponent.jsx
@@ -191,6 +191,37 @@ export default class Component extends React.Component {
     );
   };
 
+  // The generator's own travel-direction tri-state (#1959): inbound/outbound
+  // follow the lane (and track later segment direction flips); 'none' — shown
+  // as 'fixed' since that's what it means — keeps the absolute Facing angle.
+  // Exposed so users can see and repair a stencil stuck at 'none' from before
+  // manual adds seeded the lane direction.
+  directionRow = () => {
+    const componentData = this.props.component;
+    const schema =
+      AFRAME.components[this.props.name.split('__')[0]].schema.direction;
+    return (
+      <div className="compact-row">
+        <label
+          className="compact-label"
+          title="inbound/outbound follow the lane's travel direction; fixed keeps the absolute Facing angle"
+        >
+          Direction
+        </label>
+        <SelectWidget
+          id={`${this.props.name}:direction`}
+          name="direction"
+          value={componentData.data.direction}
+          options={schema.oneOf}
+          formatOptionLabel={(option) =>
+            option.value === 'none' ? 'fixed' : option.label
+          }
+          onChange={(name, value) => this.update(name, value)}
+        />
+      </div>
+    );
+  };
+
   row = (label, cells, extraClass = '') => (
     <div className={`compact-row ${extraClass}`.trim()}>
       <label className="compact-label">{label}</label>
@@ -237,6 +268,7 @@ export default class Component extends React.Component {
           maxChips={3}
         />
         {this.row('Place', placeCells, 'place-row')}
+        {this.directionRow()}
         {this.state.moreOpen &&
           this.moreInset(
             <>
@@ -276,6 +308,7 @@ export default class Component extends React.Component {
               'Padding: distance between stencils within a group — only has an effect when more than one stencil model is selected'
           })
         ])}
+        {this.directionRow()}
         {this.state.moreOpen &&
           this.moreInset(
             <>

--- a/src/editor/components/elements/StreetSegmentComponent.jsx
+++ b/src/editor/components/elements/StreetSegmentComponent.jsx
@@ -191,37 +191,6 @@ export default class Component extends React.Component {
     );
   };
 
-  // The generator's own travel-direction tri-state (#1959): inbound/outbound
-  // follow the lane (and track later segment direction flips); 'none' — shown
-  // as 'fixed' since that's what it means — keeps the absolute Facing angle.
-  // Exposed so users can see and repair a stencil stuck at 'none' from before
-  // manual adds seeded the lane direction.
-  directionRow = () => {
-    const componentData = this.props.component;
-    const schema =
-      AFRAME.components[this.props.name.split('__')[0]].schema.direction;
-    return (
-      <div className="compact-row">
-        <label
-          className="compact-label"
-          title="inbound/outbound follow the lane's travel direction; fixed keeps the absolute Facing angle"
-        >
-          Direction
-        </label>
-        <SelectWidget
-          id={`${this.props.name}:direction`}
-          name="direction"
-          value={componentData.data.direction}
-          options={schema.oneOf}
-          formatOptionLabel={(option) =>
-            option.value === 'none' ? 'fixed' : option.label
-          }
-          onChange={(name, value) => this.update(name, value)}
-        />
-      </div>
-    );
-  };
-
   row = (label, cells, extraClass = '') => (
     <div className={`compact-row ${extraClass}`.trim()}>
       <label className="compact-label">{label}</label>
@@ -268,7 +237,6 @@ export default class Component extends React.Component {
           maxChips={3}
         />
         {this.row('Place', placeCells, 'place-row')}
-        {this.directionRow()}
         {this.state.moreOpen &&
           this.moreInset(
             <>
@@ -308,7 +276,6 @@ export default class Component extends React.Component {
               'Padding: distance between stencils within a group — only has an effect when more than one stencil model is selected'
           })
         ])}
-        {this.directionRow()}
         {this.state.moreOpen &&
           this.moreInset(
             <>

--- a/src/editor/lib/segmentPanel.js
+++ b/src/editor/lib/segmentPanel.js
@@ -43,6 +43,37 @@ export function executeSegmentUpdate(entity, componentName, property, value) {
   });
 }
 
+// Generators that orient through their own `direction` property, whose
+// schema default 'none' means "fixed absolute orientation via `facing`".
+// Every path that creates them for the user (Streetmix/StreetPlan import,
+// segment type change) seeds the segment's travel direction into the
+// component; segment direction propagation deliberately skips 'none'
+// (side-facing benches, angled parking must not flip with the lane).
+const DIRECTION_SEEDED_GENERATORS = [
+  'street-generated-stencil',
+  'street-generated-clones'
+];
+
+/**
+ * Seed the host lane's travel direction into a generator's initial attribute
+ * string, so a manually added stencil/clones component starts out following
+ * the lane like the import and type-change creation paths do (#1959).
+ * Returns `attrValue` unchanged for non-directional generators, lanes with
+ * no travel direction, or a seed value that already sets a direction.
+ */
+export function seedLaneDirection(componentName, attrValue, segmentDirection) {
+  const baseName = componentName.split('__')[0];
+  if (!DIRECTION_SEEDED_GENERATORS.includes(baseName)) return attrValue;
+  if (segmentDirection !== 'inbound' && segmentDirection !== 'outbound') {
+    return attrValue;
+  }
+  if (/(^|;)\s*direction\s*:/.test(attrValue)) return attrValue;
+  const trimmed = attrValue.trim().replace(/;+\s*$/, '');
+  return trimmed
+    ? `${trimmed}; direction: ${segmentDirection}`
+    : `direction: ${segmentDirection}`;
+}
+
 // Representative color per surface material for the cross-section strip.
 // These are display-only approximations of the textures, not scene colors.
 const SURFACE_COLORS = {

--- a/test/components/street-generated-stencil.test.js
+++ b/test/components/street-generated-stencil.test.js
@@ -1,0 +1,84 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { elFactory } from './helpers.js';
+
+// A-Frame is registered against the global window. street-segment.js assigns
+// STREET.colors/STREET.types at module load, so the STREET global must exist
+// before importing it.
+beforeAll(async () => {
+  window.AFRAME_ASYNC = true;
+  await import('aframe');
+  window.STREET = window.STREET || {};
+  await import('../../src/aframe-components/street-segment.js');
+  await import('../../src/aframe-components/street-generated-stencil.js');
+  window.AFRAME.emitReady();
+});
+
+async function makeSegment(direction) {
+  const el = await elFactory();
+  el.setAttribute(
+    'street-segment',
+    `type: drive-lane; width: 3; length: 100; surface: asphalt; color: #ffffff; direction: ${direction}`
+  );
+  return el;
+}
+
+// The generator sets rotation on freshly created a-entities; wait for the
+// clone to initialize (attribute writes are buffered until then) before
+// reading it back.
+const stencilRotationY = async (el) => {
+  const comp = el.components['street-generated-stencil'];
+  expect(comp.createdEntities.length).toBeGreaterThan(0);
+  const clone = comp.createdEntities[0];
+  if (!clone.hasLoaded) {
+    await new Promise((resolve) =>
+      clone.addEventListener('loaded', resolve, { once: true })
+    );
+  }
+  return clone.getAttribute('rotation').y;
+};
+
+// Regression tests for #1959: a stencil whose own `direction` follows the
+// lane must render inbound stencils rotated 180° and track later segment
+// direction flips, while `direction: none` stays an absolute orientation.
+describe('street-generated-stencil direction', () => {
+  it('orients a direction-seeded stencil for an inbound lane', async () => {
+    const el = await makeSegment('inbound');
+    el.setAttribute(
+      'street-generated-stencil',
+      'modelsArray: left; spacing: 20; direction: inbound'
+    );
+    expect(await stencilRotationY(el)).toBe(180);
+  });
+
+  it('follows a segment direction flip', async () => {
+    const el = await makeSegment('inbound');
+    el.setAttribute(
+      'street-generated-stencil',
+      'modelsArray: left; spacing: 20; direction: inbound'
+    );
+
+    el.setAttribute('street-segment', 'direction', 'outbound');
+
+    // street-segment.update() propagates the flip into the generator ...
+    expect(el.getAttribute('street-generated-stencil').direction).toBe(
+      'outbound'
+    );
+    // ... which re-renders its stencils in the outbound orientation.
+    expect(await stencilRotationY(el)).toBe(0);
+  });
+
+  it('keeps direction: none stencils absolutely oriented through a flip', async () => {
+    const el = await makeSegment('inbound');
+    // e.g. angled-parking markings: fixed side-facing, must not flip
+    el.setAttribute(
+      'street-generated-stencil',
+      'modelsArray: parking-t; spacing: 20; direction: none; facing: 45'
+    );
+    expect(await stencilRotationY(el)).toBe(45);
+
+    el.setAttribute('street-segment', 'direction', 'outbound');
+
+    expect(el.getAttribute('street-generated-stencil').direction).toBe('none');
+    expect(await stencilRotationY(el)).toBe(45);
+  });
+});

--- a/test/editor/seedLaneDirection.test.js
+++ b/test/editor/seedLaneDirection.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { seedLaneDirection } from '../../src/editor/lib/segmentPanel.js';
+
+// #1959: a stencil/clones component added by hand to a lane must start out
+// following the lane's travel direction, like the import and type-change
+// creation paths, or it renders outbound-facing on an inbound lane and is
+// permanently skipped by segment direction propagation (which deliberately
+// ignores direction: none).
+describe('seedLaneDirection', () => {
+  it('seeds the lane direction into an empty stencil value', () => {
+    expect(seedLaneDirection('street-generated-stencil', '', 'inbound')).toBe(
+      'direction: inbound'
+    );
+    expect(seedLaneDirection('street-generated-stencil', '', 'outbound')).toBe(
+      'direction: outbound'
+    );
+  });
+
+  it('seeds clones too, matching the other creation paths', () => {
+    expect(seedLaneDirection('street-generated-clones', '', 'inbound')).toBe(
+      'direction: inbound'
+    );
+  });
+
+  it('resolves multi-instance suffixes to the base component', () => {
+    expect(
+      seedLaneDirection('street-generated-stencil__2', '', 'inbound')
+    ).toBe('direction: inbound');
+  });
+
+  it('appends to an existing seed value, normalizing trailing semicolons', () => {
+    expect(
+      seedLaneDirection(
+        'street-generated-clones',
+        'mode: random; modelsArray: sedan-rig;',
+        'outbound'
+      )
+    ).toBe('mode: random; modelsArray: sedan-rig; direction: outbound');
+  });
+
+  it('leaves a seed value that already sets a direction alone', () => {
+    expect(
+      seedLaneDirection(
+        'street-generated-stencil',
+        'direction: none; facing: 90',
+        'inbound'
+      )
+    ).toBe('direction: none; facing: 90');
+    expect(
+      seedLaneDirection(
+        'street-generated-stencil',
+        'modelsArray: left; direction: outbound',
+        'inbound'
+      )
+    ).toBe('modelsArray: left; direction: outbound');
+  });
+
+  it('does not mistake another property containing "direction" for one', () => {
+    // no such property today, but the guard must match whole names only
+    expect(
+      seedLaneDirection(
+        'street-generated-stencil',
+        'flowdirection: up',
+        'inbound'
+      )
+    ).toBe('flowdirection: up; direction: inbound');
+  });
+
+  it('does nothing for directionless lanes (sidewalk) or non-segment hosts', () => {
+    expect(seedLaneDirection('street-generated-stencil', '', 'none')).toBe('');
+    expect(seedLaneDirection('street-generated-stencil', '', undefined)).toBe(
+      ''
+    );
+  });
+
+  it('does nothing for generators without their own direction property', () => {
+    expect(seedLaneDirection('street-generated-striping', '', 'inbound')).toBe(
+      ''
+    );
+    expect(seedLaneDirection('street-generated-rail', '', 'inbound')).toBe('');
+    expect(
+      seedLaneDirection('street-generated-pedestrians', '', 'inbound')
+    ).toBe('');
+    expect(seedLaneDirection('street-generated-grass', '', 'inbound')).toBe('');
+  });
+});


### PR DESCRIPTION
Fixes #1959.

## Problem

Adding a **Stencils** (or **Clones**) component to an existing segment via the Add Component dropdown created it with the schema default `direction: none` (fixed absolute orientation), so:

1. the stencil rendered outbound-facing even on an inbound lane, and
2. it was permanently skipped by segment direction propagation — flipping the segment's inbound/outbound direction never rotated it.

Every other creation path (Streetmix/StreetPlan import, segment type change) seeds the segment's direction into the generated component; the manual add flow was the one path that didn't.

## Changes

- **Seed direction at add time** — new pure helper `seedLaneDirection` (`src/editor/lib/segmentPanel.js`), used by `AddGeneratorComponent.addComponent`: adding `street-generated-stencil` / `street-generated-clones` to a lane initializes the component with the segment's current `inbound`/`outbound` direction. Deliberate no-ops: directionless lanes (sidewalks), non-segment hosts (approved-list mode), generators without a `direction` property, and approved-list `attrValue` seeds that already set a direction.
- Clarified the `direction: none` semantics in the stencil schema comment (issue's optional point 3).

The panel deliberately does **not** expose the generator's own direction (it would duplicate the segment Direction row), and blanket-propagating segment direction to `none` components is intentionally **not** done — it would flip side-oriented clones (angled parking, benches) that rely on the skip; a regression test locks that in.

## Tests

- `test/editor/seedLaneDirection.test.js` — 8 unit tests for the seeding rules.
- `test/components/street-generated-stencil.test.js` — browser tests reproducing the issue's table: a direction-seeded stencil renders at 180° on an inbound lane, follows a segment flip to 0°, and a `direction: none` stencil holds its absolute facing through a flip.

All suites green locally: 1104 vitest (jsdom) + 248 mocha + 84 browser component tests; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKGrMPK9hSCMTuU11Xsch2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKGrMPK9hSCMTuU11Xsch2)_