### PR TITLE
Unify upload stage copy across pending card and properties panel

### DIFF
--- a/src/editor/components/elements/AssetInfoPanel.jsx
+++ b/src/editor/components/elements/AssetInfoPanel.jsx
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import posthog from 'posthog-js';
 import useAssetUploadStatus, {
   STATUS_LABELS,
-  REASON_TEXT
+  REASON_TEXT,
+  CANCELLABLE_STATUSES,
+  getStatusText
 } from './useAssetUploadStatus';
+import { useSharedMessages } from '@shared/i18n/sharedMessages.js';
 import useAssetUploadStore from '@/editor/state/assetUploadStore.js';
 import useCurrentUploadStore from '@shared/assets/state/currentUploadStore.js';
 import { uploadAndPlaceAsset } from '@/editor/lib/asset-upload/uploadAndPlaceAsset.js';
@@ -29,6 +32,7 @@ const formatStorage = () =>
 
 const AssetInfoPanel = ({ entity }) => {
   const intl = useIntl();
+  const t = useSharedMessages();
   const state = useAssetUploadStatus(entity);
   const [detailsOpen, setDetailsOpen] = useState(false);
   if (!state) return null;
@@ -61,10 +65,10 @@ const AssetInfoPanel = ({ entity }) => {
     useStore.getState().startCheckout('storage');
   };
 
+  // The percentage rides inside the stage label ("Uploading 42%") so this
+  // panel and the gallery's pending card read identically.
   let detail = '';
-  if (state.status === 'uploading' && state.progress > 0) {
-    detail = `${state.progress}%`;
-  } else if (
+  if (
     (state.status === 'uploaded' ||
       state.status === 'local' ||
       state.status === 'local_error') &&
@@ -99,9 +103,9 @@ const AssetInfoPanel = ({ entity }) => {
             display: 'inline-block'
           }}
         />
-        <strong style={{ color: meta.color }}>{meta.text}</strong>
+        <strong style={{ color: meta.color }}>{getStatusText(t, state)}</strong>
         {detail && <span style={{ opacity: 0.7 }}>· {detail}</span>}
-        {(state.status === 'uploading' || state.status === 'optimizing') && (
+        {CANCELLABLE_STATUSES.has(state.status) && (
           <button
             type="button"
             onClick={() => useCurrentUploadStore.getState().cancel()}

--- a/src/editor/components/elements/AssetInfoPanel.jsx
+++ b/src/editor/components/elements/AssetInfoPanel.jsx
@@ -5,9 +5,9 @@ import posthog from 'posthog-js';
 import useAssetUploadStatus, {
   STATUS_LABELS,
   REASON_TEXT,
-  CANCELLABLE_STATUSES,
   getStatusText
 } from './useAssetUploadStatus';
+import { CANCELLABLE_UPLOAD_STAGES } from '@shared/assets/uploadStageLabels.js';
 import { useSharedMessages } from '@shared/i18n/sharedMessages.js';
 import useAssetUploadStore from '@/editor/state/assetUploadStore.js';
 import useCurrentUploadStore from '@shared/assets/state/currentUploadStore.js';
@@ -105,7 +105,7 @@ const AssetInfoPanel = ({ entity }) => {
         />
         <strong style={{ color: meta.color }}>{getStatusText(t, state)}</strong>
         {detail && <span style={{ opacity: 0.7 }}>· {detail}</span>}
-        {CANCELLABLE_STATUSES.has(state.status) && (
+        {CANCELLABLE_UPLOAD_STAGES.has(state.status) && (
           <button
             type="button"
             onClick={() => useCurrentUploadStore.getState().cancel()}

--- a/src/editor/components/elements/AssetUploadDot.jsx
+++ b/src/editor/components/elements/AssetUploadDot.jsx
@@ -1,18 +1,18 @@
 import PropTypes from 'prop-types';
 import useAssetUploadStatus, {
   STATUS_LABELS,
-  REASON_TEXT
+  REASON_TEXT,
+  getStatusText
 } from './useAssetUploadStatus';
+import { useSharedMessages } from '@shared/i18n/sharedMessages.js';
 
 const AssetUploadDot = ({ entity }) => {
+  const t = useSharedMessages();
   const state = useAssetUploadStatus(entity);
   if (!state) return null;
   const meta = STATUS_LABELS[state.status] || STATUS_LABELS.uploaded;
   const reasonText = state.reason ? REASON_TEXT[state.reason] : null;
-  const baseTitle =
-    state.status === 'uploading' && state.progress > 0
-      ? `Uploading ${state.progress}%`
-      : meta.text;
+  const baseTitle = getStatusText(t, state);
   const title = reasonText ? `${baseTitle} — ${reasonText}` : baseTitle;
   return (
     <span

--- a/src/editor/components/elements/AssetUploadDot.jsx
+++ b/src/editor/components/elements/AssetUploadDot.jsx
@@ -6,27 +6,29 @@ import useAssetUploadStatus, {
 } from './useAssetUploadStatus';
 import { useSharedMessages } from '@shared/i18n/sharedMessages.js';
 
+// Only states that need attention get a dot: in-flight (amber) and
+// failed/missing (red). A synced cloud asset or a plain local preview is the
+// normal case and shows nothing, so the scene graph stays quiet.
+const QUIET_STATUSES = new Set(['uploaded', 'local']);
+
+/**
+ * Corner badge on the entity's scene-graph icon. Rendered inside
+ * `.entityIcons` (position: relative) and pinned to its upper right.
+ */
 const AssetUploadDot = ({ entity }) => {
   const t = useSharedMessages();
   const state = useAssetUploadStatus(entity);
-  if (!state) return null;
+  if (!state || QUIET_STATUSES.has(state.status)) return null;
   const meta = STATUS_LABELS[state.status] || STATUS_LABELS.uploaded;
   const reasonText = state.reason ? REASON_TEXT[state.reason] : null;
   const baseTitle = getStatusText(t, state);
   const title = reasonText ? `${baseTitle} — ${reasonText}` : baseTitle;
   return (
     <span
+      className="assetStatusDot"
       title={title}
       aria-label={title}
-      style={{
-        display: 'inline-block',
-        width: 7,
-        height: 7,
-        borderRadius: '50%',
-        background: meta.color,
-        marginLeft: 4,
-        flexShrink: 0
-      }}
+      style={{ background: meta.color }}
     />
   );
 };

--- a/src/editor/components/elements/useAssetUploadStatus.js
+++ b/src/editor/components/elements/useAssetUploadStatus.js
@@ -1,7 +1,10 @@
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import { auth } from '@shared/services/firebase.js';
 import useAssetUploadStore from '@/editor/state/assetUploadStore.js';
-import { getUploadStageLabel } from '@shared/assets/uploadStageLabels.js';
+import {
+  CANCELLABLE_UPLOAD_STAGES,
+  getUploadStageLabel
+} from '@shared/assets/uploadStageLabels.js';
 
 // `text` here is the fallback for states the shared stage table does not
 // cover. For in-flight stages use getStatusText() below, which reads the
@@ -40,13 +43,6 @@ export const REASON_TEXT = {
 };
 
 const PERSISTENT_ATTRS = ['data-asset-id', 'data-asset-owner-uid'];
-
-/** In-flight stages that may be cancelled from the properties panel. */
-export const CANCELLABLE_STATUSES = new Set([
-  'validating',
-  'optimizing',
-  'uploading'
-]);
 
 /**
  * User-facing text for a status from useAssetUploadStatus(): the shared
@@ -140,7 +136,7 @@ export default function useAssetUploadStatus(entity) {
 
   // While offline mid-upload, the Firebase SDK silently retries. Surface that
   // so the user doesn't think a frozen "Uploading 42%" means we're stuck.
-  if (!isOnline && CANCELLABLE_STATUSES.has(status)) {
+  if (!isOnline && CANCELLABLE_UPLOAD_STAGES.has(status)) {
     status = 'waiting';
   }
 

--- a/src/editor/components/elements/useAssetUploadStatus.js
+++ b/src/editor/components/elements/useAssetUploadStatus.js
@@ -1,10 +1,16 @@
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import { auth } from '@shared/services/firebase.js';
 import useAssetUploadStore from '@/editor/state/assetUploadStore.js';
+import { getUploadStageLabel } from '@shared/assets/uploadStageLabels.js';
 
+// `text` here is the fallback for states the shared stage table does not
+// cover. For in-flight stages use getStatusText() below, which reads the
+// same table as the gallery's pending card so both surfaces agree (#1989).
 export const STATUS_LABELS = {
-  optimizing: { color: '#f4a01a', text: 'Optimizing GLB…' },
+  validating: { color: '#f4a01a', text: 'Preparing…' },
+  optimizing: { color: '#f4a01a', text: 'Optimizing…' },
   uploading: { color: '#f4a01a', text: 'Uploading' },
+  finishing: { color: '#f4a01a', text: 'Finishing…' },
   uploaded: { color: '#2bb673', text: 'Cloud asset' },
   failed: { color: '#e0473d', text: 'Upload failed' },
   local: { color: '#7f7f7f', text: 'Temporary local preview' },
@@ -34,6 +40,24 @@ export const REASON_TEXT = {
 };
 
 const PERSISTENT_ATTRS = ['data-asset-id', 'data-asset-owner-uid'];
+
+/** In-flight stages that may be cancelled from the properties panel. */
+export const CANCELLABLE_STATUSES = new Set([
+  'validating',
+  'optimizing',
+  'uploading'
+]);
+
+/**
+ * User-facing text for a status from useAssetUploadStatus(): the shared
+ * stage label (with byte-weighted percentage while uploading) for in-flight
+ * stages, else this module's own label.
+ * @param {(id: string, values?: object) => string} t - useSharedMessages()
+ */
+export function getStatusText(t, state) {
+  const meta = STATUS_LABELS[state.status] || STATUS_LABELS.uploaded;
+  return getUploadStageLabel(t, state.status, state.progress) || meta.text;
+}
 
 // Subscription glue for navigator.onLine. The SDK silently retries network
 // errors mid-upload (we cap that at 30s), so while we wait we surface
@@ -116,7 +140,7 @@ export default function useAssetUploadStatus(entity) {
 
   // While offline mid-upload, the Firebase SDK silently retries. Surface that
   // so the user doesn't think a frozen "Uploading 42%" means we're stuck.
-  if (!isOnline && (status === 'uploading' || status === 'optimizing')) {
+  if (!isOnline && CANCELLABLE_STATUSES.has(status)) {
     status = 'waiting';
   }
 

--- a/src/editor/components/scenegraph/Entity.jsx
+++ b/src/editor/components/scenegraph/Entity.jsx
@@ -6,7 +6,6 @@ import Events from '../../lib/Events';
 import { removeEntity, cloneEntity, getEntityBadges } from '../../lib/entity';
 import { defineMessages } from 'react-intl';
 import { AwesomeIcon } from '../elements/AwesomeIcon';
-import AssetUploadDot from '../elements/AssetUploadDot';
 import EntityContextMenu from './EntityContextMenu';
 import EntityLabel from './EntityLabel';
 import {
@@ -375,7 +374,6 @@ class Entity extends React.Component {
               forceEditing={isRenaming}
               onEditingEnd={() => this.props.setRenamingEntity(null)}
             />
-            <AssetUploadDot entity={entity} />
             {badgeBar}
           </span>
           <span className="entityActions">

--- a/src/editor/components/scenegraph/EntityLabel.jsx
+++ b/src/editor/components/scenegraph/EntityLabel.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { getEntityIcon, getEntityDisplayName } from '../../lib/entity';
 import useAssetUploadStatus from '../elements/useAssetUploadStatus';
+import AssetUploadDot from '../elements/AssetUploadDot';
 import InlineEditInput from '../elements/InlineEditInput';
 import { Edit24Icon } from '@shared/icons';
 import { commonMessages } from '@/editor/i18n/commonMessages';
@@ -76,10 +77,20 @@ const EntityLabel = ({
     });
   };
 
+  // Upload status rides on the icon as a corner badge (amber/red only; a
+  // synced asset shows nothing) so it never collides with the name or
+  // the trailing role badges.
+  const iconWithStatus = icon && (
+    <span className="entityIcons">
+      {icon}
+      <AssetUploadDot entity={entity} />
+    </span>
+  );
+
   if (canEdit && editing) {
     return (
       <span className="entityPrint">
-        {icon && <span className="entityIcons">{icon}</span>}
+        {iconWithStatus}
         <InlineEditInput
           className="entityNameInput"
           defaultValue={displayName}
@@ -99,7 +110,7 @@ const EntityLabel = ({
 
   return (
     <span className={`entityPrint${canEdit ? ' editable' : ''}`}>
-      {icon && <span className="entityIcons">{icon}</span>}
+      {iconWithStatus}
       {displayName && (
         <span
           className="entityName"

--- a/src/editor/lib/asset-upload/uploadAndPlaceAsset.js
+++ b/src/editor/lib/asset-upload/uploadAndPlaceAsset.js
@@ -344,7 +344,9 @@ export async function uploadAndPlaceAsset(file, position, existingEntity) {
   const { setUpload, clearUpload } = useAssetUploadStore.getState();
 
   setUpload(entityId, {
-    status: 'uploading',
+    // Nothing is moving yet — quota preflight and the model-load gate come
+    // first. The flow flips this to optimizing/uploading as bytes move.
+    status: 'validating',
     progress: 0,
     reason: null,
     sizeBytes: file.size,
@@ -571,6 +573,10 @@ export async function uploadAndPlaceAsset(file, position, existingEntity) {
     // (preload + entity swap). The pending card keeps showing progress
     // until we call clear() below — atomic swap, no overlap.
     currentUploadStore.markAwaiting(assetId);
+    // Bytes are up and the doc exists; what remains is preload (up to 12s)
+    // and the entity swap. Say so on the properties panel too, rather than
+    // leaving it on "Uploading 100%" while the card says Finishing (#1989).
+    setUpload(entityId, { status: 'finishing', progress: 100 });
 
     const asset = await assetsService.getAsset(assetId, userId);
     // Prefer the optimized GLB when available; fall back to the original source.

--- a/src/editor/state/assetUploadStore.js
+++ b/src/editor/state/assetUploadStore.js
@@ -4,7 +4,11 @@
  * Two slices:
  *   uploads — keyed by entity.id, holds in-flight upload state for an entity:
  *               { status, progress, sizeBytes, originalFilename }
- *             Status values: 'uploading' | 'optimizing' | 'failed' | 'local'.
+ *             Status values: the in-flight stages 'validating' |
+ *             'optimizing' | 'uploading' | 'finishing' (labelled by
+ *             shared/assets/uploadStageLabels.js, in step with
+ *             currentUploadStore), plus the entity-only outcomes 'failed' |
+ *             'local' | 'local_error'.
  *             Once an upload succeeds the entity gets data-asset-id +
  *             data-asset-owner-uid attrs and the in-flight slot can be cleared
  *             (the hook reads metadata from the assets cache instead).

--- a/src/editor/style/entity.scss
+++ b/src/editor/style/entity.scss
@@ -23,6 +23,7 @@
 }
 
 .entityIcons {
+  position: relative;
   display: flex;
   align-items: center;
   // make 80% size and darker color for the svg icons
@@ -30,6 +31,19 @@
     width: 16px;
     height: 16px;
   }
+}
+
+// Asset upload status, pinned to the icon's upper right (AssetUploadDot).
+// The ring separates it from the icon strokes beneath; color is inline.
+.assetStatusDot {
+  position: absolute;
+  top: -2px;
+  right: -3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1.5px variables.$darkgray-800;
+  pointer-events: auto;
 }
 
 .badge {

--- a/src/shared/assets/components/AssetsPanelBody.jsx
+++ b/src/shared/assets/components/AssetsPanelBody.jsx
@@ -25,6 +25,7 @@ import {
   FILE_PICKER_ACCEPT
 } from '@shared/asset-upload';
 import { useSharedMessages } from '@shared/i18n/sharedMessages';
+import { getUploadStageLabel } from '../uploadStageLabels.js';
 import styles from './AssetsPanelBody.module.scss';
 
 const FILTERS = [
@@ -96,7 +97,8 @@ const AssetsPanelBody = ({
   const sentinelRef = useRef(null);
   const [filter, setFilter] = useState('all');
   const usage = useStorageUsage(isLoggedIn);
-  const isUploading = useCurrentUploadStore((s) => !!s.upload);
+  const currentUpload = useCurrentUploadStore((s) => s.upload);
+  const isUploading = !!currentUpload;
 
   // Storage upsell state (#1644). The full-storage card's soft decline
   // ("free up space instead") hides it for this mount only — it returns next
@@ -242,7 +244,10 @@ const AssetsPanelBody = ({
             disabled={isUploading}
             title={isUploading ? t('uploadInProgress') : t('uploadAnAsset')}
           >
-            {isUploading ? t('uploading') : t('upload')}
+            {isUploading
+              ? // Stage only, no percentage: a button label should not tick.
+                getUploadStageLabel(t, currentUpload.status) || t('uploading')
+              : t('upload')}
           </button>
           <button
             type="button"

--- a/src/shared/assets/components/PendingUploadCard.jsx
+++ b/src/shared/assets/components/PendingUploadCard.jsx
@@ -10,25 +10,24 @@
 
 import { useCurrentUploadStore } from '@shared/assets';
 import { formatBytes } from '../utils.js';
+import { useSharedMessages } from '@shared/i18n/sharedMessages.js';
+import { getUploadStageLabel } from '../uploadStageLabels.js';
 import styles from './Assets.module.scss';
 
 const CANCELLABLE_STATUSES = new Set(['validating', 'optimizing', 'uploading']);
 
-const STATUS_LABELS = {
-  validating: 'Validating…',
-  optimizing: 'Optimizing…',
-  uploading: 'Uploading…',
-  thumbnailing: 'Finishing…',
-  finishing: 'Finishing…'
-};
-
 const PendingUploadCard = () => {
   const upload = useCurrentUploadStore((s) => s.upload);
   const cancel = useCurrentUploadStore((s) => s.cancel);
+  const t = useSharedMessages();
   if (!upload) return null;
 
-  const label = STATUS_LABELS[upload.status] || 'Uploading…';
   const pct = Math.max(0, Math.min(100, Math.round(upload.progress || 0)));
+  // Same table as the editor's properties panel, so both say the same thing
+  // at the same moment (#1989).
+  const label =
+    getUploadStageLabel(t, upload.status, upload.progress) ||
+    t('uploadStageUploading');
 
   return (
     <div className={styles.pendingCard} title={upload.filename}>

--- a/src/shared/assets/components/PendingUploadCard.jsx
+++ b/src/shared/assets/components/PendingUploadCard.jsx
@@ -11,10 +11,11 @@
 import { useCurrentUploadStore } from '@shared/assets';
 import { formatBytes } from '../utils.js';
 import { useSharedMessages } from '@shared/i18n/sharedMessages.js';
-import { getUploadStageLabel } from '../uploadStageLabels.js';
+import {
+  CANCELLABLE_UPLOAD_STAGES,
+  getUploadStageLabel
+} from '../uploadStageLabels.js';
 import styles from './Assets.module.scss';
-
-const CANCELLABLE_STATUSES = new Set(['validating', 'optimizing', 'uploading']);
 
 const PendingUploadCard = () => {
   const upload = useCurrentUploadStore((s) => s.upload);
@@ -52,7 +53,7 @@ const PendingUploadCard = () => {
             {formatBytes(upload.sizeBytes)}
           </div>
         )}
-        {CANCELLABLE_STATUSES.has(upload.status) && (
+        {CANCELLABLE_UPLOAD_STAGES.has(upload.status) && (
           <button
             type="button"
             className={styles.pendingCancelBtn}

--- a/src/shared/assets/services/assetsService.js
+++ b/src/shared/assets/services/assetsService.js
@@ -26,6 +26,7 @@ import {
   onSnapshot,
   serverTimestamp
 } from 'firebase/firestore';
+import { createAggregateProgress } from '../uploadProgress.js';
 import { ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
 import { db, storage } from '@shared/services/firebase.js';
 import {
@@ -214,19 +215,25 @@ class AssetsServiceV2 {
       // IMPORTANT: Upload to Storage FIRST before creating Firestore doc
       // This ensures no orphaned Firestore documents if upload fails.
       //
-      // Original and optimized uploads run in parallel. Progress events only
-      // track the original (primary) upload so the UI stays coherent.
+      // Original and optimized uploads run in parallel behind one progress
+      // bar, so progress is byte-weighted across both: 100% only once every
+      // byte of every file is up (#1989 — the original alone hit 100% while
+      // the optimized variant was still transferring).
+      const reportProgress = createAggregateProgress(
+        [blob.size, optimizedFile?.size || 0],
+        (progress) => {
+          this.events.dispatchEvent(
+            new CustomEvent('uploadProgress', {
+              detail: { assetId, progress }
+            })
+          );
+        }
+      );
       const uploadPromises = [
         this.uploadToStorage(
           blob,
           storagePath,
-          (progress) => {
-            this.events.dispatchEvent(
-              new CustomEvent('uploadProgress', {
-                detail: { assetId, progress }
-              })
-            );
-          },
+          (progress) => reportProgress(0, progress),
           signal,
           // Tag so storage-level audit scripts can distinguish quota-counted
           // originals from platform-derived optimized artifacts.
@@ -246,7 +253,7 @@ class AssetsServiceV2 {
           this.uploadToStorage(
             optimizedFile,
             optimizedStoragePath,
-            null,
+            (progress) => reportProgress(1, progress),
             signal,
             // assetRole: 'optimized' marks this file as a platform-derived
             // artifact; quota scripts should exclude it from user quota.

--- a/src/shared/assets/services/assetsService.js
+++ b/src/shared/assets/services/assetsService.js
@@ -267,6 +267,10 @@ class AssetsServiceV2 {
               err
             );
             optimizedStoragePath = null;
+            // The bar is byte-weighted across both files; count this one
+            // as finished (skipped) so aggregate progress can still reach
+            // 100 on its own rather than stalling at the original's share.
+            reportProgress(1, 100);
             return null;
           })
         );

--- a/src/shared/assets/uploadProgress.js
+++ b/src/shared/assets/uploadProgress.js
@@ -1,0 +1,26 @@
+/**
+ * Combine per-file upload progress into one percentage.
+ *
+ * addAsset() uploads the original and (for GLBs) the optimized variant in
+ * parallel, and the UI shows a single bar. Reporting only the original's
+ * progress meant "Uploading 100%" sat there while the optimized file was
+ * still going out — so the bar is byte-weighted across every file: 100%
+ * means every byte of every file has been transferred.
+ *
+ * @param {number[]} sizes - byte size of each file, in the order callers
+ *   will index into `report(i, pct)`.
+ * @param {(pct: number) => void} emit - receives the combined 0..100.
+ * @returns {(index: number, pct: number) => void} per-file reporter taking
+ *   that file's own 0..100.
+ */
+export function createAggregateProgress(sizes, emit) {
+  const total = sizes.reduce((sum, n) => sum + (Number(n) || 0), 0);
+  const transferred = sizes.map(() => 0);
+  return (index, pct) => {
+    const size = Number(sizes[index]) || 0;
+    const clamped = Math.max(0, Math.min(100, Number(pct) || 0));
+    transferred[index] = (clamped / 100) * size;
+    const done = transferred.reduce((sum, n) => sum + n, 0);
+    emit(total > 0 ? (done / total) * 100 : clamped);
+  };
+}

--- a/src/shared/assets/uploadStageLabels.js
+++ b/src/shared/assets/uploadStageLabels.js
@@ -1,0 +1,49 @@
+/**
+ * One stage→label mapping for every surface that shows an in-flight upload:
+ * the gallery's pending card, the assets panel Upload button, and the
+ * editor's properties panel / scene-graph dot. They used to keep their own
+ * tables and drifted ("Uploading 100%" on one, "Finishing…" on the other —
+ * #1989). Strings live in sharedMessages because the pending card also
+ * renders in the generator and bollardbuddy islands, where no IntlProvider
+ * is mounted.
+ *
+ * Stages are the `status` values written by uploadAsset() /
+ * uploadAndPlaceAsset() into currentUploadStore and the editor's per-entity
+ * upload slot:
+ *   validating   quota preflight, before any bytes move
+ *   optimizing   GLB pipeline in the worker (CPU-bound, up to 30s)
+ *   uploading    bytes moving; progress is byte-weighted across every file
+ *   thumbnailing / finishing   asset doc written; thumbnail upload, preload
+ *                and entity swap still running
+ */
+
+export const UPLOAD_STAGE_MESSAGE_IDS = {
+  validating: 'uploadStagePreparing',
+  optimizing: 'uploadStageOptimizing',
+  uploading: 'uploadStageUploading',
+  thumbnailing: 'uploadStageFinishing',
+  finishing: 'uploadStageFinishing'
+};
+
+export function isUploadStage(status) {
+  return Object.prototype.hasOwnProperty.call(UPLOAD_STAGE_MESSAGE_IDS, status);
+}
+
+/**
+ * @param {(id: string, values?: object) => string} t - a sharedMessages
+ *   formatter (useSharedMessages() or a bound formatSharedMessage).
+ * @param {string} status
+ * @param {number} [progress] - 0..100; only shown for `uploading`, and only
+ *   once it is above zero so a just-started upload reads "Uploading…" rather
+ *   than "Uploading 0%".
+ * @returns {string|null} null when `status` is not an in-flight stage.
+ */
+export function getUploadStageLabel(t, status, progress = 0) {
+  const id = UPLOAD_STAGE_MESSAGE_IDS[status];
+  if (!id) return null;
+  const pct = Math.max(0, Math.min(100, Math.round(Number(progress) || 0)));
+  if (status === 'uploading' && pct > 0) {
+    return t('uploadStageUploadingPct', { pct });
+  }
+  return t(id);
+}

--- a/src/shared/assets/uploadStageLabels.js
+++ b/src/shared/assets/uploadStageLabels.js
@@ -25,6 +25,19 @@ export const UPLOAD_STAGE_MESSAGE_IDS = {
   finishing: 'uploadStageFinishing'
 };
 
+/**
+ * Stages during which the user may still cancel: the AbortSignal from
+ * currentUploadStore is honoured by the optimizer and the Storage upload.
+ * Once the asset doc exists (thumbnailing / finishing) there is nothing
+ * left to abort. Single source for the pending card's Cancel button and the
+ * editor properties panel's.
+ */
+export const CANCELLABLE_UPLOAD_STAGES = new Set([
+  'validating',
+  'optimizing',
+  'uploading'
+]);
+
 export function isUploadStage(status) {
   return Object.prototype.hasOwnProperty.call(UPLOAD_STAGE_MESSAGE_IDS, status);
 }

--- a/src/shared/i18n/sharedMessages.js
+++ b/src/shared/i18n/sharedMessages.js
@@ -825,6 +825,39 @@ const SHARED_MESSAGES = {
     'pt-BR': 'Enviando…',
     fr: 'Téléversement…'
   },
+  // In-flight upload stages, shared by every surface that shows one (see
+  // shared/assets/uploadStageLabels.js). "Preparing" covers the quota
+  // preflight: nothing is moving yet, so it must not say Uploading.
+  uploadStagePreparing: {
+    en: 'Preparing…',
+    es: 'Preparando…',
+    'pt-BR': 'Preparando…',
+    fr: 'Préparation…'
+  },
+  uploadStageOptimizing: {
+    en: 'Optimizing…',
+    es: 'Optimizando…',
+    'pt-BR': 'Otimizando…',
+    fr: 'Optimisation…'
+  },
+  uploadStageUploading: {
+    en: 'Uploading…',
+    es: 'Subiendo…',
+    'pt-BR': 'Enviando…',
+    fr: 'Téléversement…'
+  },
+  uploadStageUploadingPct: {
+    en: 'Uploading {pct}%',
+    es: 'Subiendo {pct}%',
+    'pt-BR': 'Enviando {pct}%',
+    fr: 'Téléversement {pct}%'
+  },
+  uploadStageFinishing: {
+    en: 'Finishing…',
+    es: 'Finalizando…',
+    'pt-BR': 'Finalizando…',
+    fr: 'Finalisation…'
+  },
   uploadAnAsset: {
     en: 'Upload an asset',
     es: 'Subir un recurso',

--- a/test/shared/assets/uploadProgress.test.js
+++ b/test/shared/assets/uploadProgress.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createAggregateProgress } from '../../../src/shared/assets/uploadProgress.js';
+
+describe('createAggregateProgress', () => {
+  it('weights each file by its byte size', () => {
+    const emit = vi.fn();
+    const report = createAggregateProgress([100, 300], emit);
+    report(0, 100); // the small file finishes first
+    expect(emit).toHaveBeenLastCalledWith(25);
+    report(1, 50);
+    expect(emit).toHaveBeenLastCalledWith(62.5);
+    report(1, 100);
+    expect(emit).toHaveBeenLastCalledWith(100);
+  });
+
+  it('never reports 100 until every file is done (#1989)', () => {
+    const emit = vi.fn();
+    const report = createAggregateProgress([90_000_000, 10_000_000], emit);
+    report(0, 100);
+    expect(emit).toHaveBeenLastCalledWith(90);
+  });
+
+  it('ignores a zero-size slot (no optimized variant)', () => {
+    const emit = vi.fn();
+    const report = createAggregateProgress([500, 0], emit);
+    report(0, 40);
+    expect(emit).toHaveBeenLastCalledWith(40);
+  });
+
+  it('clamps out-of-range per-file values', () => {
+    const emit = vi.fn();
+    const report = createAggregateProgress([100, 100], emit);
+    report(0, 140);
+    report(1, -5);
+    expect(emit).toHaveBeenLastCalledWith(50);
+  });
+});

--- a/test/shared/assets/uploadStageLabels.test.js
+++ b/test/shared/assets/uploadStageLabels.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getUploadStageLabel,
+  isUploadStage,
+  UPLOAD_STAGE_MESSAGE_IDS
+} from '../../../src/shared/assets/uploadStageLabels.js';
+import { formatSharedMessage } from '../../../src/shared/i18n/sharedMessages.js';
+
+const t = (id, values) => formatSharedMessage(id, values, { locale: 'en' });
+
+describe('getUploadStageLabel', () => {
+  it('covers every stage the upload pipeline writes', () => {
+    for (const status of [
+      'validating',
+      'optimizing',
+      'uploading',
+      'thumbnailing',
+      'finishing'
+    ]) {
+      expect(isUploadStage(status)).toBe(true);
+      expect(getUploadStageLabel(t, status)).toBeTruthy();
+    }
+  });
+
+  it('never says Uploading before bytes move', () => {
+    expect(getUploadStageLabel(t, 'validating')).toBe('Preparing…');
+    expect(getUploadStageLabel(t, 'optimizing')).toBe('Optimizing…');
+  });
+
+  it('shows the percentage only while uploading and only above zero', () => {
+    expect(getUploadStageLabel(t, 'uploading', 0)).toBe('Uploading…');
+    expect(getUploadStageLabel(t, 'uploading', 42.4)).toBe('Uploading 42%');
+    expect(getUploadStageLabel(t, 'finishing', 100)).toBe('Finishing…');
+  });
+
+  it('reads Finishing on both post-doc stages so surfaces agree', () => {
+    expect(getUploadStageLabel(t, 'thumbnailing')).toBe(
+      getUploadStageLabel(t, 'finishing')
+    );
+  });
+
+  it('returns null for non-stage statuses', () => {
+    expect(isUploadStage('uploaded')).toBe(false);
+    expect(getUploadStageLabel(t, 'uploaded')).toBeNull();
+    expect(getUploadStageLabel(t, 'failed')).toBeNull();
+  });
+
+  it('maps every stage to a message id that exists', () => {
+    for (const id of Object.values(UPLOAD_STAGE_MESSAGE_IDS)) {
+      expect(t(id)).not.toBe(id);
+    }
+    expect(t('uploadStageUploadingPct', { pct: 7 })).not.toBe(
+      'uploadStageUploadingPct'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1989.

## Summary

Large GLB uploads looked stuck because the two upload surfaces kept their own status tables and drifted: the properties panel said "Uploading 100%" while the gallery's pending card said "Finishing…".

- **Byte-weighted progress.** `addAsset()` uploads the original and the optimized GLB in parallel behind one progress bar, but only the original reported progress. The bar now aggregates both by bytes (`createAggregateProgress`), so 100% means every byte of every file is up. The `uploadProgress` event contract is unchanged.
- **One stage→label table.** `shared/assets/uploadStageLabels.js` (strings in `sharedMessages`, en/es/pt-BR/fr, since the pending card also renders in the generator and bollardbuddy islands) drives the pending card, the assets panel Upload button, the properties panel and the scene-graph dot. The percentage rides inside the label ("Uploading 42%"), so both surfaces read identically.
- **Nothing says Uploading before bytes move.** The editor's per-entity slot starts as `validating` ("Preparing…") through quota preflight and the model-load gate. The Upload button shows the current stage (without a ticking percentage) instead of a blanket "Uploading…".
- **Finishing on both surfaces.** After the asset doc is written, the editor slot flips to `finishing`, matching the card, instead of lingering on "Uploading 100%" through the GLB preload and entity swap.

## Deviation from the issue

The issue proposed "Uploading original NN%" and "Uploading optimized…" as separate labels. Since the two files upload in parallel, a single byte-weighted percentage is the honest number; naming the file would imply a sequence that doesn't exist.

## Test plan

- [x] `npm run test:modern` — 1128 pass, incl. new `uploadProgress.test.js` and `uploadStageLabels.test.js`; the existing `sharedMessages` test enforces all four locales for the new ids
- [x] `npm run lint` clean, `npm run dist` clean
- [ ] Browser: drop a ~100 MB GLB in the editor and watch the properties panel and the pending card say the same stage throughout; confirm the bar doesn't hit 100% until the optimized upload finishes; confirm the Upload button reads Preparing…/Optimizing… before Uploading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANAecAtrr1TfnLEYNYmiYL
