### PR TITLE
Migrate cloud-scene links from hash to path URLs (/scenes/UUID)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ The cloud URL lives in `gltf-model` / `src`. Firebase Storage download tokens al
 - React → A-Frame: `entity.setAttribute()` or `AFRAME.INSPECTOR.execute()`
 - A-Frame → React: `Events.emit()` or `useStore.setState()`
 
-**URL Hash Schemes:** Streetmix URL, StreetPlan URL, Cloud UUID (`#scenes/...`), Managed Street JSON
+**URL Schemes:** Cloud scenes use path URLs (`/scenes/UUID`, server-visible for unfurls/SEO — #1970; legacy `#/scenes/` hash links load forever and self-upgrade via `history.replaceState`; helpers in `src/tested/scene-url-utils.js`). App-state deep links stay hash-based: Streetmix URL, StreetPlan URL, Managed Street JSON, `#asset:`, `#mcp`
 
 **File Naming:** A-Frame: `kebab-case.js`, React: `PascalCase.js/jsx`, Styles: `.module.scss`
 

--- a/index.html
+++ b/index.html
@@ -31,12 +31,13 @@
   <script src="/dist/aframe-street-component.js"></script>
   <title>3DStreet</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" type="image/x-icon" href="ui_assets/favicon.ico">
+  <!-- Root-absolute so the document also works served at /scenes/UUID (#1970) -->
+  <link rel="icon" type="image/x-icon" href="/ui_assets/favicon.ico">
   <link rel="stylesheet" href="/dist/viewer-styles.css">
 </head>
 
 <body>
-  <img id="screenshot-img" src="ui_assets/3DStreet-Viewer-Start-Editor.svg" alt="Invisible Image" style="display:none;">
+  <img id="screenshot-img" src="/ui_assets/3DStreet-Viewer-Start-Editor.svg" alt="Invisible Image" style="display:none;">
   <!-- loading animation start -->
   <div class="loader__wrapper">
     <div class="loader">

--- a/public/functions/replicate.js
+++ b/public/functions/replicate.js
@@ -53,7 +53,7 @@ async function postAIImageToDiscord(userId, imageUrl, prompt, modelName, sceneId
     const truncatedPrompt = prompt.length > 200 ? prompt.substring(0, 200) + '...' : prompt;
 
     // Construct scene URL if sceneId is provided
-    const sceneUrl = sceneId ? `https://3dstreet.app/#scenes/${sceneId}` : null;
+    const sceneUrl = sceneId ? `https://3dstreet.app/scenes/${sceneId}` : null;
 
     // Determine footer text based on source parameter
     // Default to 'editor' for backwards compatibility
@@ -118,7 +118,7 @@ async function postAIVideoToDiscord(userId, videoUrl, prompt, modelName, duratio
     const truncatedPrompt = prompt.length > 200 ? prompt.substring(0, 200) + '...' : prompt;
 
     // Construct scene URL if sceneId is provided
-    const sceneUrl = sceneId ? `https://3dstreet.app/#scenes/${sceneId}` : null;
+    const sceneUrl = sceneId ? `https://3dstreet.app/scenes/${sceneId}` : null;
 
     // Create Discord message with video
     // Include video URL in description so Discord can auto-embed it

--- a/src/README.md
+++ b/src/README.md
@@ -135,7 +135,9 @@ I learned a few things:
 | `streetplan-url`      | StreetPlan API URL                                              | `https://3dstreet.app/#https://streetplan.net/3dstreet/89241`              |
 | `managed-street-json` | Managed Street JSON Blob                                        | `https://3dstreet.app/#managed-street-json:{"data":"value"}`               |
 | `cloud-uuid-legacy`   | 3DStreet Scene JSON Format from Cloud UUID with .json Extension | `https://3dstreet.app/#scenes/bc72ab26-891d-417b-a50f-0cf84621a54c.json`   |
-| `cloud-uuid`          | 3DStreet Scene JSON Format from Cloud UUID                      | `https://3dstreet.app/#scenes/bc72ab26-891d-417b-a50f-0cf84621a54c`        |
+| `cloud-uuid`          | 3DStreet Scene JSON Format from Cloud UUID (legacy hash form)   | `https://3dstreet.app/#/scenes/bc72ab26-891d-417b-a50f-0cf84621a54c`       |
+
+Cloud scene links are now written in path form — `https://3dstreet.app/scenes/bc72ab26-891d-417b-a50f-0cf84621a54c` — so the server sees which scene a link points to (social unfurls, SEO; issue #1970). The hash forms above keep loading forever and self-upgrade to the path form on arrival. Query params (`?viewer=true`, `?embed=true`, `?camera=…`) compose normally with the path form.
 
 ### More Notes
 

--- a/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/editor/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -12,6 +12,7 @@ import posthog from 'posthog-js';
 import useStore from '../../../../store.js';
 import { fileJSON } from '@/editor/lib/SceneUtils';
 import { commonMessages } from '@/editor/i18n/commonMessages';
+import { scenePath } from '@/tested/scene-url-utils.js';
 
 const SCENES_PER_PAGE = 20;
 // Static descriptors so formatjs can extract the tab labels (a dynamic
@@ -72,7 +73,7 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
         author: sceneData.author
       };
       localStorage.setItem('sceneData', JSON.stringify(fullData));
-      const newTabUrl = `#/scenes/${scene.id}`;
+      const newTabUrl = scenePath(scene.id);
       const newTab = window.open(newTabUrl, '_blank');
       newTab.focus();
     } else {
@@ -91,10 +92,8 @@ const ScenesModal = ({ initialTab = 'owner', delay = undefined }) => {
         })
       );
       createElementsForScenesFromJSON(sceneData.data, sceneData.memory);
-      // This runs in a click handler, not during render — the immutability rule
-      // can't see that and flags the global write as a false positive.
-      // eslint-disable-next-line react-hooks/immutability
-      window.location.hash = `#/scenes/${scene.id}`;
+      // Path-form scene URL without reloading (#1970)
+      window.history.pushState(null, '', scenePath(scene.id));
 
       const sceneId = scene.id;
       const sceneTitle = sceneData.title;

--- a/src/editor/components/modals/ShareModal/ShareModal.component.jsx
+++ b/src/editor/components/modals/ShareModal/ShareModal.component.jsx
@@ -15,6 +15,7 @@ import { getUserProfile } from '@shared/utils/username';
 import { Tooltip } from 'radix-ui';
 import { commonMessages } from '@/editor/i18n/commonMessages';
 import { formatLocationString } from '../../../../utils.js';
+import { scenePath } from '@/tested/scene-url-utils.js';
 
 const TooltipWrapper = ({ children, content, side = 'bottom', ...props }) => {
   return (
@@ -134,7 +135,8 @@ function ShareModal() {
   const getShareUrl = () => {
     const sceneId = STREET.utils.getCurrentSceneId();
     if (sceneId) {
-      return `https://3dstreet.app/#/scenes/${sceneId}`;
+      // Path form so pasted links unfurl per-scene (server-visible, #1970)
+      return `https://3dstreet.app${scenePath(sceneId)}`;
     }
     return window.location.href;
   };

--- a/src/editor/lib/SceneUtils.js
+++ b/src/editor/lib/SceneUtils.js
@@ -7,6 +7,7 @@ import {
 } from '@/editor/api/scene';
 import { createUniqueId } from '@/editor/lib/entity.js';
 import { getCurrentCameraState } from '@/editor/lib/cameraUtils.js';
+import { scenePath } from '@/tested/scene-url-utils.js';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@shared/services/firebase';
 
@@ -341,8 +342,9 @@ export async function saveScene(currentUser, doSaveAs, doPromptTitle) {
   AFRAME.scenes[0].setAttribute('metadata', 'sceneId', sceneId);
   AFRAME.scenes[0].setAttribute('metadata', 'authorId', currentUser.uid);
 
-  // Change the hash URL without reloading
-  window.location.hash = `#/scenes/${sceneId}`;
+  // Change the URL to the path form without reloading (#1970). The old
+  // #/scenes/ hash form still loads but is no longer written anywhere.
+  window.history.pushState(null, '', scenePath(sceneId));
   return sceneId;
 }
 

--- a/src/editor/lib/asset-modal-handlers.js
+++ b/src/editor/lib/asset-modal-handlers.js
@@ -11,13 +11,14 @@
 import * as Sentry from '@sentry/react';
 import Events from './Events';
 import { encodeCameraStateToParam } from './cameraUtils.js';
+import { scenePath } from '@/tested/scene-url-utils.js';
 
 /**
  * Take the user back to where a snapshot was captured (#1605). If the
  * snapshot belongs to the currently open scene, glide the camera to the
  * captured pose (event → the controls' focusCameraState, mirroring the
  * focus-on-entity pattern). Otherwise open the scene in a new tab — same as
- * the plain scene link — with the pose as a `?camera=` hash param that
+ * the plain scene link — with the pose as a `?camera=` query param that
  * set-loader-from-hash applies as the load fly-in target.
  */
 export const focusSnapshotScene = (item) => {
@@ -34,7 +35,7 @@ export const focusSnapshotScene = (item) => {
   const cameraSuffix = cameraParam
     ? `?camera=${encodeURIComponent(cameraParam)}`
     : '';
-  window.open(`/#/scenes/${sceneId}${cameraSuffix}`, '_blank');
+  window.open(`${scenePath(sceneId)}${cameraSuffix}`, '_blank');
 };
 
 export const openInGenerator = async (item, tabName) => {

--- a/src/editor/lib/cameraUtils.js
+++ b/src/editor/lib/cameraUtils.js
@@ -42,9 +42,9 @@ export function getCurrentCameraState() {
 }
 
 /**
- * Serialize a camera state into a compact URL-hash param value
+ * Serialize a camera state into a compact URL param value
  * (`px,py,pz,rx,ry,rz,fov`) for camera vantage deep links like
- * `#/scenes/UUID?camera=…`. Decoded by decodeCameraStateFromParam in
+ * `/scenes/UUID?camera=…`. Decoded by decodeCameraStateFromParam in
  * set-loader-from-hash. Rounded — cm position / ~0.006° rotation — to keep
  * the URL short; well beyond visual precision either way.
  * @param {Object} cameraState - Camera state with position, rotation, zoom

--- a/src/editor/lib/mcp/sceneTools.js
+++ b/src/editor/lib/mcp/sceneTools.js
@@ -18,11 +18,13 @@ import {
   createElementsForScenesFromJSON,
   saveSceneWithScreenshot
 } from '../SceneUtils.js';
+import { scenePath } from '@/tested/scene-url-utils.js';
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
 export function sceneUrlFor(sceneId) {
-  return `${window.location.origin}${window.location.pathname}#/scenes/${sceneId}`;
+  // Path form so the link is server-visible (social unfurls / OG tags, #1970)
+  return `${window.location.origin}${scenePath(sceneId)}`;
 }
 
 /**
@@ -88,11 +90,11 @@ async function loadSceneHandler(args) {
   const match = UUID_RE.exec(String(args?.sceneId || ''));
   if (!match) {
     throw new Error(
-      'sceneId must be a scene UUID (or a 3DStreet URL containing #/scenes/<uuid>)'
+      'sceneId must be a scene UUID (or a 3DStreet URL containing /scenes/<uuid>)'
     );
   }
   const sceneId = match[0].toLowerCase();
-  // Same endpoint the #/scenes/<id> hash loader fetches at startup
+  // Same endpoint the /scenes/<id> loader fetches at startup
   // (set-loader-from-hash in json-utils_1.1.js), including its localhost
   // rewrite to the dev deployment.
   const base = window.location.href.includes('localhost')
@@ -113,7 +115,7 @@ async function loadSceneHandler(args) {
   }
   useStore.getState().startLoadingScene('Loading scene from cloud...');
   createElementsForScenesFromJSON(json.data, json.memory);
-  window.location.hash = `#/scenes/${sceneId}`;
+  window.history.pushState(null, '', scenePath(sceneId));
   AFRAME.scenes[0].setAttribute('metadata', 'sceneId', sceneId);
   if (json.author) {
     AFRAME.scenes[0].setAttribute('metadata', 'authorId', json.author);
@@ -158,7 +160,7 @@ export const mcpSceneTools = [
         sceneId: {
           type: 'string',
           description:
-            'Scene UUID, or a 3DStreet URL containing #/scenes/<uuid>.'
+            'Scene UUID, or a 3DStreet URL containing /scenes/<uuid>.'
         }
       },
       required: ['sceneId']

--- a/src/json-utils_1.1.js
+++ b/src/json-utils_1.1.js
@@ -12,6 +12,12 @@ import {
 } from './tested/street-segment-utils';
 import { migrateMeasureLinesToShapes } from './tested/migrate-measure-lines';
 import { migrateImplicitStreetAlign } from './tested/migrate-street-align';
+import {
+  getSceneIdFromPathname,
+  getSceneIdFromHash,
+  scenePath,
+  upgradedSceneUrlFromHash
+} from './tested/scene-url-utils';
 
 /* global AFRAME, Node */
 // Components removed alongside the legacy viewer mode. Stripped from
@@ -28,10 +34,13 @@ window.STREET = {};
 var assetsUrl;
 STREET.utils = {};
 STREET.store = useStore;
-function getSceneUuidFromURLHash() {
-  const currentHash = window.location.hash;
-  const match = currentHash.match(/#\/scenes\/([a-zA-Z0-9-]+)/);
-  return match && match[1] ? match[1] : null;
+function getSceneUuidFromURL() {
+  // Path form (/scenes/UUID) is canonical; legacy hash form (#/scenes/UUID)
+  // is still honored forever (#1970).
+  return (
+    getSceneIdFromPathname(window.location.pathname) ||
+    getSceneIdFromHash(window.location.hash)
+  );
 }
 
 function getCurrentSceneId() {
@@ -40,7 +49,7 @@ function getCurrentSceneId() {
   const scene = AFRAME.scenes[0];
   let currentSceneId = scene?.getAttribute('metadata')?.sceneId;
   // console.log('currentSceneId from scene metadata', currentSceneId);
-  const urlSceneId = getSceneUuidFromURLHash();
+  const urlSceneId = getSceneUuidFromURL();
   // console.log('urlSceneId', urlSceneId);
   if (!currentSceneId) {
     // console.log('no currentSceneId from state');
@@ -803,22 +812,51 @@ AFRAME.registerComponent('set-loader-from-hash', {
     // using play instead of init method so scene loads before setting its metadata component
     if (!this.runOnce) {
       this.runOnce = true;
+      this.urlCameraState = null;
+      // Canonical path-form cloud scene URL: /scenes/UUID (#1970). Query
+      // params compose normally here, so the camera vantage deep link
+      // (#1605) is a real ?camera= query param.
+      const pathSceneId = getSceneIdFromPathname(window.location.pathname);
+      if (pathSceneId) {
+        this.urlCameraState = decodeCameraStateFromParam(
+          new URLSearchParams(window.location.search).get('camera')
+        );
+        useStore.getState().startLoadingScene('Loading scene...');
+        console.log(
+          '[set-loader-from-hash]',
+          'Load 3DStreet scene from path URL',
+          pathSceneId
+        );
+        this.fetchJSON(`${scenePath(pathSceneId)}.json`);
+        return;
+      }
       // get hash from window
       let streetURL = window.location.hash.substring(1);
       if (!streetURL) {
         return;
       }
+      // Legacy hash scene link (#/scenes/UUID or #scenes/UUID.json,
+      // optionally ?camera=… inside the hash). Old links in Discord/docs/
+      // emails must keep working forever; they self-upgrade to the path form
+      // so a copied URL is the server-visible one (#1970). Gated on the
+      // prefix so a JSON-blob hash that merely mentions a scene URL can't
+      // rewrite the address bar.
+      if (streetURL.startsWith('/scenes/') || streetURL.startsWith('scenes/')) {
+        const upgradedURL = upgradedSceneUrlFromHash(window.location);
+        if (upgradedURL) {
+          window.history.replaceState(null, '', upgradedURL);
+        }
+      }
       // Camera vantage deep link: #/scenes/UUID?camera=px,py,pz,rx,ry,rz,fov
       // (e.g. snapshot gallery "open scene at capture pose", #1605). Strip
       // the param before the path is used to build the fetch URL; the decoded
       // pose overrides the scene's default snapshot camera in fetchJSON.
-      this.urlCameraState = null;
       if (streetURL.startsWith('/scenes/') && streetURL.includes('?')) {
-        const [scenePath, queryString] = streetURL.split('?');
+        const [hashScenePath, queryString] = streetURL.split('?');
         this.urlCameraState = decodeCameraStateFromParam(
           new URLSearchParams(queryString).get('camera')
         );
-        streetURL = scenePath;
+        streetURL = hashScenePath;
       }
       // `#mcp` (with optional `=PORT`) is the MCP relay auto-pair URL —
       // handled by AIChatPanel, not the scene loader. Without this bail,
@@ -1017,7 +1055,11 @@ AFRAME.registerComponent('set-loader-from-hash', {
               });
 
               // Clear the hash to avoid "URI Too Long" errors in auth
-              window.location.hash = '';
+              window.history.replaceState(
+                null,
+                '',
+                window.location.pathname + window.location.search
+              );
 
               // Open Geo Modal
               setModal('geo');

--- a/src/shared/assets/components/AssetsModal.jsx
+++ b/src/shared/assets/components/AssetsModal.jsx
@@ -142,9 +142,9 @@ const AssetsModal = ({
       ? { aspectRatio: `${width} / ${height}`, width: `${width}px` }
       : undefined;
 
-  // Generate scene URL for linking back to the editor
+  // Generate scene URL for linking back to the editor (path form, #1970)
   const sceneUrl = sceneId
-    ? `${window.location.origin}/#/scenes/${sceneId}`
+    ? `${window.location.origin}/scenes/${sceneId}`
     : null;
 
   const handleDelete = (e) => {

--- a/src/store.js
+++ b/src/store.js
@@ -9,11 +9,14 @@ import { resolveInitialLocale, persistLocale } from './editor/i18n/config';
 
 const firstModal = () => {
   const hash = window.location.hash;
+  // A path-form scene URL (/scenes/UUID, #1970) is a deep link like the old
+  // hash form: the scene is loading, so no intro modal.
+  const isSceneDeepLink = window.location.pathname.startsWith('/scenes/');
   let modal = hash.includes('payment')
     ? 'payment'
     : hash.includes('profile') || hash.includes('/modal/profile')
       ? 'profile'
-      : !hash.length
+      : !hash.length && !isSceneDeepLink
         ? 'new'
         : null;
   const isStreetMix = hash.includes('streetmix');

--- a/src/street-utils.js
+++ b/src/street-utils.js
@@ -1,6 +1,7 @@
 /* global AFRAME */
 /* 3DStreet utils functions */
 import useStore from '@/store.js';
+import { clearedSceneUrl } from '@/tested/scene-url-utils.js';
 
 /*
  * create element with provided Id, clear old element data and replace with new HTML string
@@ -68,10 +69,11 @@ export function newScene(clearMetaData = true, clearUrlHash = true) {
     AFRAME.scenes[0].setAttribute('metadata', 'authorId', '');
   }
 
-  // clear url hash
+  // clear url hash, and reset a path-form scene URL (/scenes/UUID) back to
+  // root (#1970)
   if (clearUrlHash) {
     setTimeout(function () {
-      window.location.hash = '';
+      window.history.replaceState(null, '', clearedSceneUrl(window.location));
     });
   }
 }

--- a/src/tested/scene-url-utils.js
+++ b/src/tested/scene-url-utils.js
@@ -1,0 +1,104 @@
+/**
+ * Cloud-scene URL helpers (#1970).
+ *
+ * Cloud scene links are path-based (`/scenes/UUID`) so the server sees which
+ * scene a link points to (social unfurls, SEO, per-scene OG tags). The legacy
+ * hash form (`#/scenes/UUID`, with an optional `?camera=` inside the hash)
+ * must keep working forever — old links live in Discord/docs/emails — and
+ * self-upgrades to the path form on arrival via history.replaceState.
+ *
+ * Pure string functions only (no window access) so they stay unit-testable:
+ * test/core/scene-url-utils.test.js.
+ */
+
+const UUID_PATTERN =
+  '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+// Bare scene path only — `/scenes/UUID.json` is the getScene data endpoint
+// (firebase.json rewrite), not an app URL, so `.json` must not match.
+const SCENE_PATHNAME_RE = new RegExp(`^/scenes/(${UUID_PATTERN})/?$`, 'i');
+
+// Tolerant hash match: `#/scenes/UUID` (or the older `#scenes/UUID.json`
+// form) anywhere in the hash, with anything (e.g. `?camera=…`, `.json`)
+// after the id.
+const SCENE_HASH_RE = new RegExp(`#/?scenes/(${UUID_PATTERN})`, 'i');
+
+/**
+ * @param {string} pathname - window.location.pathname
+ * @returns {string|null} lowercase scene UUID, or null
+ */
+function getSceneIdFromPathname(pathname) {
+  const match = (pathname || '').match(SCENE_PATHNAME_RE);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * @param {string} hash - window.location.hash (leading '#' included)
+ * @returns {string|null} lowercase scene UUID, or null
+ */
+function getSceneIdFromHash(hash) {
+  const match = (hash || '').match(SCENE_HASH_RE);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * Canonical app URL path for a cloud scene.
+ * @param {string} sceneId
+ * @returns {string} `/scenes/<sceneId>`
+ */
+function scenePath(sceneId) {
+  return `/scenes/${sceneId}`;
+}
+
+/**
+ * Upgrade a legacy hash scene URL to the canonical path form, for
+ * history.replaceState on boot. Query params written before the hash
+ * (`?embed=true#/scenes/UUID`) are preserved, and a `?camera=` param carried
+ * inside the hash (`#/scenes/UUID?camera=…`) is folded into the real query
+ * string (hash wins if both exist).
+ *
+ * @param {{ search: string, hash: string }} parts - window.location parts
+ * @returns {string|null} path + query (no origin), or null when the hash is
+ *   not a scene link
+ */
+function upgradedSceneUrlFromHash({ search, hash }) {
+  const sceneId = getSceneIdFromHash(hash);
+  if (!sceneId) {
+    return null;
+  }
+  const params = new URLSearchParams(search || '');
+  const hashQueryIndex = (hash || '').indexOf('?');
+  if (hashQueryIndex !== -1) {
+    const hashParams = new URLSearchParams(hash.substring(hashQueryIndex + 1));
+    const camera = hashParams.get('camera');
+    if (camera) {
+      params.set('camera', camera);
+    }
+  }
+  const query = params.toString();
+  return scenePath(sceneId) + (query ? `?${query}` : '');
+}
+
+/**
+ * URL to restore on "new scene": root path (resets a `/scenes/UUID` path the
+ * same way clearing the hash reset the old links), keeping unrelated query
+ * params (`?viewer=`, `?embed=`, …) but dropping `?camera=` — a camera
+ * vantage belongs to the scene link it arrived on.
+ *
+ * @param {{ search: string }} parts - window.location parts
+ * @returns {string} path + query (no origin)
+ */
+function clearedSceneUrl({ search }) {
+  const params = new URLSearchParams(search || '');
+  params.delete('camera');
+  const query = params.toString();
+  return '/' + (query ? `?${query}` : '');
+}
+
+export {
+  getSceneIdFromPathname,
+  getSceneIdFromHash,
+  scenePath,
+  upgradedSceneUrlFromHash,
+  clearedSceneUrl
+};

--- a/test/core/scene-url-utils.test.js
+++ b/test/core/scene-url-utils.test.js
@@ -1,0 +1,127 @@
+/* global describe, it */
+
+import assert from 'assert';
+import {
+  getSceneIdFromPathname,
+  getSceneIdFromHash,
+  scenePath,
+  upgradedSceneUrlFromHash,
+  clearedSceneUrl
+} from '../../src/tested/scene-url-utils.js';
+
+const UUID = 'bc72ab26-891d-417b-a50f-0cf84621a54c';
+
+describe('scene-url-utils', function () {
+  describe('#getSceneIdFromPathname()', function () {
+    it('parses /scenes/UUID', function () {
+      assert.strictEqual(getSceneIdFromPathname(`/scenes/${UUID}`), UUID);
+    });
+    it('tolerates a trailing slash', function () {
+      assert.strictEqual(getSceneIdFromPathname(`/scenes/${UUID}/`), UUID);
+    });
+    it('lowercases an uppercase UUID', function () {
+      assert.strictEqual(
+        getSceneIdFromPathname(`/scenes/${UUID.toUpperCase()}`),
+        UUID
+      );
+    });
+    it('does not match the .json data endpoint', function () {
+      assert.strictEqual(getSceneIdFromPathname(`/scenes/${UUID}.json`), null);
+    });
+    it('does not match a non-UUID id', function () {
+      assert.strictEqual(getSceneIdFromPathname('/scenes/hello-world'), null);
+    });
+    it('does not match root or other paths', function () {
+      assert.strictEqual(getSceneIdFromPathname('/'), null);
+      assert.strictEqual(getSceneIdFromPathname(`/gallery/${UUID}`), null);
+      assert.strictEqual(getSceneIdFromPathname(''), null);
+      assert.strictEqual(getSceneIdFromPathname(undefined), null);
+    });
+  });
+
+  describe('#getSceneIdFromHash()', function () {
+    it('parses #/scenes/UUID', function () {
+      assert.strictEqual(getSceneIdFromHash(`#/scenes/${UUID}`), UUID);
+    });
+    it('parses with a ?camera= query inside the hash', function () {
+      assert.strictEqual(
+        getSceneIdFromHash(`#/scenes/${UUID}?camera=1,2,3,0,0,0,45`),
+        UUID
+      );
+    });
+    it('parses the legacy .json hash forms', function () {
+      // https://3dstreet.app/#scenes/UUID.json (cloud-uuid-legacy)
+      assert.strictEqual(getSceneIdFromHash(`#scenes/${UUID}.json`), UUID);
+      assert.strictEqual(getSceneIdFromHash(`#/scenes/${UUID}.json`), UUID);
+    });
+    it('ignores non-scene hashes', function () {
+      assert.strictEqual(getSceneIdFromHash('#mcp'), null);
+      assert.strictEqual(getSceneIdFromHash('#asset:owner/id'), null);
+      assert.strictEqual(getSceneIdFromHash(''), null);
+      assert.strictEqual(getSceneIdFromHash(undefined), null);
+    });
+  });
+
+  describe('#scenePath()', function () {
+    it('builds the canonical path', function () {
+      assert.strictEqual(scenePath(UUID), `/scenes/${UUID}`);
+    });
+  });
+
+  describe('#upgradedSceneUrlFromHash()', function () {
+    it('upgrades a plain hash link to the path form', function () {
+      assert.strictEqual(
+        upgradedSceneUrlFromHash({ search: '', hash: `#/scenes/${UUID}` }),
+        `/scenes/${UUID}`
+      );
+    });
+    it('preserves query params written before the hash', function () {
+      assert.strictEqual(
+        upgradedSceneUrlFromHash({
+          search: '?embed=true',
+          hash: `#/scenes/${UUID}`
+        }),
+        `/scenes/${UUID}?embed=true`
+      );
+    });
+    it('folds a ?camera= param inside the hash into the query string', function () {
+      const url = upgradedSceneUrlFromHash({
+        search: '?viewer=true',
+        hash: `#/scenes/${UUID}?camera=1,2,3,0,0,0,45`
+      });
+      const [path, query] = url.split('?');
+      const params = new URLSearchParams(query);
+      assert.strictEqual(path, `/scenes/${UUID}`);
+      assert.strictEqual(params.get('viewer'), 'true');
+      assert.strictEqual(params.get('camera'), '1,2,3,0,0,0,45');
+    });
+    it('returns null for a non-scene hash', function () {
+      assert.strictEqual(
+        upgradedSceneUrlFromHash({ search: '', hash: '#mcp' }),
+        null
+      );
+      assert.strictEqual(
+        upgradedSceneUrlFromHash({ search: '?embed=true', hash: '' }),
+        null
+      );
+    });
+  });
+
+  describe('#clearedSceneUrl()', function () {
+    it('resets to root with no params', function () {
+      assert.strictEqual(clearedSceneUrl({ search: '' }), '/');
+    });
+    it('keeps unrelated query params', function () {
+      assert.strictEqual(
+        clearedSceneUrl({ search: '?viewer=true' }),
+        '/?viewer=true'
+      );
+    });
+    it('drops the scene-specific camera param', function () {
+      assert.strictEqual(
+        clearedSceneUrl({ search: '?viewer=true&camera=1,2,3,0,0,0,45' }),
+        '/?viewer=true'
+      );
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,9 @@ const config = {
   devServer: {
     liveReload: false,
     allowedHosts: 'all',
+    // Serve index.html for path-form scene URLs (/scenes/UUID, #1970) —
+    // mirrors the `** → /index.html` rewrite in public/firebase.json.
+    historyApiFallback: true,
     static: [
       {
         directory: '.',


### PR DESCRIPTION
Implements Phase 1 of #1970: cloud scene links are now written in path form (`3dstreet.app/scenes/UUID`) so the server sees which scene a link points to — the prerequisite for per-scene social unfurls and SEO. Legacy hash links keep working forever and self-upgrade on arrival.

## Load side

- `set-loader-from-hash` (`src/json-utils_1.1.js`) now checks `location.pathname` first: `/scenes/UUID` loads the scene with `?camera=` read as a real query param, so `?viewer=`, `?embed=` and `?camera=` compose normally.
- **Permanent hash fallback:** `#/scenes/UUID` (and the older `#scenes/UUID.json`) still load, and self-upgrade to the path form via `history.replaceState` — folding a `?camera=` carried *inside* the hash into the real query string, and preserving params written before the hash (`?embed=true#/scenes/UUID`). The upgrade is gated on the `scenes/` hash prefix so a JSON-blob hash that merely mentions a scene URL can't rewrite the address bar.
- `STREET.utils.getCurrentSceneId()` reads the UUID from either form.
- The intro-modal heuristic in `src/store.js` treats a `/scenes/` path like a hash deep link — without this, path URLs showed the "new scene" modal over the loading scene.

## Write side (all emit path URLs now)

- Save flow (`SceneUtils.js`) and ScenesModal open — `history.pushState`; ScenesModal ctrl-click new tab
- MCP `sceneTools.js` (`sceneUrlFor` + `loadScene`)
- ShareModal `getShareUrl`
- Snapshot "open scene at capture pose" links (`asset-modal-handlers.js`) — `?camera=` is a real query param
- AssetsModal scene link, and the Discord embed links in `public/functions/replicate.js`
- "New scene" resets a `/scenes/` path back to `/`, keeping unrelated query params but dropping `?camera=` (scene-specific); the geojson-hash clear also switched to `replaceState`

## Plumbing

- New pure helper module `src/tested/scene-url-utils.js` (parse pathname/hash, build canonical path, upgrade/clear URLs) with unit tests in `test/core/scene-url-utils.test.js` (18 cases).
- `webpack.config.js`: `historyApiFallback: true` so the dev server serves the app at `/scenes/UUID` (prod already does via the `** → /index.html` rewrite in `firebase.json` — no hosting config changes needed for Phase 1).
- `index.html`: the two relative asset references (favicon, screenshot placeholder) are now root-absolute so the document also works when served at `/scenes/UUID`.
- Docs: `src/README.md` URL-scheme table + `CLAUDE.md` updated.

## Out of scope

Phase 2 (per-scene OG-tag Cloud Function, where the `firebase.json` rewrite gets added) is a follow-up — see the rollout-plan comment below. Other hash schemes (`#managed-street-json:`, `#asset:`, Streetmix/StreetPlan URLs, `#mcp`) intentionally stay hash-based per the issue.

## Testing

- `test:core` 305 passing (incl. 18 new scene-url-utils cases), `test:modern` 1115 passing, lint + prettier clean, production webpack build compiles.
- **Runtime-verified in a real browser** (headless Chromium + Playwright driving the webpack dev server, scene JSON stubbed): 12/12 checks pass —
  - `/scenes/UUID?camera=…` loads the scene, URL stays path form, `?camera=` decoded from the query string, no intro modal over the deep link, scene title applied
  - `#/scenes/UUID` loads and self-upgrades to `/scenes/UUID` (hash cleared)
  - `?viewer=true#/scenes/UUID?camera=…` upgrades to `/scenes/UUID?viewer=true&camera=…` with the pose decoded
  - "new scene" resets the path back to `/`
  - plain root boot still shows the intro modal; `#mcp` is untouched and fetches no scene
- `test:components` fails in this container on a pre-existing Playwright browser-runner error (fails identically on a clean checkout — unrelated to this change).
- Still worth a hands-on pass for signed-in flows (save writing the path URL, Share modal) on local/staging before merging.

Closes #1970 (Phase 1; Phase 2 tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKEoWp9YMdm4q9sKTUak9b