### PR TITLE
Add meshopt simplify to GLB optimization, fix thumbnail capture transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "jspdf": "^4.2.1",
         "jszip": "^3.10.1",
         "lodash-es": "^4.17.23",
+        "meshoptimizer": "^1.2.0",
         "nanoid": "^5.1.6",
         "pbf": "^5.1.2",
         "posthog-js": "^1.356.1",
@@ -19660,6 +19661,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.2.0.tgz",
+      "integrity": "sha512-davRZeIJbxJrE24cwQle7ZDsxjdk/OphNOV83oX+efQinyoHY9Jcyz3MHbaoG0qySZajldGztNZ1RN/T19PZsg==",
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jspdf": "^4.2.1",
     "jszip": "^3.10.1",
     "lodash-es": "^4.17.23",
+    "meshoptimizer": "^1.2.0",
     "nanoid": "^5.1.6",
     "pbf": "^5.1.2",
     "posthog-js": "^1.356.1",

--- a/public/model-viewer-screenshot.html
+++ b/public/model-viewer-screenshot.html
@@ -34,6 +34,7 @@
          resulting blob as the asset thumbnail. Same stabilisation pattern
          as @shopify/screenshot-glb: poster-dismissed → 3× rAF →
          modelViewer.toBlob(). -->
+
     <model-viewer
       id="mv"
       loading="eager"
@@ -87,26 +88,11 @@
         const data = e.data;
         if (!data || typeof data !== 'object') return;
         if (data.type !== '3dstreet:load-blob') return;
-        // Prefer the blob-URL form: parent does URL.createObjectURL on its
-        // side and posts the (tiny) URL string. Avoids structuredClone of
-        // 10-50 MB of bytes that postMessage(blob) would do. fetch() works
-        // because the parent's blob URL is reachable from the same-origin
-        // iframe; we then create our own blob URL scoped to this document.
-        // The old { blob } payload is still accepted in case a deployed
-        // copy of this HTML is cached and a newer parent talks to it.
-        if (data.url) {
-          fetch(data.url)
-            .then((r) => r.blob())
-            .then(loadFromBlob)
-            .catch((err) => {
-              post({
-                type: '3dstreet:screenshot-error',
-                error: 'failed to fetch blob url: ' + err
-              });
-            });
-        } else if (data.blob) {
-          loadFromBlob(data.blob);
-        }
+        // Structured clone hands over a handle to the same blob (no byte
+        // copy). Deliberately NOT a blob: URL for us to fetch() — that form
+        // failed with "TypeError: Failed to fetch" under memory pressure at
+        // sizes as small as ~12 MB. See captureThumbnail.js.
+        loadFromBlob(data.blob);
       });
 
       mv.addEventListener('error', (e) => {

--- a/public/model-viewer-screenshot.html
+++ b/public/model-viewer-screenshot.html
@@ -85,6 +85,11 @@
       }
 
       window.addEventListener('message', (e) => {
+        // Only the embedder drives this page, and it is same-origin. Not a
+        // security boundary: the page renders whatever GLB it is handed and
+        // posts the thumbnail back to that same window, so the worst a
+        // stray sender achieves is a screenshot of its own model.
+        if (e.source !== window.parent) return;
         const data = e.data;
         if (!data || typeof data !== 'object') return;
         if (data.type !== '3dstreet:load-blob') return;

--- a/src/shared/asset-upload/analyzeGltf.js
+++ b/src/shared/asset-upload/analyzeGltf.js
@@ -22,8 +22,7 @@
  */
 
 import { formatSharedMessage } from '../i18n/sharedMessages';
-
-const GLB_MAGIC = 0x46546c67; // 'glTF' little-endian
+import { hasGlbMagic } from './glbMagic.js';
 
 export function isGltfJsonFile(file) {
   return (file?.name || '').toLowerCase().endsWith('.gltf');
@@ -71,7 +70,7 @@ export async function analyzeGltfFile(file) {
     return { status: 'invalid', externalRefs: [] };
   }
   const view = new DataView(buffer);
-  if (view.byteLength >= 4 && view.getUint32(0, true) === GLB_MAGIC) {
+  if (hasGlbMagic(view)) {
     return { status: 'binary', externalRefs: [] };
   }
   let json;

--- a/src/shared/asset-upload/captureThumbnail.js
+++ b/src/shared/asset-upload/captureThumbnail.js
@@ -14,6 +14,16 @@
  * to model-viewer. No network round-trip — the editor and generator flows
  * used to ask the iframe to re-download the cloud URL (10s of MB of
  * needless bandwidth) just to render one frame.
+ *
+ * We post the Blob itself rather than a blob: URL for the iframe to
+ * fetch(). That URL hop was a real source of failures: `fetch()` on a
+ * blob URL returns "TypeError: Failed to fetch" under memory pressure,
+ * reproducibly and at sizes as small as ~12 MB, while postMessage of the
+ * same Blob succeeded every time (measured up to 113 MB, in 144ms).
+ * Structured-cloning a Blob does NOT copy the bytes — Chrome passes a
+ * handle to the browser-process blob store — so this is also one less
+ * full copy than fetch() + r.blob(), which built a second blob in the
+ * iframe.
  */
 
 import { assetsService, STORAGE_PATHS } from '@shared/assets';
@@ -28,7 +38,7 @@ const READY_TIMEOUT_MS = 5000;
  * @param {object} [opts]
  * @param {number} [opts.width=512]
  * @param {number} [opts.height=512]
- * @param {number} [opts.timeout=30000] - ms before rejecting.
+ * @param {number} [opts.timeout=15000] - ms before rejecting.
  * @returns {Promise<Blob>} JPEG thumbnail blob.
  */
 export function captureGlbThumbnail(
@@ -64,19 +74,10 @@ export function captureGlbThumbnail(
 
     let settled = false;
     let blobPosted = false;
-    // Object URL pointing at glbBlob, lazily created when the iframe asks
-    // for the bytes. Cheaper to pass to the iframe than postMessage(blob),
-    // which structuredClones the full bytes (a 50 MB GLB = 50 MB copy in
-    // parent + 50 MB copy in iframe). Revoked unconditionally in cleanup().
-    let glbObjectUrl = null;
     const cleanup = () => {
       window.removeEventListener('message', onMessage);
       clearTimeout(timer);
       clearTimeout(readyTimer);
-      if (glbObjectUrl) {
-        URL.revokeObjectURL(glbObjectUrl);
-        glbObjectUrl = null;
-      }
       if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
     };
     const onMessage = (e) => {
@@ -84,13 +85,12 @@ export function captureGlbThumbnail(
       const data = e.data;
       if (!data || typeof data !== 'object') return;
       if (data.type === '3dstreet:screenshot-ready') {
-        // Iframe is wired up and listening, hand it the URL.
+        // Iframe is wired up and listening, hand it the bytes.
         if (!blobPosted) {
           blobPosted = true;
           clearTimeout(readyTimer);
-          glbObjectUrl = URL.createObjectURL(glbBlob);
           iframe.contentWindow.postMessage(
-            { type: '3dstreet:load-blob', url: glbObjectUrl },
+            { type: '3dstreet:load-blob', blob: glbBlob },
             '*'
           );
         }

--- a/src/shared/asset-upload/extractGlbAttribution.js
+++ b/src/shared/asset-upload/extractGlbAttribution.js
@@ -33,13 +33,13 @@
  * and then drops it.
  */
 
-const GLB_MAGIC = 0x46546c67; // 'glTF' little-endian
+import { hasGlbMagic } from './glbMagic.js';
+
 const CHUNK_JSON = 0x4e4f534a; // 'JSON' little-endian
 
 function readGlbJsonChunk(buffer) {
   const view = new DataView(buffer);
-  const magic = view.byteLength >= 4 ? view.getUint32(0, true) : 0;
-  if (magic !== GLB_MAGIC) {
+  if (!hasGlbMagic(view)) {
     // Not GLB binary — self-contained .gltf uploads pass their JSON straight
     // through here. Throws on non-JSON input, caught by the caller.
     return JSON.parse(new TextDecoder().decode(buffer));

--- a/src/shared/asset-upload/glbMagic.js
+++ b/src/shared/asset-upload/glbMagic.js
@@ -1,0 +1,21 @@
+/**
+ * The GLB container's magic number, shared by everything in the upload
+ * path that has to tell binary GLB from self-contained .gltf JSON:
+ * optimizeGlb.worker.js, extractGlbAttribution.js, analyzeGltf.js.
+ *
+ * Deliberately dependency-free — optimizeGlb.worker.js imports it, and
+ * the worker bundle shouldn't drag main-thread modules along for a
+ * four-byte check.
+ */
+
+/** First four bytes of every GLB: 'glTF', little-endian. */
+export const GLB_MAGIC = 0x46546c67;
+
+/**
+ * @param {DataView} view - Positioned at the start of the file.
+ * @returns {boolean} true when the buffer opens with the GLB magic. A
+ *   buffer too short to hold it is simply not a GLB, not an error.
+ */
+export function hasGlbMagic(view) {
+  return view.byteLength >= 4 && view.getUint32(0, true) === GLB_MAGIC;
+}

--- a/src/shared/asset-upload/optimizeGlb.js
+++ b/src/shared/asset-upload/optimizeGlb.js
@@ -1,14 +1,12 @@
 /**
  * Client-side GLB optimization, runs in a Web Worker.
  *
- * The heavy gltf-transform pipeline (dedup → instance → flatten → join →
- * weld → resample → prune → sparse → palette → textureCompress(webp) →
- * draco(edgebreaker)) lives in
- * optimizeGlb.worker.js. This file is the main-thread shim: it spawns the
- * worker, transfers the bytes in zero-copy, and races the result against
- * a wall-clock timeout. On timeout / abort / worker error we
- * `worker.terminate()` and return the original File so the upload still
- * proceeds, server-side compression catches what we gave up on.
+ * Main-thread shim: spawns the worker, transfers the bytes in zero-copy,
+ * and races the result against a wall-clock timeout. On timeout / abort /
+ * worker error we `worker.terminate()` and return the original File so the
+ * upload still proceeds, server-side compression catches what we gave up
+ * on. The pipeline itself, and the message protocol, are documented in
+ * optimizeGlb.worker.js.
  *
  * Why a worker:
  *   - gltf-transform's transform() is a single main-thread monolith. With
@@ -21,18 +19,35 @@
  * (uploadAsset.js, uploadAndPlaceAsset.js) don't change:
  *   { blob, metadata: { optimizationSkipped, reason?, inputBytes,
  *                       outputBytes, hadDraco?, hadWebP? } }
- *
- * `draco3dgltf` is a Node-only module (it imports `fs`); the webpack
- * resolve.fallback in the parent config handles the static-analysis
- * shim for the worker bundle too.
  */
 
-const DEFAULT_TIMEOUT_MS = 15000;
+/**
+ * Wall-clock budget for everything that happens worker-side, because the
+ * timer starts with the postMessage below and only the result stops it:
+ *
+ *   1. worker bundle + the lazy dep chunks (@gltf-transform/core,
+ *      /extensions, /functions, draco3dgltf, meshoptimizer/simplifier)
+ *   2. WASM instantiation — Draco decoder + encoder, meshopt simplifier.
+ *      Each optimizeGlb() call spawns a fresh Worker, so this is paid on
+ *      every upload, not once per session
+ *   3. readBinary() parsing the GLB into a gltf-transform Document
+ *   4. all 12 transform steps (simplify and textureCompress dominate on
+ *      dense/heavily-textured models; draco scales with the post-simplify
+ *      triangle count)
+ *   5. writeBinary() and the transfer back
+ *
+ * Reading the File into an ArrayBuffer happens before the timer starts and
+ * is not counted. Raised 15s → 30s: a real 113 MB photogrammetry GLB
+ * measured 9.4s on a fast machine, which left far too little headroom —
+ * a slower CPU or a cold dep/WASM load pushed past 15s and silently fell
+ * back to the unoptimized original.
+ */
+const DEFAULT_TIMEOUT_MS = 30000;
 
 /**
  * @param {File|Blob} file - Source GLB.
  * @param {object} [opts]
- * @param {number} [opts.timeoutMs=15000] - Worker is terminated if it
+ * @param {number} [opts.timeoutMs=30000] - Worker is terminated if it
  *   hasn't returned in this many ms; original file is used instead.
  * @param {AbortSignal} [opts.signal] - Same: terminates and falls back.
  * @returns {Promise<{ blob: Blob, metadata: object }>}

--- a/src/shared/asset-upload/optimizeGlb.worker.js
+++ b/src/shared/asset-upload/optimizeGlb.worker.js
@@ -1,9 +1,13 @@
 /**
  * Web Worker that runs the gltf-transform optimization pipeline off the
- * main thread. The main-thread shim in optimizeGlb.js races this worker
- * against a wall-clock timeout and `worker.terminate()`s on bail, so the
- * editor stays responsive even for photogrammetry GLBs that take many
- * seconds to Draco-encode.
+ * main thread:
+ *
+ *   dedup → instance → flatten → join → weld → simplify(meshopt) →
+ *   resample → prune → sparse → palette → textureCompress(webp) →
+ *   draco(edgebreaker)
+ *
+ * simplify() is the only lossy step. optimizeGlb.js is the main-thread
+ * shim that owns the timeout and the fall-back-to-original contract.
  *
  * Protocol:
  *   parent → worker: { type: 'optimize', bytes: ArrayBuffer }  (transferred)
@@ -20,12 +24,13 @@
  * applies to worker bundles too.
  */
 
-const GLB_MAGIC = 0x46546c67; // 'glTF' little-endian
+import { hasGlbMagic } from './glbMagic.js';
 
 function isGlbBytes(bytes) {
   if (bytes.byteLength < 4) return false;
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  return view.getUint32(0, true) === GLB_MAGIC;
+  return hasGlbMagic(
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  );
 }
 
 let depsPromise = null;
@@ -33,12 +38,15 @@ let depsPromise = null;
 async function loadDeps() {
   if (!depsPromise) {
     depsPromise = (async () => {
-      const [core, extensions, functions, draco3d] = await Promise.all([
-        import('@gltf-transform/core'),
-        import('@gltf-transform/extensions'),
-        import('@gltf-transform/functions'),
-        import('draco3dgltf')
-      ]);
+      const [core, extensions, functions, draco3d, meshopt] = await Promise.all(
+        [
+          import('@gltf-transform/core'),
+          import('@gltf-transform/extensions'),
+          import('@gltf-transform/functions'),
+          import('draco3dgltf'),
+          import('meshoptimizer/simplifier')
+        ]
+      );
       const draco3dDefault = draco3d.default || draco3d;
       // Draco's Emscripten loader resolves its .wasm via locateFile.
       // In a worker the default resolution lands at a path the dev
@@ -56,7 +64,8 @@ async function loadDeps() {
         ALL_EXTENSIONS: extensions.ALL_EXTENSIONS,
         functions,
         decoderModule,
-        encoderModule
+        encoderModule,
+        MeshoptSimplifier: meshopt.MeshoptSimplifier
       };
     })();
   }
@@ -65,12 +74,19 @@ async function loadDeps() {
 
 async function optimize(originalBytes) {
   const inputBytes = originalBytes.byteLength;
-  const { WebIO, ALL_EXTENSIONS, functions, decoderModule, encoderModule } =
-    await loadDeps();
+  const {
+    WebIO,
+    ALL_EXTENSIONS,
+    functions,
+    decoderModule,
+    encoderModule,
+    MeshoptSimplifier
+  } = await loadDeps();
   const {
     dedup,
     instance,
     weld,
+    simplify,
     resample,
     prune,
     sparse,
@@ -126,6 +142,7 @@ async function optimize(originalBytes) {
     flatten(),
     join(),
     weld(),
+    simplify({ simplifier: MeshoptSimplifier, ratio: 0, error: 0.001 }),
     resample(),
     prune(),
     sparse(),

--- a/test/shared/asset-upload/captureThumbnail.test.js
+++ b/test/shared/asset-upload/captureThumbnail.test.js
@@ -1,0 +1,59 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { captureGlbThumbnail } from '../../../src/shared/asset-upload/captureThumbnail.js';
+
+vi.mock('@shared/assets', () => ({
+  assetsService: { uploadToStorage: vi.fn(), updateAsset: vi.fn() },
+  STORAGE_PATHS: { assetFile: vi.fn() }
+}));
+
+function fakeGlb(size) {
+  const blob = new Blob([new Uint8Array(8)], { type: 'model/gltf-binary' });
+  Object.defineProperty(blob, 'size', { value: size });
+  return blob;
+}
+
+describe('captureGlbThumbnail', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('rejects non-Blob input', async () => {
+    await expect(captureGlbThumbnail('not-a-blob')).rejects.toThrow(
+      'expected Blob'
+    );
+  });
+
+  it('attempts capture regardless of size', () => {
+    // No size bail-out: a large GLB gets the same iframe as a small one.
+    captureGlbThumbnail(fakeGlb(113 * 1000 * 1000));
+    expect(document.querySelector('iframe')).not.toBeNull();
+  });
+
+  it('posts the Blob itself, never a blob: URL', () => {
+    // The URL hop is what failed under memory pressure ("TypeError: Failed
+    // to fetch"), so the payload shape is the fix and worth pinning.
+    const createObjectURL = vi.fn(() => 'blob:should-not-be-used');
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL: vi.fn() });
+    const glb = fakeGlb(1024);
+    captureGlbThumbnail(glb);
+    const iframe = document.querySelector('iframe');
+    const postMessage = vi.fn();
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: { postMessage },
+      configurable: true
+    });
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: { type: '3dstreet:screenshot-ready' }
+      })
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: '3dstreet:load-blob', blob: glb },
+      '*'
+    );
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/test/shared/asset-upload/captureThumbnail.test.js
+++ b/test/shared/asset-upload/captureThumbnail.test.js
@@ -12,6 +12,27 @@ function fakeGlb(size) {
   return blob;
 }
 
+/**
+ * Start a capture against a stubbed iframe. Every test must drive the
+ * returned promise to settlement (`send` a screenshot-blob or -error),
+ * otherwise the 5s ready timer and 15s capture timer outlive the test and
+ * reject with nobody listening.
+ */
+function startCapture(glbBlob) {
+  const promise = captureGlbThumbnail(glbBlob);
+  const iframe = document.querySelector('iframe');
+  const postMessage = vi.fn();
+  Object.defineProperty(iframe, 'contentWindow', {
+    value: { postMessage },
+    configurable: true
+  });
+  const send = (data) =>
+    window.dispatchEvent(
+      new MessageEvent('message', { source: iframe.contentWindow, data })
+    );
+  return { promise, iframe, postMessage, send };
+}
+
 describe('captureGlbThumbnail', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -25,35 +46,49 @@ describe('captureGlbThumbnail', () => {
     );
   });
 
-  it('attempts capture regardless of size', () => {
-    // No size bail-out: a large GLB gets the same iframe as a small one.
-    captureGlbThumbnail(fakeGlb(113 * 1000 * 1000));
-    expect(document.querySelector('iframe')).not.toBeNull();
+  it('resolves with the captured JPEG and tears the iframe down', async () => {
+    const jpeg = new Blob(['jpeg'], { type: 'image/jpeg' });
+    const { promise, iframe, send } = startCapture(fakeGlb(1024));
+    send({ type: '3dstreet:screenshot-ready' });
+    send({ type: '3dstreet:screenshot-blob', blob: jpeg });
+    await expect(promise).resolves.toBe(jpeg);
+    expect(iframe.parentNode).toBeNull();
   });
 
-  it('posts the Blob itself, never a blob: URL', () => {
+  it('rejects when the iframe reports an error', async () => {
+    const { promise, send } = startCapture(fakeGlb(1024));
+    send({ type: '3dstreet:screenshot-ready' });
+    send({ type: '3dstreet:screenshot-error', error: 'model load failed' });
+    await expect(promise).rejects.toThrow('model load failed');
+  });
+
+  it('attempts capture regardless of size', async () => {
+    // No size bail-out: a large GLB gets the same iframe as a small one.
+    const jpeg = new Blob(['jpeg'], { type: 'image/jpeg' });
+    const { promise, iframe, send } = startCapture(fakeGlb(113 * 1000 * 1000));
+    expect(iframe).not.toBeNull();
+    send({ type: '3dstreet:screenshot-ready' });
+    send({ type: '3dstreet:screenshot-blob', blob: jpeg });
+    await promise;
+  });
+
+  it('posts the Blob itself, never a blob: URL', async () => {
     // The URL hop is what failed under memory pressure ("TypeError: Failed
     // to fetch"), so the payload shape is the fix and worth pinning.
     const createObjectURL = vi.fn(() => 'blob:should-not-be-used');
     vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL: vi.fn() });
     const glb = fakeGlb(1024);
-    captureGlbThumbnail(glb);
-    const iframe = document.querySelector('iframe');
-    const postMessage = vi.fn();
-    Object.defineProperty(iframe, 'contentWindow', {
-      value: { postMessage },
-      configurable: true
-    });
-    window.dispatchEvent(
-      new MessageEvent('message', {
-        source: iframe.contentWindow,
-        data: { type: '3dstreet:screenshot-ready' }
-      })
-    );
+    const { promise, postMessage, send } = startCapture(glb);
+    send({ type: '3dstreet:screenshot-ready' });
     expect(postMessage).toHaveBeenCalledWith(
       { type: '3dstreet:load-blob', blob: glb },
       '*'
     );
     expect(createObjectURL).not.toHaveBeenCalled();
+    send({
+      type: '3dstreet:screenshot-blob',
+      blob: new Blob(['jpeg'], { type: 'image/jpeg' })
+    });
+    await promise;
   });
 });


### PR DESCRIPTION
This fixes #1978

## Summary

Two independent changes to the user asset upload path, plus cleanup.

### Optimization pipeline

- **Add `simplify()`** (meshoptimizer, `ratio: 0`, `error: 0.001`) after `weld()`. It is the only lossy step in the pipeline: it decimates as far as the 0.1% error bound allows, so dense scans collapse hard while clean low-poly models come out untouched. Verified against the real pipeline: a 3M-triangle test sphere → 8.8k triangles, a 12-triangle cube → unchanged.
- Adds the `meshoptimizer` dependency, imported from its `/simplifier` subpath so the worker bundle skips the encoder, decoder, clusterizer and tangents. Its WASM is inlined as base64, so unlike `draco3dgltf` there is nothing to copy next to the worker bundle and no `locateFile` to fix up. It lands in lazy chunks (~47 KB), not the main bundle.
- **Raise the worker timeout 15s → 30s.** A real 113 MB photogrammetry GLB measured 9.4s on a fast machine, leaving too little headroom — a slower CPU or a cold dep/WASM load blew past 15s and silently fell back to the unoptimized original. The docblock now enumerates what the budget actually covers (dep chunks, WASM instantiation paid per upload since every call spawns a fresh Worker, parse, all 12 steps, writeBinary).

### Thumbnail capture

Fixes `[asset-upload] thumbnail capture failed Error: failed to fetch blob url: TypeError: Failed to fetch`, reported on a 113 MB GLB.

The screenshot iframe was handed a `blob:` URL to `fetch()`. That fetch fails under memory pressure — reproduced in Chrome at 11.6 MB, the exact size of the reporter's optimized blob, while XHR on the *same* URL succeeded. It is not the iframe boundary (same-document `fetch` fails identically) and not a blob-store quota.

The parent now **postMessages the Blob** instead. Structured-cloning a Blob passes a handle to the browser-process blob store rather than copying bytes, so it is also one full copy fewer than `fetch()` + `r.blob()`. Measured: 11.6 MB in 20ms, 113 MB in 144ms, where the URL form failed at both sizes. The iframe already supported this payload — it was sitting there as the legacy branch. The now-unreachable `{ url }` branch is removed.

Confirmed fixed by the reporter on the original 113 MB file.

### Cleanup

- Split the near-duplicate module JSDoc so the worker owns the pipeline and message protocol while the shim owns the timeout and fallback contract.
- Consolidate `GLB_MAGIC` into `glbMagic.js`. It was declared in three modules, each having grown its own slightly different short-buffer guard.
- Correct an out-of-date default in the thumbnail JSDoc (`timeout` documented as `30000`, actual `DEFAULT_TIMEOUT_MS` is `15000`). This is a doc-code sync fix in a different file, not a reduction of the worker timeout this PR raises.

## Test plan

- [x] `npm run dist` compiles (only pre-existing sass deprecation warnings); main bundle 4.12 MiB against the 4.25 MiB budget
- [x] `npm run test:modern` — 238 shared tests pass, including a new `captureThumbnail.test.js` pinning that we post the Blob and never call `createObjectURL`
- [x] `npm run lint` clean
- [x] Pipeline exercised end-to-end in Node against generated meshes (triangle counts and timings above)
- [x] Reporter confirmed a thumbnail is now produced for the 113 MB GLB that previously failed

## Notes for review

- `simplify()` is **lossy** and applies to every GLB upload — this is the first step in the pipeline that permanently discards geometry from the served asset. The original bytes are still uploaded and kept (`storageUrl`); only the served `optimizedSourceUrl` is decimated. There is no per-asset opt-out today.
- There is deliberately no size bail-out on thumbnail capture: if a model is too heavy to render, the existing capture timeout bails and tears down the iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX7nmScX4dNpFbfh7b42TZ
