### PR TITLE
Fix entity selection, autosave, and UI polish (#1992, #1994, #1999, #2000)

### DIFF
--- a/src/editor/components/elements/FocusHotspotSidebar.jsx
+++ b/src/editor/components/elements/FocusHotspotSidebar.jsx
@@ -1,6 +1,6 @@
 /* global AFRAME */
 import PropTypes from 'prop-types';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import PropertyRow from './PropertyRow';
 import { Button } from './Button';
@@ -29,16 +29,56 @@ export const FocusHotspotSectionControls = ({ entity }) => {
   const [, setUpdateTrigger] = useState(0);
   const componentName = 'focus-hotspot';
   const component = entity?.components?.[componentName];
-  // Local draft so typing doesn't spam the undo stack; committed on blur.
+  // Local draft so typing doesn't spam the undo stack; committed on blur
+  // and after a typing pause (#1998) — the commit is an entityupdate
+  // command, which is what the cloud autosave listens for, so a
+  // description edit left sitting in the textarea still autosaves.
   const [descriptionDraft, setDescriptionDraft] = useState(
     component?.data?.description ?? ''
   );
+
+  // Pending commit for the idle debounce. The entry carries its own entity
+  // so a flush from a cleanup (entity switch, unmount) writes to the
+  // entity the text was typed on, not whatever is selected by then.
+  const pendingCommitRef = useRef(null);
+  const commitTimerRef = useRef(null);
+  const COMMIT_IDLE_MS = 2000;
+
+  const flushPendingCommit = () => {
+    clearTimeout(commitTimerRef.current);
+    const pending = pendingCommitRef.current;
+    pendingCommitRef.current = null;
+    if (!pending) return;
+    const pendingComponent = pending.entity?.components?.[componentName];
+    if (!pendingComponent) return;
+    if (pending.value === (pendingComponent.data?.description ?? '')) return;
+    AFRAME.INSPECTOR.execute('entityupdate', {
+      entity: pending.entity,
+      component: componentName,
+      property: 'description',
+      value: pending.value
+    });
+  };
 
   useEffect(() => {
     setDescriptionDraft(
       entity?.components?.[componentName]?.data?.description ?? ''
     );
+    return flushPendingCommit;
   }, [entity]);
+
+  // The debounce leaves a short window where the typed text is not yet
+  // committed (and so not yet autosaved) — warn on tab close during it.
+  const isDirty = descriptionDraft !== (component?.data?.description ?? '');
+  useEffect(() => {
+    if (!isDirty) return;
+    const onBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [isDirty]);
 
   useEffect(() => {
     const onEntityUpdate = (detail) => {
@@ -56,14 +96,12 @@ export const FocusHotspotSectionControls = ({ entity }) => {
 
   if (!component || !component.schema || !component.data) return null;
 
-  const commitDescription = () => {
-    if (descriptionDraft === component.data.description) return;
-    AFRAME.INSPECTOR.execute('entityupdate', {
-      entity,
-      component: componentName,
-      property: 'description',
-      value: descriptionDraft
-    });
+  const onDescriptionChange = (e) => {
+    const value = e.target.value;
+    setDescriptionDraft(value);
+    pendingCommitRef.current = { entity, value };
+    clearTimeout(commitTimerRef.current);
+    commitTimerRef.current = setTimeout(flushPendingCommit, COMMIT_IDLE_MS);
   };
 
   return (
@@ -94,8 +132,8 @@ export const FocusHotspotSectionControls = ({ entity }) => {
           name="focusHotspotDescription"
           rows={5}
           value={descriptionDraft}
-          onChange={(e) => setDescriptionDraft(e.target.value)}
-          onBlur={commitDescription}
+          onChange={onDescriptionChange}
+          onBlur={flushPendingCommit}
           placeholder={intl.formatMessage({
             id: 'focusHotspot.descriptionPlaceholder',
             defaultMessage: 'Shown in the info panel when a visitor clicks…'

--- a/src/editor/components/elements/FocusHotspotSidebar.jsx
+++ b/src/editor/components/elements/FocusHotspotSidebar.jsx
@@ -56,7 +56,10 @@ export const FocusHotspotSectionControls = ({ entity }) => {
       entity: pending.entity,
       component: componentName,
       property: 'description',
-      value: pending.value
+      value: pending.value,
+      // A flush can run right after the user selects a different entity —
+      // don't let the command yank the selection back here.
+      noSelectEntity: true
     });
   };
 

--- a/src/editor/components/scenegraph/EntityContextMenu.jsx
+++ b/src/editor/components/scenegraph/EntityContextMenu.jsx
@@ -21,10 +21,10 @@ import { commonMessages } from '@/editor/i18n/commonMessages';
  * classes so both menus look identical, keyboard hints included.
  */
 const EntityContextMenu = ({ entity, onSelectEntity, onRename, children }) => {
-  // Cloud-asset entities are excluded from rename like in EntityLabel: their
-  // displayed name comes from the Firestore asset, so a data-layer-name
-  // rename would not be reflected.
-  const canRename = canRenameEntity(entity) && !entity.dataset.assetId;
+  // Cloud-asset entities rename like any other row: the rename writes a
+  // per-instance data-layer-name, which EntityLabel shows in place of the
+  // shared Firestore asset name (#2000).
+  const canRename = canRenameEntity(entity);
 
   const capture = (event) =>
     posthog.capture(event, { source: 'scenegraph_context_menu' });

--- a/src/editor/components/scenegraph/EntityLabel.jsx
+++ b/src/editor/components/scenegraph/EntityLabel.jsx
@@ -7,25 +7,27 @@ import InlineEditInput from '../elements/InlineEditInput';
 import { Edit24Icon } from '@shared/icons';
 import { commonMessages } from '@/editor/i18n/commonMessages';
 
+// No 'mesh' entry: 3D-model rows carry a distinct icon (#1999), so the
+// "glTF Model" type prefix would be redundant.
 const ASSET_TYPE_PREFIX_MESSAGES = {
-  mesh: { id: 'entity.assetTypeMesh', defaultMessage: 'glTF Model' },
   image: { id: 'entity.assetTypeImage', defaultMessage: 'Image' },
   video: { id: 'entity.assetTypeVideo', defaultMessage: 'Video' },
   splat: { id: 'entity.assetTypeSplat', defaultMessage: 'Splat' }
 };
 
 /**
- * Renders an entity's icon + display name. For entities backed by a cloud
- * asset (data-asset-id present), the asset `name` is used, prefixed with
- * a human-readable type label (e.g. "glTF Model • truck"). Other entities
- * fall back to the default lookup chain (data-layer-name → class → tag)
- * via getEntityDisplayName.
+ * Renders an entity's icon + display name. A user-set data-layer-name
+ * always wins — it names this one placement (#2000). Without one, entities
+ * backed by a cloud asset (data-asset-id present) show the asset `name`,
+ * prefixed with a human-readable type label for non-mesh types (e.g.
+ * "Image • logo"). Other entities fall back to the default lookup chain
+ * (class → tag) via getEntityDisplayName.
  *
  * With `editable`, hovering the name reveals a pencil and clicking edits it
  * in place: Enter (or blur) commits the rename through the undoable
- * entityupdate command, Escape reverts. Cloud-asset entities are excluded —
- * their displayed name comes from the Firestore asset, so a data-layer-name
- * rename would not be reflected.
+ * entityupdate command, Escape reverts. On an asset-backed entity the
+ * rename writes a per-instance data-layer-name; the shared Firestore asset
+ * keeps its own name.
  *
  * `forceEditing` puts the label into edit mode from the outside (the scene
  * graph's context menu Rename item) without the hover pencil affordance;
@@ -54,20 +56,25 @@ const EntityLabel = ({
   if (!entity) return null;
 
   const icon = getEntityIcon(entity);
+  const layerName = entity.getAttribute('data-layer-name');
   let override = null;
-  if (state?.assetId && state.name) {
+  if (!layerName && state?.assetId && state.name) {
     const prefixMessage = ASSET_TYPE_PREFIX_MESSAGES[state.type];
     const prefix = prefixMessage
       ? intl.formatMessage(prefixMessage)
       : undefined;
     override = prefix ? `${prefix} • ${state.name}` : state.name;
   }
-  const displayName = override || getEntityDisplayName(entity);
-  const canEdit = (editable || forceEditing) && !override;
+  const displayName = layerName || override || getEntityDisplayName(entity);
+  // What the rename input opens with: the bare instance/asset name, never
+  // the type-prefixed label — committing it unchanged writes nothing.
+  const editSeed =
+    layerName || (state?.assetId && state.name) || getEntityDisplayName(entity);
+  const canEdit = editable || forceEditing;
 
   const commitRename = (value) => {
     const newName = value.trim();
-    if (!newName || newName === displayName) return;
+    if (!newName || newName === editSeed) return;
     AFRAME.INSPECTOR.execute('entityupdate', {
       entity,
       component: 'data-layer-name',
@@ -82,7 +89,7 @@ const EntityLabel = ({
         {icon && <span className="entityIcons">{icon}</span>}
         <InlineEditInput
           className="entityNameInput"
-          defaultValue={displayName}
+          defaultValue={editSeed}
           onCommit={commitRename}
           onClose={() => {
             setEditing(false);

--- a/src/editor/lib/entity.js
+++ b/src/editor/lib/entity.js
@@ -15,6 +15,7 @@ import {
   VideoCameraIcon,
   LayersIcon,
   Object24IconCyan,
+  Geometry24Icon,
   ShapeIcon,
   ViewerStartIcon
 } from '@shared/icons';
@@ -741,6 +742,13 @@ export function getEntityIcon(entity) {
   // Check for class-based icons
   if (entity.classList.contains('autocreated')) {
     return <AutoIcon />;
+  }
+
+  // Primitive geometry reads differently from a 3D-model-backed entity
+  // (uploaded glTF or catalog mixin), so it gets its own icon (#1999);
+  // model rows keep the wireframe cube default below.
+  if (!entity.getAttribute('gltf-model') && entity.getAttribute('geometry')) {
+    return <Geometry24Icon />;
   }
 
   // Check for ID-based icons

--- a/src/editor/lib/raycaster.js
+++ b/src/editor/lib/raycaster.js
@@ -144,6 +144,37 @@ export function initRaycaster(inspector) {
     }
     event.preventDefault();
     onUpPosition.set(event.clientX, event.clientY);
+    handleEmptySpaceClick(event);
+  }
+
+  // Click on empty space deselects (#1992). handleClick never runs for a
+  // miss — the cursor component only emits `click` when the press and
+  // release both landed on the same intersected entity — so the miss case
+  // is caught here, on the container mouseup that bubbles after it. A press
+  // that grabbed a viewport gizmo handle (transform gizmo, shape vertex,
+  // street node/width bar) sets inspector.gizmoCapturedPress (viewport.js):
+  // those helpers are invisible to the entity raycaster, so without the
+  // flag a zero-movement click on a handle would read as empty space and
+  // deselect the entity being manipulated.
+  function handleEmptySpaceClick(event) {
+    const gizmoCaptured = inspector.gizmoCapturedPress;
+    inspector.gizmoCapturedPress = false;
+    // Left button only, and only the first click of a multi-click — same
+    // rule as handleClick (the dblclick handler owns the second click).
+    if (event.button !== 0 || event.detail > 1 || gizmoCaptured) {
+      return;
+    }
+    if (onDownPosition.distanceTo(onUpPosition) > CLICK_MAX_DRAG_PX) {
+      return;
+    }
+    // When the click hit an entity, handleClick already ran (the cursor's
+    // clearCurrentIntersection(false) re-reads the still-current
+    // intersections synchronously, so getIntersectedEl() is not blanked by
+    // it) — nothing to do here.
+    if (!inspector.selectedEntity || getIntersectedEl()) {
+      return;
+    }
+    inspector.selectEntity(null);
   }
 
   /**

--- a/src/editor/lib/viewport.js
+++ b/src/editor/lib/viewport.js
@@ -690,6 +690,21 @@ export function Viewport(inspector) {
     });
   });
 
+  // Each gizmo dispatches 'mouseDown' only when a press actually grabs one
+  // of its handles. Record that on the inspector so the raycaster's
+  // empty-space-click deselection (raycaster.js, #1992) doesn't mistake a
+  // zero-movement click on a handle — invisible to the entity raycaster —
+  // for a click on nothing. The raycaster clears the flag on mouseup.
+  const markGizmoPress = () => {
+    inspector.gizmoCapturedPress = true;
+  };
+  [
+    transformControls,
+    shapeVertexControls,
+    streetNodeControls,
+    segmentWidthControls
+  ].forEach((gizmo) => gizmo.addEventListener('mouseDown', markGizmoPress));
+
   transformControls.addEventListener('mouseDown', () => {
     const object = transformControls.object;
     if (object) {

--- a/src/editor/style/scenegraph.scss
+++ b/src/editor/style/scenegraph.scss
@@ -109,11 +109,10 @@
     column-gap: 8px;
   }
 
-  // Layer styling
+  // Layer styling. No vertical margins: top-level rows sit flush like child
+  // rows, so every row in the tree gets the same spacing (#1994).
   .layer {
     width: 100%;
-    margin-top: 6px;
-    margin-bottom: 6px;
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/src/shared/icons/icons.jsx
+++ b/src/shared/icons/icons.jsx
@@ -1050,6 +1050,30 @@ export const Object24IconCyan = () => (
   </svg>
 );
 
+// Layers-panel icon for primitive-geometry entities (#1999): basic 2D
+// shapes, distinct from the wireframe cube that marks 3D-model rows.
+export const Geometry24Icon = () => (
+  <svg
+    width="24"
+    height="28"
+    viewBox="0 0 24 28"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      x="2.5"
+      y="4.5"
+      width="11.5"
+      height="11.5"
+      rx="1"
+      stroke="#00FFFF"
+      strokeWidth="2.5"
+      strokeLinejoin="round"
+    />
+    <circle cx="15.5" cy="18.5" r="6" stroke="#00FFFF" strokeWidth="2.5" />
+  </svg>
+);
+
 // Illustration-grade art: served from ui_assets (cached, on-demand)
 // instead of inlining tens of KiB of path data into the JS bundle.
 export const SignInMicrosoftIconSVG = () => (


### PR DESCRIPTION
## Summary

This PR addresses four interconnected issues affecting entity selection, autosave behavior, layer panel spacing, and entity naming/icons:

1. **Empty space click deselection** (#1992) - Clicking on empty 3D space now deselects the current entity
2. **Description autosave** (#1998) - Focus hotspot descriptions now autosave after a typing pause, not just on blur
3. **Layer panel spacing** (#1994) - Removed inconsistent vertical margins from layer rows
4. **Entity naming and icons** (#1999, #2000) - Improved display of entity names and added distinct icon for primitive geometry

## Key Changes

### Entity Selection & Raycaster (`src/editor/lib/raycaster.js`)
- Added `handleEmptySpaceClick()` to detect clicks on empty 3D space and deselect the entity
- Distinguishes between entity clicks (handled by cursor component) and empty space clicks (handled on container mouseup)
- Respects gizmo captures to avoid deselecting when clicking on transform/shape/street gizmo handles

### Gizmo Press Tracking (`src/editor/lib/viewport.js`)
- Added `gizmoCapturedPress` flag on inspector to signal when a gizmo handle is being manipulated
- Prevents empty-space-click deselection from interfering with gizmo interactions

### Focus Hotspot Autosave (`src/editor/components/elements/FocusHotspotSidebar.jsx`)
- Replaced immediate `commitDescription()` on blur with debounced autosave
- Added `pendingCommitRef` and `commitTimerRef` to track pending description changes
- Implemented `flushPendingCommit()` to commit changes after 2 seconds of typing inactivity
- Added `beforeunload` warning when unsaved changes exist (typing pause window)
- Cleanup on entity switch or unmount flushes pending commits to the correct entity

### Entity Naming & Icons (`src/editor/components/scenegraph/EntityLabel.jsx`)
- User-set `data-layer-name` now takes priority over asset name for display
- Asset-backed entities can now be renamed with a per-instance `data-layer-name` (shared Firestore asset name unchanged)
- Separated display name (with type prefix) from edit seed (bare name) to avoid committing unchanged values
- Updated JSDoc to clarify naming precedence and rename behavior

### Context Menu (`src/editor/components/scenegraph/EntityContextMenu.jsx`)
- Removed asset-entity rename restriction; all entities can now be renamed with per-instance `data-layer-name`

### Entity Icons (`src/editor/lib/entity.js`)
- Added `Geometry24Icon` for primitive geometry entities (distinct from 3D-model wireframe cube)
- Primitive geometry without `gltf-model` attribute now displays geometry icon

### Geometry Icon (`src/shared/icons/icons.jsx`)
- New `Geometry24Icon` component: cyan rectangle + circle representing 2D shapes

### Layer Panel Spacing (`src/editor/style/scenegraph.scss`)
- Removed `margin-top` and `margin-bottom` from `.layer` class
- All rows now sit flush with consistent spacing, matching child row behavior

## Implementation Details

- The autosave debounce uses refs to preserve pending commits across re-renders and entity switches
- Empty-space-click detection runs on container mouseup (after cursor component's click event) to catch misses
- Gizmo press flag is cleared on raycaster mouseup to reset state for the next interaction
- Entity rename now writes to `data-layer-name` component for all entity types, enabling per-instance naming while preserving shared asset metadata

https://claude.ai/code/session_01VvgFqmv5gH5dPCJFnAGjXs