### PR TITLE
Progressive GLB streaming for large uploads via needle gltf-progressive (#1990 spike + plan)

### DIFF
--- a/docs/agent-context/asset-uploads.md
+++ b/docs/agent-context/asset-uploads.md
@@ -16,6 +16,8 @@ The cloud URL lives in `gltf-model` / `src`. Firebase Storage download tokens al
 
 **All other metadata** (`size`, `originalFilename`, etc.) lives in Firestore and is fetched on demand — never saved in the scene JSON.
 
+**Progressive-streaming GLBs (#1990, in progress):** large uploads get a Needle Cloud progressive variant as their `optimizedSourceUrl`, served from `cloud.needle.tools`. Because scene JSON persists only the URL, `isProgressiveModelUrl` (`src/tested/progressive-models.js`) is the one runtime predicate for "this model streams": `gltf-model` hooks needle's extension onto its loader for those srcs and skips the clone-template cache, `batch-models` excludes them from batching, and `asset-fallback` retries `storageUrl` when the CDN copy fails. Plan and status: `docs/plans/1990-progressive-glb-streaming.md`.
+
 **Cloud Functions:**
 
 - `onAssetWritten` — Firestore trigger, maintains `users/{uid}/meta/usage.bytesUsed` via transaction. Only `size` (original) counts toward quota; `optimizedSourceSize` is excluded (platform cost).

--- a/docs/plans/1990-progressive-glb-streaming.md
+++ b/docs/plans/1990-progressive-glb-streaming.md
@@ -24,7 +24,22 @@ lands (or fold what's durable into `docs/agent-context/`).
   - Duplicates (x2) loaded fine with their own LOD state; batching was not
     active in that editor session, so the BatchedMesh interaction is still
     unverified (Phase 1 excludes progressive URLs from batching regardless).
-- **Needle CLI facts (needle-cloud 3.x):** the command is `optimize`, not
+- **Needle deletion: NONE available (checked 2026-09-12, needle-cloud 2.5.0,
+  the latest release; there is no 3.x).** The CLI has no delete/remove command
+  (`settings, mcp, send-logs, login, logout, me, list, download, deploy,
+optimize, generate-material, generate-3d, ask`), its bundle makes no
+  `DELETE` request, its MCP server exposes no content-management tool, and
+  the cloud docs (`engine.needle.tools/docs/cloud/`) document no REST API
+  beyond outgoing webhooks. Deletion is web-UI only. Phase 2 GC therefore
+  writes an orphan ledger (`needleOrphans` or a field on the purged asset's
+  tombstone) and we ask Needle support for an API; the ledger is the manual
+  purge list until then.
+- **`--usecase world` works** on a fresh `--name`: `list --output json`
+  returns `url: https://cloud.needle.tools/-/assets/<viewId>-world/file`
+  (the spike's earlier "-product only" result was a name reuse). The worker
+  reads `url` from `list --output json` filtered by `title` = the `--name`
+  it passed (also `identifier`, `content_type: '3d-asset'`, `is_public`).
+- **Needle CLI facts (needle-cloud 2.5.0):** the command is `optimize`, not
   `upload`: `npx needle-cloud optimize <file.glb> --token <t> --progressive true
 --name <id>`. The env var `NEEDLE_CLOUD_TOKEN` was read but rejected as
   "not logged in"; `--token` works. `--usecase world` produced no `-world`
@@ -267,8 +282,8 @@ profile: 'world' } }` → write terminal job status. Failures →
 
 ## Risks / open questions
 
-1. **Needle Cloud deletion API unknown** — third-party copies of user data need a
-   GC path; orphan ledger + support inquiry; resolve before GA.
+1. **Needle Cloud has no deletion API** (verified, see State of work) — GC
+   writes an orphan ledger; ask Needle support; manual purge until then.
 2. **Public CDN privacy** — mitigated by skipping `private` assets + UI copy;
    existing `visibility` toggle is the opt-out.
 3. **Shared-texture-extension invariant** ("never swap a Source post-GPU-upload")

--- a/docs/plans/1990-progressive-glb-streaming.md
+++ b/docs/plans/1990-progressive-glb-streaming.md
@@ -41,8 +41,8 @@ lands (or fold what's durable into `docs/agent-context/`).
   (`cdn.needle.tools/static/three/0.179.1/basis2/`), a runtime third-party
   dependency to decide on in Phase 1 (self-host the transcoder, or set
   A-Frame's `ktx2TranscoderPath`).
-- **Phase 1 runtime integration: DONE (2026-09-12, on this branch; browser
-  pass still pending).** The spike flag is gone; behavior is keyed purely off
+- **Phase 1 runtime integration: DONE (2026-09-12, on this branch; editor
+  pass passed the same day, see below).** The spike flag is gone; behavior is keyed purely off
   the src URL:
   - `src/tested/progressive-models.js` (in `src/tested/`, not `src/lib/`, so
     the mocha suite covers it: `test/core/progressive-models.test.js`):
@@ -65,11 +65,17 @@ storageUrl]`, tried per assetId per session, so an unreachable Needle CDN
     Needle-hosted model loads, so it adds no availability domain beyond the
     model itself. Revisit only if we self-host models.
   - `&debugprogressive` in the URL still enables the library's LOD logs.
-  - Editor pass to run (needs a processed Needle URL): place via a `gltf-model`
-    entity with the CDN URL, duplicate ×3 (batch log says "progressive-streaming
-    model", all copies refine on zoom), undo/delete, save/reload; block
-    `cloud.needle.tools` in DevTools on an entity carrying `data-asset-id` /
-    `data-asset-owner-uid` and confirm the storageUrl retry.
+  - **Editor pass (2026-09-12, local dev server, progressive-world URL
+    `https://cloud.needle.tools/-/assets/Zp9qu81CtVaR-1CtVaR-world/file.glb`):**
+    `model-loaded` in 608 ms at 58k tris with 128px textures; on close-up it
+    streamed mesh LOD5→0 (1.67M tris) and the 2048 texture LODs through our
+    loader, KTX2 transcoder fetched from Needle's CDN on demand. Three
+    duplicates each parsed their own instance (no clone-cache entry), all
+    stayed unbatched, no `Texture is immutable` / WebGL / uncaught errors;
+    removing a duplicate tore down cleanly. **Not covered:** save/reload
+    (URL persistence is unchanged by Phase 1) and the CDN-blocked → storageUrl
+    fallback (needs a real asset doc with a Needle `optimizedSourceUrl`, i.e.
+    Phase 2 writeback); test both on dev during Phase 2 end-to-end.
 - **Open question raised by the numbers:** the >10 MB threshold may be too
   high; a ~5 MB cutoff is plausible. Decide after processing a mid-size
   (5-15 MB) upload and comparing against the client-side Draco+WebP result.

--- a/docs/plans/1990-progressive-glb-streaming.md
+++ b/docs/plans/1990-progressive-glb-streaming.md
@@ -1,0 +1,238 @@
+# Progressive GLB streaming for large user uploads (issue #1990)
+
+Implementation plan for [issue #1990](https://github.com/3DStreet/3dstreet/issues/1990):
+integrate needle-tools' `gltf-progressive` so user-uploaded GLBs over 10MB stream
+progressively (tiny low-LOD first, refined by screen-space density), reusing the
+existing generationJobs/RAD cloud-job architecture. Delete this file once the work
+lands (or fold what's durable into `docs/agent-context/`).
+
+## State of work
+
+- **Done (pushed on this branch):** Phase 0 spike scaffolding —
+  `@needle-tools/gltf-progressive@3.6.1` (exact pin) plus a flag-gated hook in
+  `src/aframe-components/gltf-model.js`. Enable with `?progressive` in the URL or
+  `localStorage.progressiveModels = 'true'`. The library is dynamically imported
+  (module evaluation has side effects: a decoder-reachability fetch, eager
+  DRACO/KTX2 loader construction, a `Needle` global) and webpack code-splits it
+  into a lazy chunk, so the main bundle is unchanged with the flag off.
+  `useNeedleProgressive` only fills decoders the loader is missing, so A-Frame's
+  DRACO/KTX2/meshopt setup wins. Lint + core/modern test suites pass.
+- **Not done:** everything from "Phase 0 — Validation spike" step 1 onward. The
+  spike needs a Needle Cloud account (external credential) and a real browser.
+
+## Decisions already made
+
+- Scope: **user-uploaded assets only** (not the `assets.3dstreet.app` catalog).
+- Rule: uploads **>10MB** get Needle Cloud processing (~€50/mo); **<10MB** keep
+  the existing client-side gltf-transform optimization.
+- Processed files served **directly from Needle Cloud's CDN**.
+- **Validation spike first**; the pipeline is built only if the spike passes.
+- **Reuse the generic cloud-job architecture** — no Needle-specific data models.
+
+## The generic architecture to reuse
+
+The provider-agnostic async job queue `users/{uid}/generationJobs/{jobId}` with the
+scheduled reconciler backstop (`docs/generation-job-queue.md`), and specifically the
+**RAD splat pipeline** as the proven template (`docs/rad-cloud-run-pipeline.md`,
+`public/functions/rad-dispatch.js`): asset-doc `onCreate` trigger → `generationJobs`
+doc (`provider: 'cloudrun'`, `kind: 'splat-rad'`, `tokenCost: 0`) → Cloud Tasks →
+worker converts → **writes back into the existing `optimizedSource*` fields on the
+asset doc** → terminal job status; reconciler re-enqueues wedged jobs. RAD is
+explicitly "the splat analog of the GLB optimized variant."
+
+**Framing that eliminates new schema:** the Needle progressive output _is_ the
+optimized variant for large GLBs. Large uploads skip the client-side worker (whose
+15s timeout mostly defeats it on big files anyway) and the server-side job produces
+the optimized variant instead. Consequences:
+
+- **No new asset-doc fields.** Writeback = `optimizedSourceUrl` (Needle CDN URL) +
+  `optimizedSourceSize` + provenance in the existing `optimizationMetadata` blob
+  (`{ format: 'needle-progressive', needleAssetId, profile }`).
+  `optimizedSourcePath` stays absent (nothing in our bucket).
+- **No firestore.rules changes.** The update deny-list (`public/firestore.rules`
+  assets block) already protects the quota fields; `optimizedSourceUrl` /
+  `optimizationMetadata` are written via Admin SDK exactly as the RAD worker does.
+- **No quota changes.** `onAssetWritten` counts only `size`; optimized bytes are
+  already platform cost.
+- **`getServedUrl` unchanged** (`optimizedSourceUrl ?? storageUrl`,
+  `src/shared/assets/utils.js`) — placement and gallery drags pick up the
+  progressive URL automatically, same as RAD.
+- **Existing UI mostly free**: `MeshDetailsModal` already renders the
+  optimized-variant row from `optimizationMetadata`.
+
+## External facts (verified)
+
+`@needle-tools/gltf-progressive` is MIT, stable **3.6.1**, peerDep
+`three >= 0.160.0` (app pins `0.184.0`; webpack externalizes bare `three` to
+`window.THREE`, so it patches the same loader classes A-Frame uses — but it also
+bundles its own `three/examples/jsm` loader instances internally, which the spike
+must validate). Integration: `useNeedleProgressive(gltfLoader, renderer)`; models
+without LOD data load normally (no-op). Processing via the `needle-cloud` npm CLI
+(auth `NEEDLE_CLOUD_TOKEN`), returning Progressive-World/Product URLs. Avoid
+`4.0.0-alpha`.
+
+## Key runtime constraint
+
+User uploads ARE batchable — `BATCHABLE_SELECTOR` (`src/batch-models.js`) matches
+`[gltf-model]`, and 2+ copies get folded into fixed-buffer `BatchedMesh`
+(late-repack threshold 1), structurally incompatible with runtime LOD swaps. The
+clone-template cache in `src/aframe-components/gltf-model.js` (2nd+ instance of a
+src clones the parsed scene instead of loading) similarly bypasses the loader.
+Both need exclusions for progressive URLs (Phase 1).
+
+---
+
+## Phase 0 — Validation spike (gates everything)
+
+1. **Manual processing** (no repo changes): Needle Cloud team/trial + read/write
+   token; `NEEDLE_CLOUD_TOKEN=… npx needle-cloud upload model.glb --team '…'` on
+   1–2 real >10MB GLBs. Record: returned URLs, exact CLI output format (the
+   worker parses it), CDN hostname(s) (for the URL predicate), and wall-clock CLI
+   duration (sizes the Cloud Tasks dispatchDeadline / service timeout).
+2. **Loader hook** — already on this branch (see State of work).
+3. **Manual checks** (`verify` skill or by hand):
+   - Progressive URL in `gltf-model`: fast low-LOD, refines on zoom, no errors.
+     Catalog/small models unchanged with flag on.
+   - **Shared-texture extension** (`GLTFSharedTextureSourceExtension` in
+     gltf-model.js): watch for `glTexStorage2D: Texture is immutable` during LOD
+     swaps — verify texture LODs swap the material's Texture, not a GPU-uploaded
+     `Source`.
+   - **Batching**: duplicate the entity 2-3× — expect LOD refinement to
+     freeze/break inside `BatchedMesh` (evidence for Phase 1 exclusion). Repeat
+     with batching off to check the clone cache (expect clones not to refine).
+   - Module-instance mismatch: the library's internal LOD loads use its own
+     bundled `three/examples` GLTFLoader (same 0.184 version, different module
+     instance than `window.THREE`) — confirm parsed LOD geometry/textures render
+     correctly through the super-three renderer.
+4. **Measure** with `scripts/measure-load.mjs`: same scene, progressive URL vs
+   Storage URL — time-to-loaded, FPS, bytes before first render.
+5. **Gate**: proceed if ≥40% faster time-to-first-visible OR ≥60% fewer
+   bytes-before-first-render, no texture-immutable errors, no three-compat
+   failures, equivalent close-range quality, no FPS regression. Otherwise stop
+   and report findings on the issue.
+
+## Phase 1 — Runtime integration
+
+- **New `src/lib/progressive-models.js`**: `isProgressiveModelUrl(src)` (hostname
+  test against the Needle CDN domains from Phase 0 — works for saved scenes with
+  zero metadata, since scene JSON persists only the URL +
+  `data-asset-id`/`data-asset-owner-uid`); `hookProgressiveLoader(loader, sceneEl)`
+  (idempotent `useNeedleProgressive` wrapper); optional `LODsManager` tuning knob.
+- **`src/aframe-components/gltf-model.js`**: replace the spike flag — in
+  `loadModel()` hook the loader only when `isProgressiveModelUrl(src)`; all other
+  loads stay byte-identical. Clone-cache exclusion: add
+  `&& !isProgressiveModelUrl(src)` to the `srcLoadCount(src) >= 2` branch.
+- **`src/batch-models.js`**: in `getBatchProvider()`'s gltf-model branch, return
+  `key: null` when `isProgressiveModelUrl(key)` — a null key already excludes from
+  defer-load, grouping, and late repack. Log a distinct "progressive-streaming
+  model" reason.
+- **Fallback** — `src/aframe-components/asset-fallback-system.js`: today it gives
+  up when the fresh doc's `optimizedSourceUrl ?? storageUrl` equals the failing
+  URL. Generic fix: when the preferred URL equals the failing one, retry
+  `storageUrl` if it differs, and remember the assetId for the session. Covers
+  "Needle CDN unreachable" since the Firebase original is never deleted.
+- **Verification**: `npm run lint`, `npm test`; measure-load.mjs on a mixed
+  catalog+progressive scene, both batching modes (catalog batching stats
+  unchanged); editor pass: place, duplicate ×3 (stays unbatched, all refine),
+  undo/delete, save/reload.
+
+## Phase 2 — Processing via the existing job queue
+
+- **Client-side split at the 10MB rule** —
+  `src/editor/lib/asset-upload/uploadAndPlaceAsset.js`: skip `optimizeGlb(file)`
+  when `kind === 'glb' && file.size > 10 * MB` (decimal, matching quota
+  convention); upload original only. Small files keep the current worker path.
+- **New `public/functions/progressive-dispatch.js`**, closely mirroring
+  `rad-dispatch.js` (exported from `index.js`):
+  - Firestore v1 `onCreate` on `users/{userId}/assets/{assetId}`; guards:
+    `type === 'mesh'`, `size > 10MB`, no `optimizedSourceUrl`, `storagePath`
+    present, `visibility !== 'private'` (public-CDN privacy guard).
+  - Writes a `generationJobs` doc **before** dispatch (crash-safe, reconcilable):
+    `{ kind: 'glb-progressive', provider: 'cloudrun', status: 'queued',
+tokenCost: 0, tokenCharged: false, refunded: false, assetId, storagePath,
+inputBytes, createdAt, dispatchedAt }` — same normalized vocab as `splat-rad`
+    so the reconciler's provider-agnostic queries just work.
+- **Worker**: a tiny **`needle-uploader/` Cloud Run service** (Node-only container
+  with pinned `needle-cloud`; far simpler than `rad-converter/`), enqueued via
+  Cloud Tasks with OIDC exactly like `enqueueRadTask` (generalize/copy the helper;
+  per-project URL map + env override, same as `RAD_SERVICE_URLS`). Contract
+  mirrors `rad-converter/server.js`: download GLB from `storagePath` →
+  `needle-cloud upload` (token from Secret Manager) → parse Progressive-World URL
+  → patch asset doc `{ optimizedSourceUrl, optimizedSourceSize,
+optimizationMetadata: { format: 'needle-progressive', needleAssetId,
+profile: 'world' } }` → write terminal job status. Failures →
+  `status: 'failed'` with error; unparseable CLI output is a failure, never a
+  bad URL.
+- **Reconciler** — `public/functions/scheduled/generation-job-reconcile.js`: the
+  `case 'cloudrun'` re-enqueue seam exists; make re-enqueue kind-aware
+  (`splat-rad` → `enqueueRadTask`, `glb-progressive` → the new enqueue helper).
+- **GC** — `public/functions/scheduled/asset-gc.js` purge path: when
+  `optimizationMetadata.format === 'needle-progressive'`, delete the Needle copy
+  via `needleAssetId` if their CLI/API supports deletion (**open question**);
+  otherwise write to an orphan ledger for later purge. Resolve before GA.
+- **Rollout**: worker + queue infra → functions → client 10MB split (order-safe:
+  until the trigger deploys, big uploads simply serve `storageUrl`).
+
+## Phase 3 — UI polish (small)
+
+- Extend `deriveOptimizationInfo` (`src/shared/assets/utils.js`) so
+  `MeshDetailsModal` labels `needle-progressive` as "Streaming (progressive LOD)";
+  show nothing until writeback (simplest).
+- Upload toast for >10MB GLBs: "Uploaded — streaming version processing in
+  background". Scenes saved before writeback keep the working `storageUrl`;
+  re-placements and the fallback path heal forward (same behavior RAD relies on).
+- Privacy: `visibility: 'private'` assets are skipped by the trigger; note in UI
+  copy that public assets' processed copies live on Needle's public CDN. Per-asset
+  opt-out rides the existing client-writable `visibility` toggle — no new field.
+- Update `docs/agent-context/asset-uploads.md` + `docs/agent-context/generation.md`
+  (new job kind) per CLAUDE.md's doc-maintenance rule.
+
+## Verification (per phase)
+
+- **Phase 0**: measure-load.mjs vs gate criteria; browser pass; recorded CLI
+  timings/output.
+- **Phase 1**: lint + `npm test`; mixed-scene measure-load.mjs in both batching
+  modes; duplicate/undo/save-reload editor pass.
+- **Phase 2**: emulator test of the trigger writing a correct `generationJobs`
+  doc; end-to-end on dev: upload ~15MB GLB → job `queued → succeeded` → asset doc
+  gains Needle `optimizedSourceUrl` → gallery re-drag streams progressively;
+  kill-switch (block Needle CDN in DevTools → falls back to `storageUrl`);
+  reconciler re-enqueue test (kill the worker mid-job). No rules changes ⇒ no
+  `test:rules` additions beyond a regression run.
+
+## Risks / open questions
+
+1. **Needle Cloud deletion API unknown** — third-party copies of user data need a
+   GC path; orphan ledger + support inquiry; resolve before GA.
+2. **Public CDN privacy** — mitigated by skipping `private` assets + UI copy;
+   existing `visibility` toggle is the opt-out.
+3. **Shared-texture-extension invariant** ("never swap a Source post-GPU-upload")
+   — Phase 0 gate.
+4. **Semantic overload of `optimizedSourceUrl`** — it now may point off-bucket.
+   Audited consumers (`getServedUrl`, fallback system, GC, `MeshDetailsModal`)
+   are covered above; anything else assuming a bucket URL should surface in
+   Phase 2 testing. Chosen deliberately over new fields to minimize schema/rules
+   surface.
+5. **three/super-three lockstep** gains a third participant; pin exact versions,
+   re-check on A-Frame/three bumps. Avoid 4.x alpha.
+6. **Cost/throughput** of the €50/mo plan unverified — instrument the worker with
+   PostHog (`asset_progressive_processed`, sizes/duration); consider gating to
+   PRO/MAX if volume is costly.
+7. **CLI output fragility** — pin `needle-cloud` in the worker image; assert on
+   the Phase-0-recorded output shape.
+8. **Editor top-down/screenshot views** may sit at low LOD; the library has a
+   force-highest-LOD hook if needed.
+
+## Critical files
+
+- `src/aframe-components/gltf-model.js` (spike hook already in; Phase 1 reworks
+  it) · `src/batch-models.js` (`getBatchProvider`) · `src/lib/progressive-models.js`
+  (new)
+- `src/aframe-components/asset-fallback-system.js` · `src/shared/assets/utils.js`
+  (`deriveOptimizationInfo` only)
+- `src/editor/lib/asset-upload/uploadAndPlaceAsset.js` (10MB split)
+- `public/functions/progressive-dispatch.js` (new, mirrors `rad-dispatch.js`) ·
+  `needle-uploader/` (new, mirrors `rad-converter/` handler contract) ·
+  `public/functions/scheduled/generation-job-reconcile.js` (kind-aware
+  re-enqueue) · `public/functions/scheduled/asset-gc.js`
+- Docs: `docs/agent-context/asset-uploads.md`, `docs/agent-context/generation.md`

--- a/docs/plans/1990-progressive-glb-streaming.md
+++ b/docs/plans/1990-progressive-glb-streaming.md
@@ -41,16 +41,42 @@ lands (or fold what's durable into `docs/agent-context/`).
   (`cdn.needle.tools/static/three/0.179.1/basis2/`), a runtime third-party
   dependency to decide on in Phase 1 (self-host the transcoder, or set
   A-Frame's `ktx2TranscoderPath`).
-- **Done (pushed on this branch):** Phase 0 spike scaffolding,
-  `@needle-tools/gltf-progressive@3.6.1` (exact pin) plus a flag-gated hook in
-  `src/aframe-components/gltf-model.js`. Enable with `?progressive` in the URL or
-  `localStorage.progressiveModels = 'true'`; add `&debugprogressive` for the
-  library's LOD logs. The library is dynamically imported (module evaluation
-  has side effects) and webpack code-splits it into a lazy chunk.
+- **Phase 1 runtime integration: DONE (2026-09-12, on this branch; browser
+  pass still pending).** The spike flag is gone; behavior is keyed purely off
+  the src URL:
+  - `src/tested/progressive-models.js` (in `src/tested/`, not `src/lib/`, so
+    the mocha suite covers it: `test/core/progressive-models.test.js`):
+    `isProgressiveModelUrl(src)` = hostname allowlist `PROGRESSIVE_MODEL_HOSTS`
+    (`cloud.needle.tools`), accepting `url(...)`-wrapped srcs;
+    `hookProgressiveLoader(loader, renderer)` = idempotent per-loader
+    `useNeedleProgressive`, lazy-imports the library (still a separate webpack
+    chunk; main bundle +0.5 KB), never rejects.
+  - `gltf-model.js` `loadModel()`: hooks the loader only for progressive srcs
+    (chained into `ready`), and skips the clone-template cache for them so each
+    instance parses and refines with its own LOD state.
+  - `batch-models.js` `getBatchProvider()`: `key: null` +
+    `skipReason: 'progressive-streaming model'` for progressive srcs (excludes
+    deferral, grouping and late repack; the reason shows in the batch log).
+  - `asset-fallback-system.js`: candidate list `[optimizedSourceUrl,
+storageUrl]`, tried per assetId per session, so an unreachable Needle CDN
+    falls back to the Firebase original (generic: also heals a stale token).
+  - **KTX2 transcoder decision:** keep the library default (Needle's CDN,
+    `cdn.needle.tools/static/three/0.179.1/basis2/`). It is only fetched when a
+    Needle-hosted model loads, so it adds no availability domain beyond the
+    model itself. Revisit only if we self-host models.
+  - `&debugprogressive` in the URL still enables the library's LOD logs.
+  - Editor pass to run (needs a processed Needle URL): place via a `gltf-model`
+    entity with the CDN URL, duplicate ×3 (batch log says "progressive-streaming
+    model", all copies refine on zoom), undo/delete, save/reload; block
+    `cloud.needle.tools` in DevTools on an entity carrying `data-asset-id` /
+    `data-asset-owner-uid` and confirm the storageUrl retry.
 - **Open question raised by the numbers:** the >10 MB threshold may be too
   high; a ~5 MB cutoff is plausible. Decide after processing a mid-size
   (5-15 MB) upload and comparing against the client-side Draco+WebP result.
-- **Next:** Phase 1 runtime integration.
+  Note #1978 / PR #1985 (merged) added a client-side meshopt `simplify` step
+  and a 30 s timeout, which changes the small-file baseline.
+- **Next:** Phase 2 processing pipeline (first: the Needle deletion-API
+  question, and the `needle-uploader/` worker contract).
 
 ## Decisions already made
 
@@ -145,7 +171,8 @@ Both need exclusions for progressive URLs (Phase 1).
 
 ## Phase 1 — Runtime integration
 
-- **New `src/lib/progressive-models.js`**: `isProgressiveModelUrl(src)` (hostname
+- **New `src/tested/progressive-models.js`** (planned as `src/lib/`; moved so
+  it is mocha-covered): `isProgressiveModelUrl(src)` (hostname
   test against the Needle CDN domains from Phase 0 — works for saved scenes with
   zero metadata, since scene JSON persists only the URL +
   `data-asset-id`/`data-asset-owner-uid`); `hookProgressiveLoader(loader, sceneEl)`
@@ -257,9 +284,9 @@ profile: 'world' } }` → write terminal job status. Failures →
 
 ## Critical files
 
-- `src/aframe-components/gltf-model.js` (spike hook already in; Phase 1 reworks
-  it) · `src/batch-models.js` (`getBatchProvider`) · `src/lib/progressive-models.js`
-  (new)
+- `src/aframe-components/gltf-model.js` · `src/batch-models.js`
+  (`getBatchProvider`) · `src/tested/progressive-models.js` (+
+  `test/core/progressive-models.test.js`)
 - `src/aframe-components/asset-fallback-system.js` · `src/shared/assets/utils.js`
   (`deriveOptimizationInfo` only)
 - `src/editor/lib/asset-upload/uploadAndPlaceAsset.js` (10MB split)

--- a/docs/plans/1990-progressive-glb-streaming.md
+++ b/docs/plans/1990-progressive-glb-streaming.md
@@ -8,17 +8,49 @@ lands (or fold what's durable into `docs/agent-context/`).
 
 ## State of work
 
-- **Done (pushed on this branch):** Phase 0 spike scaffolding —
+- **Phase 0 spike: PASSED (2026-09-11, local, Meshy AI building GLB).** Results:
+  - Source `1001SCapitolSt` Meshy export: 76.2 MB, 1.67M tris, 3x 2048 JPEG,
+    no compression. Needle output: optimized (Draco+KTX2) 12.4 MB; progressive
+    initial file **3.7 MB** (mesh LOD2 = 417k tris, 512px textures embedded),
+    with mesh LOD0 (full 1.67M) and 1024/2048 texture LODs streamed on demand.
+  - In the editor via our `gltf-model` loader: progressive `model-loaded` in
+    **869 ms**; on close-up it fetched LOD0 + 2048 textures and refined to the
+    full mesh. The original file took 32.8 s to download and then froze the
+    main thread for >45 s while parsing.
+  - No `Texture is immutable` / WebGL errors across LOD swaps: the library
+    replaces the material's Texture and refcount-disposes the old one, which is
+    the pattern our shared-texture extension requires.
+  - Needle CLI upload+process round trip for 76 MB: ~2 min (upload ~1 min).
+  - Duplicates (x2) loaded fine with their own LOD state; batching was not
+    active in that editor session, so the BatchedMesh interaction is still
+    unverified (Phase 1 excludes progressive URLs from batching regardless).
+- **Needle CLI facts (needle-cloud 3.x):** the command is `optimize`, not
+  `upload`: `npx needle-cloud optimize <file.glb> --token <t> --progressive true
+--name <id>`. The env var `NEEDLE_CLOUD_TOKEN` was read but rejected as
+  "not logged in"; `--token` works. `--usecase world` produced no `-world`
+  variant; only `-product` exists. The CLI prints only the edit URL; get the
+  served URL from `needle-cloud list --token <t> --output json` (`url` field):
+  `https://cloud.needle.tools/-/assets/<viewId>-product/file`, with siblings
+  `<viewId>-optimized/file` (Draco+KTX2) and `<viewId>/file` (original).
+  Served with `access-control-allow-origin: *` and public `cache-control`
+  even though the list shows `is_public: false`.
+- **KTX2 is mandatory:** Needle output uses `KHR_texture_basisu`. A-Frame 1.8
+  configures a default Draco path but no KTX2 transcoder, so without the hook
+  the load fails with "setKTX2Loader must be called before loading KTX2
+  textures". The hook fills the missing KTX2 loader from Needle's CDN
+  (`cdn.needle.tools/static/three/0.179.1/basis2/`), a runtime third-party
+  dependency to decide on in Phase 1 (self-host the transcoder, or set
+  A-Frame's `ktx2TranscoderPath`).
+- **Done (pushed on this branch):** Phase 0 spike scaffolding,
   `@needle-tools/gltf-progressive@3.6.1` (exact pin) plus a flag-gated hook in
   `src/aframe-components/gltf-model.js`. Enable with `?progressive` in the URL or
-  `localStorage.progressiveModels = 'true'`. The library is dynamically imported
-  (module evaluation has side effects: a decoder-reachability fetch, eager
-  DRACO/KTX2 loader construction, a `Needle` global) and webpack code-splits it
-  into a lazy chunk, so the main bundle is unchanged with the flag off.
-  `useNeedleProgressive` only fills decoders the loader is missing, so A-Frame's
-  DRACO/KTX2/meshopt setup wins. Lint + core/modern test suites pass.
-- **Not done:** everything from "Phase 0 — Validation spike" step 1 onward. The
-  spike needs a Needle Cloud account (external credential) and a real browser.
+  `localStorage.progressiveModels = 'true'`; add `&debugprogressive` for the
+  library's LOD logs. The library is dynamically imported (module evaluation
+  has side effects) and webpack code-splits it into a lazy chunk.
+- **Open question raised by the numbers:** the >10 MB threshold may be too
+  high; a ~5 MB cutoff is plausible. Decide after processing a mid-size
+  (5-15 MB) upload and comparing against the client-side Draco+WebP result.
+- **Next:** Phase 1 runtime integration.
 
 ## Decisions already made
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@gltf-transform/functions": "^4.3.0",
         "@img-comparison-slider/react": "^8.0.2",
         "@mapbox/vector-tile": "^3.0.0",
+        "@needle-tools/gltf-progressive": "3.6.1",
         "@react-google-maps/api": "^2.20.8",
         "@sentry/react": "^10.40.0",
         "@sparkjsdev/spark": "^2.1.0",
@@ -3544,6 +3545,15 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@needle-tools/gltf-progressive": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@needle-tools/gltf-progressive/-/gltf-progressive-3.6.1.tgz",
+      "integrity": "sha512-6O2Qgpy2FE5awtUqU5FJ/DFbhmpyGKgzDO1gQPmby++0zbUDuuprxk1jwzlBtP7sXdn3alEbdHRjL+nHl8uglA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.160.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@gltf-transform/functions": "^4.3.0",
     "@img-comparison-slider/react": "^8.0.2",
     "@mapbox/vector-tile": "^3.0.0",
+    "@needle-tools/gltf-progressive": "3.6.1",
     "@react-google-maps/api": "^2.20.8",
     "@sentry/react": "^10.40.0",
     "@sparkjsdev/spark": "^2.1.0",

--- a/src/aframe-components/asset-fallback-system.js
+++ b/src/aframe-components/asset-fallback-system.js
@@ -2,7 +2,10 @@ import { assetsService } from '@shared/assets';
 
 AFRAME.registerSystem('asset-fallback', {
   init() {
-    this._retried = new Set();
+    // assetId → URLs already tried this session. Bounds retries to the asset's distinct URLs
+    // (served/optimized, then the Firebase original), so a URL that keeps failing never loops.
+    this._tried = new Map();
+    this._exhausted = new Set();
     this._onModelError = this._onModelError.bind(this);
     this.el.addEventListener('model-error', this._onModelError);
   },
@@ -17,12 +20,14 @@ AFRAME.registerSystem('asset-fallback', {
     const ownerUid = entity.getAttribute('data-asset-owner-uid');
     if (!assetId || !ownerUid) return;
 
-    // One retry attempt per assetId per session — prevents loops if the fresh
-    // URL also fails (URL unchanged, genuine 403, deleted asset, etc.).
-    if (this._retried.has(assetId)) return;
-    this._retried.add(assetId);
-
     const currentSrc = entity.getAttribute('gltf-model') || '';
+    const currentUrl = currentSrc.replace(/^url\(|\)$/g, '');
+    let tried = this._tried.get(assetId);
+    if (!tried) this._tried.set(assetId, (tried = new Set()));
+    tried.add(currentUrl);
+    // Every candidate URL already failed (or the doc fetch did): nothing left to try.
+    if (this._exhausted.has(assetId)) return;
+
     console.warn(
       `[asset-fallback] model-error on asset ${assetId} — fetching fresh URL`
     );
@@ -32,33 +37,37 @@ AFRAME.registerSystem('asset-fallback', {
       freshDoc = await assetsService.getAsset(assetId, ownerUid);
     } catch (err) {
       console.warn('[asset-fallback] could not fetch asset doc:', err);
+      this._exhausted.add(assetId);
       return;
     }
 
     if (!freshDoc) {
       console.warn(`[asset-fallback] asset ${assetId} not found in Firestore`);
+      this._exhausted.add(assetId);
       return;
     }
 
-    const freshUrl = freshDoc.optimizedSourceUrl ?? freshDoc.storageUrl;
-    if (!freshUrl) {
-      console.warn(`[asset-fallback] asset ${assetId} has no usable URL`);
-      return;
-    }
-
-    // Only retry if the URL has actually changed — if it's the same the 403
-    // is not a stale-token problem and we should not loop.
-    const currentUrl = currentSrc.replace(/^url\(|\)$/g, '');
-    if (freshUrl === currentUrl) {
-      console.warn(
-        `[asset-fallback] fresh URL matches current — not a stale-token issue, giving up`
-      );
-      return;
-    }
-
-    console.warn(
-      `[asset-fallback] retrying asset ${assetId} with refreshed URL`
+    // Preferred URL first (a refreshed download token, or an optimized variant produced
+    // since the scene was saved), then the Firebase original. The original is never deleted
+    // while the asset lives, so it covers an unreachable off-bucket optimized variant
+    // (e.g. a progressive model on the Needle CDN, #1990). A URL equal to the failing one is
+    // not a stale-token problem and is skipped rather than retried.
+    const freshUrl = [freshDoc.optimizedSourceUrl, freshDoc.storageUrl].find(
+      (url) => url && !tried.has(url)
     );
+    if (!freshUrl) {
+      console.warn(
+        `[asset-fallback] asset ${assetId} has no untried URL — giving up`
+      );
+      this._exhausted.add(assetId);
+      return;
+    }
+
+    const kind =
+      freshUrl === freshDoc.storageUrl && freshDoc.optimizedSourceUrl
+        ? 'original'
+        : 'refreshed';
+    console.warn(`[asset-fallback] retrying asset ${assetId} with ${kind} URL`);
     entity.setAttribute('gltf-model', `url(${freshUrl})`);
   }
 });

--- a/src/aframe-components/gltf-model.js
+++ b/src/aframe-components/gltf-model.js
@@ -8,31 +8,10 @@ import {
   removeMember,
   BATCHING_ENABLED
 } from '../batch-models';
-
-// Progressive-LOD streaming spike (#1990): opt-in via `?progressive` in the URL or
-// localStorage.progressiveModels = 'true'. While enabled, every gltf-model loader is hooked
-// with needle-tools' gltf-progressive so needle-processed GLBs stream low-LOD-first; models
-// without needle LOD data load byte-for-byte unchanged, so hooking unconditionally is safe.
-// The library is imported dynamically because merely evaluating its module has side effects
-// (a decoder-reachability fetch, eager DRACO/KTX2 loader construction, a `Needle` global)
-// that must not run for users outside the spike.
-let progressiveSpike; // undefined = flag not read yet; null = off; Promise = module loading
-function getProgressiveSpike() {
-  if (progressiveSpike === undefined) {
-    let enabled = false;
-    try {
-      enabled =
-        new URLSearchParams(window.location.search).has('progressive') ||
-        window.localStorage.getItem('progressiveModels') === 'true';
-    } catch (e) {
-      // location/localStorage access can throw (privacy modes, workers) — spike stays off.
-    }
-    progressiveSpike = enabled
-      ? import('@needle-tools/gltf-progressive')
-      : null;
-  }
-  return progressiveSpike;
-}
+import {
+  isProgressiveModelUrl,
+  hookProgressiveLoader
+} from '../tested/progressive-models';
 
 // Share one decoded THREE.Source across textures (within and across GLBs) that embed the
 // byte-identical image. The server bakes images[].extras.imageHash; GLTFLoader.loadImageSource
@@ -269,26 +248,6 @@ export const gltfModelPlus = {
     if (ktxLoader) {
       this.loader.setKTX2Loader(ktxLoader);
     }
-    // #1990 spike: hook progressive streaming onto this loader. Chained into this.ready so
-    // loadModel() cannot race the hook registration. useNeedleProgressive only fills decoders
-    // the loader is still missing, so the A-Frame-provided DRACO/KTX2/meshopt above win.
-    const spike = getProgressiveSpike();
-    if (spike) {
-      const hooked = spike
-        .then(({ useNeedleProgressive }) => {
-          if (sceneEl.renderer) {
-            useNeedleProgressive(self.loader, sceneEl.renderer);
-          } else {
-            console.warn(
-              '[gltf-model] progressive spike: renderer unavailable at init; loader not hooked'
-            );
-          }
-        })
-        .catch((err) => {
-          console.warn('[gltf-model] progressive spike failed to load:', err);
-        });
-      this.ready = Promise.all([this.ready, hooked]).then(() => {});
-    }
   },
 
   update: function () {
@@ -354,7 +313,17 @@ export const gltfModelPlus = {
     // fast 403) doesn't hang Promise.all.
     this._loadSettled = false;
 
-    this.ready.then(function () {
+    // Progressive-streaming models (#1990) need needle's extension on this loader before the
+    // load starts; every other src leaves the loader untouched. Chained into the ready promise
+    // so the load below cannot race the hook.
+    const progressive = isProgressiveModelUrl(src);
+    const ready = progressive
+      ? this.ready.then(() =>
+          hookProgressiveLoader(self.loader, el.sceneEl.renderer)
+        )
+      : this.ready;
+
+    ready.then(function () {
       self.el.emit('model-loading', { src });
       function gltfLoaded(gltfModel) {
         if (src !== self.data) {
@@ -413,8 +382,10 @@ export const gltfModelPlus = {
       }
       // The 2nd+ loader of a src clones a pristine template parsed once by loadParsedGltf
       // instead of re-parsing (skips re-download, draco/image decode and accessor→geometry
-      // build). The first loader parses the GLB directly.
-      const cacheOn = !globalThis.__gltfCacheDisabled;
+      // build). The first loader parses the GLB directly. Progressive models never clone: the
+      // needle extension refines each parsed instance's meshes/textures in place with its own
+      // per-instance LOD state, which a clone of a template would bypass (and stay low-LOD).
+      const cacheOn = !globalThis.__gltfCacheDisabled && !progressive;
       if (cacheOn && srcLoadCount(src) >= 2) {
         loadParsedGltf(self.loader, el.sceneEl, src, onProgress)
           .then((entry) => {

--- a/src/aframe-components/gltf-model.js
+++ b/src/aframe-components/gltf-model.js
@@ -9,6 +9,31 @@ import {
   BATCHING_ENABLED
 } from '../batch-models';
 
+// Progressive-LOD streaming spike (#1990): opt-in via `?progressive` in the URL or
+// localStorage.progressiveModels = 'true'. While enabled, every gltf-model loader is hooked
+// with needle-tools' gltf-progressive so needle-processed GLBs stream low-LOD-first; models
+// without needle LOD data load byte-for-byte unchanged, so hooking unconditionally is safe.
+// The library is imported dynamically because merely evaluating its module has side effects
+// (a decoder-reachability fetch, eager DRACO/KTX2 loader construction, a `Needle` global)
+// that must not run for users outside the spike.
+let progressiveSpike; // undefined = flag not read yet; null = off; Promise = module loading
+function getProgressiveSpike() {
+  if (progressiveSpike === undefined) {
+    let enabled = false;
+    try {
+      enabled =
+        new URLSearchParams(window.location.search).has('progressive') ||
+        window.localStorage.getItem('progressiveModels') === 'true';
+    } catch (e) {
+      // location/localStorage access can throw (privacy modes, workers) — spike stays off.
+    }
+    progressiveSpike = enabled
+      ? import('@needle-tools/gltf-progressive')
+      : null;
+  }
+  return progressiveSpike;
+}
+
 // Share one decoded THREE.Source across textures (within and across GLBs) that embed the
 // byte-identical image. The server bakes images[].extras.imageHash; GLTFLoader.loadImageSource
 // surfaces image extras on texture.userData, and at that point the Texture has only just been
@@ -243,6 +268,26 @@ export const gltfModelPlus = {
     }
     if (ktxLoader) {
       this.loader.setKTX2Loader(ktxLoader);
+    }
+    // #1990 spike: hook progressive streaming onto this loader. Chained into this.ready so
+    // loadModel() cannot race the hook registration. useNeedleProgressive only fills decoders
+    // the loader is still missing, so the A-Frame-provided DRACO/KTX2/meshopt above win.
+    const spike = getProgressiveSpike();
+    if (spike) {
+      const hooked = spike
+        .then(({ useNeedleProgressive }) => {
+          if (sceneEl.renderer) {
+            useNeedleProgressive(self.loader, sceneEl.renderer);
+          } else {
+            console.warn(
+              '[gltf-model] progressive spike: renderer unavailable at init; loader not hooked'
+            );
+          }
+        })
+        .catch((err) => {
+          console.warn('[gltf-model] progressive spike failed to load:', err);
+        });
+      this.ready = Promise.all([this.ready, hooked]).then(() => {});
     }
   },
 

--- a/src/batch-models.js
+++ b/src/batch-models.js
@@ -1,6 +1,7 @@
 /* global AFRAME, THREE, ImageBitmap */
 
 import { releaseSharedSource } from './sharedTextureSources';
+import { isProgressiveModelUrl } from './tested/progressive-models';
 
 // Static batching feature flag.
 // The flag is used to conditionnaly register the gltf-model component override and batch models, so it can't be
@@ -205,9 +206,15 @@ const BATCHABLE_SELECTOR = '[gltf-model], [gltf-part], [atlas-uvs]';
 function getBatchProvider(el) {
   const gltfModel = el.components?.['gltf-model'];
   if (gltfModel) {
+    const src = el.getAttribute('gltf-model');
+    // Progressive-streaming models (#1990) refine their meshes/textures at runtime, which a
+    // fixed-buffer BatchedMesh can't follow. A null key already excludes an entity from
+    // deferral, grouping and late repack; skipReason keeps the log honest about why.
+    const progressive = isProgressiveModelUrl(src);
     return {
       kind: 'gltf-model',
-      key: el.getAttribute('gltf-model'),
+      key: progressive ? null : src,
+      skipReason: progressive ? 'progressive-streaming model' : undefined,
       ownsResources: true,
       strip: () => gltfModel.removeMesh(),
       reload: () => gltfModel.update()
@@ -1451,12 +1458,13 @@ export async function batchModels(sceneEl) {
     );
   }
 
-  // Group by key. Missing-key entities have no model to load — just log + status, no BVH.
+  // Group by key. Missing-key entities either have no model to load or are excluded by their
+  // provider (see getBatchProvider skipReason) — just log + status, no BVH.
   const groups = new Map();
   for (const el of gltfEntities) {
     const key = getBatchKey(el);
     if (!key) {
-      const reason = 'no gltf-model src';
+      const reason = getBatchProvider(el)?.skipReason || 'no gltf-model src';
       console.log(`[batch-models] not batched ${describeEl(el)}: ${reason}`);
       setStatus(el, false, reason);
       continue;

--- a/src/tested/progressive-models.js
+++ b/src/tested/progressive-models.js
@@ -1,0 +1,75 @@
+/**
+ * Progressive-LOD streaming for large user-uploaded GLBs (#1990).
+ *
+ * Large uploads are processed by Needle Cloud into a progressive GLB (tiny low-LOD
+ * core, mesh/texture LODs streamed on demand) and served from Needle's CDN. That CDN
+ * URL becomes the asset's `optimizedSourceUrl`, so it flows into `gltf-model` src
+ * through the ordinary served-URL path and gets persisted verbatim in scene JSON.
+ * Saved scenes carry nothing else about the asset, so the ONLY runtime signal that a
+ * model streams is its URL: `isProgressiveModelUrl` is the single predicate every
+ * runtime exclusion keys off (loader hook, batching, clone-template cache).
+ *
+ * The needle library is imported lazily: merely evaluating its module has side
+ * effects (a decoder-reachability fetch, eager DRACO/KTX2 loader construction, a
+ * `Needle` global), so it must not run in sessions with no progressive model.
+ */
+
+/** Hostnames whose GLBs are Needle-processed progressive models. */
+export const PROGRESSIVE_MODEL_HOSTS = ['cloud.needle.tools'];
+
+/**
+ * True when a gltf-model src points at a progressive-streaming model.
+ * Accepts the raw URL or A-Frame's `url(...)` wrapped form; anything unparsable
+ * (blob:, relative catalog paths, empty) is not progressive.
+ */
+export function isProgressiveModelUrl(src) {
+  if (typeof src !== 'string') return false;
+  const url = src
+    .trim()
+    .replace(/^url\((.*)\)$/s, '$1')
+    .trim();
+  if (!/^https?:\/\//i.test(url)) return false;
+  let hostname;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch (e) {
+    return false;
+  }
+  return PROGRESSIVE_MODEL_HOSTS.includes(hostname);
+}
+
+let libraryPromise = null;
+const hookedLoaders = new WeakSet();
+
+/**
+ * Hook needle's progressive extension onto a GLTFLoader (idempotent per loader).
+ * Resolves once the loader is ready to load a progressive URL; never rejects — a
+ * failed hook logs and resolves so the caller's load proceeds and surfaces its own
+ * model-error (which the asset-fallback system turns into a storageUrl retry).
+ *
+ * `useNeedleProgressive` only fills decoders the loader still lacks, so a caller's
+ * DRACO/meshopt/KTX2 setup wins. In practice the KTX2 transcoder comes from the
+ * library's default (Needle's CDN): A-Frame configures none, and needle output is
+ * always KHR_texture_basisu. Same availability domain as the models themselves.
+ */
+export function hookProgressiveLoader(loader, renderer) {
+  if (!loader || hookedLoaders.has(loader)) return Promise.resolve();
+  if (!renderer) {
+    console.warn(
+      '[progressive-models] renderer unavailable; loader not hooked, model will load unstreamed if at all'
+    );
+    return Promise.resolve();
+  }
+  if (!libraryPromise) {
+    libraryPromise = import('@needle-tools/gltf-progressive');
+  }
+  return libraryPromise
+    .then(({ useNeedleProgressive }) => {
+      if (hookedLoaders.has(loader)) return;
+      useNeedleProgressive(loader, renderer);
+      hookedLoaders.add(loader);
+    })
+    .catch((err) => {
+      console.warn('[progressive-models] failed to hook loader:', err);
+    });
+}

--- a/test/core/progressive-models.test.js
+++ b/test/core/progressive-models.test.js
@@ -1,0 +1,80 @@
+/* global describe, it */
+
+/**
+ * Progressive-streaming model predicate (#1990).
+ *
+ * Saved scenes persist only the gltf-model URL for a user asset, so the URL is the
+ * single runtime signal that a model streams progressively. Every runtime exclusion
+ * (loader hook, batching, clone-template cache) keys off this predicate, so it must
+ * accept exactly the Needle CDN forms and nothing else.
+ */
+
+import assert from 'assert';
+import {
+  isProgressiveModelUrl,
+  PROGRESSIVE_MODEL_HOSTS
+} from '../../src/tested/progressive-models.js';
+
+const NEEDLE_URL =
+  'https://cloud.needle.tools/-/assets/Z23hhzB1ZHhKeJ-product/file';
+
+describe('isProgressiveModelUrl', () => {
+  it('matches a Needle CDN served URL, raw or url()-wrapped', () => {
+    assert.strictEqual(isProgressiveModelUrl(NEEDLE_URL), true);
+    assert.strictEqual(isProgressiveModelUrl(`url(${NEEDLE_URL})`), true);
+    assert.strictEqual(isProgressiveModelUrl(`  url( ${NEEDLE_URL} ) `), true);
+    assert.strictEqual(
+      isProgressiveModelUrl(
+        NEEDLE_URL.replace('https://cloud', 'HTTPS://CLOUD')
+      ),
+      true
+    );
+  });
+
+  it('rejects Firebase Storage, catalog, blob and relative sources', () => {
+    assert.strictEqual(
+      isProgressiveModelUrl(
+        'https://firebasestorage.googleapis.com/v0/b/x/o/users%2Fu%2Fa.glb?alt=media&token=t'
+      ),
+      false
+    );
+    assert.strictEqual(
+      isProgressiveModelUrl(
+        'https://assets.3dstreet.app/sets/vehicles/gltf-exports/draco/car.glb'
+      ),
+      false
+    );
+    assert.strictEqual(
+      isProgressiveModelUrl('blob:https://3dstreet.app/abc'),
+      false
+    );
+    assert.strictEqual(isProgressiveModelUrl('#gltf-part-src'), false);
+    assert.strictEqual(isProgressiveModelUrl('models/thing.glb'), false);
+  });
+
+  it('rejects look-alike hosts and non-strings', () => {
+    assert.strictEqual(
+      isProgressiveModelUrl(
+        'https://cloud.needle.tools.evil.com/-/assets/x/file'
+      ),
+      false
+    );
+    assert.strictEqual(
+      isProgressiveModelUrl('https://evil.com/?u=https://cloud.needle.tools/x'),
+      false
+    );
+    assert.strictEqual(isProgressiveModelUrl(''), false);
+    assert.strictEqual(isProgressiveModelUrl(null), false);
+    assert.strictEqual(isProgressiveModelUrl(undefined), false);
+    assert.strictEqual(isProgressiveModelUrl({ src: NEEDLE_URL }), false);
+  });
+
+  it('keys purely off the host allowlist', () => {
+    for (const host of PROGRESSIVE_MODEL_HOSTS) {
+      assert.strictEqual(
+        isProgressiveModelUrl(`https://${host}/anything`),
+        true
+      );
+    }
+  });
+});


### PR DESCRIPTION
Spike + plan for #1990: stream large user-uploaded GLBs with needle-tools `gltf-progressive`, processed by Needle Cloud, reusing the existing generationJobs/RAD job pipeline. **Draft: nothing here is meant to ship yet.** The full plan and state of work live in `docs/plans/1990-progressive-glb-streaming.md`; this description is the resume point.

## What's on the branch

- `@needle-tools/gltf-progressive@3.6.1` (MIT, exact pin; peer `three >= 0.160` satisfied by our 0.184).
- **Phase 1 runtime integration (URL-keyed, no flag):** `src/tested/progressive-models.js` exposes `isProgressiveModelUrl` (hostname allowlist: `cloud.needle.tools`) and an idempotent `hookProgressiveLoader`. `gltf-model` hooks needle's extension only for those srcs and skips the clone-template cache for them; `batch-models` excludes them from batching (log reason `progressive-streaming model`); `asset-fallback` now retries `storageUrl` when the optimized/CDN URL fails. The library stays a lazy webpack chunk (main bundle +0.5 KB); the KTX2 transcoder keeps the library's Needle CDN default, fetched only when a Needle-hosted model loads. Unit test: `test/core/progressive-models.test.js`. `&debugprogressive` in the URL still enables the library's LOD logs.
- `docs/plans/1990-progressive-glb-streaming.md`: decisions, architecture, phases 0-3, risks.

## Phase 0 spike: PASSED (2026-09-11, local, Meshy AI building GLB)

Source `1001SCapitolSt` Meshy export: 76.2 MB, 1.67M tris, 3x 2048 JPEG, uncompressed.

| | Bytes to first render | Time to first render |
|---|---|---|
| Original (how uploads load today) | 76.2 MB | 32.8 s download, then >45 s main-thread parse freeze |
| Needle progressive | **3.7 MB** | **869 ms** |

- Initial file carries mesh LOD2 (417k tris) with 512px textures; on close-up it streamed mesh LOD0 (full 1.67M) and 2048 textures through our own `gltf-model` loader.
- No `Texture is immutable` / WebGL errors across LOD swaps: the library replaces the material's Texture and refcount-disposes the old one, the pattern our shared-texture extension requires.
- Needle CLI upload + process round trip for 76 MB: ~2 min (upload ~1 min). Needle "optimized" (Draco+KTX2, non-progressive) output: 12.4 MB.
- Two duplicates loaded fine with their own LOD state; batching was not active in that session, so the BatchedMesh interaction is still unverified (Phase 1 excludes progressive URLs from batching regardless).

## Learned during the spike (affects Phase 1/2)

- **KTX2 is mandatory.** Needle output uses `KHR_texture_basisu`; A-Frame 1.8 sets a default Draco path but no KTX2 transcoder, so without the hook the load fails ("setKTX2Loader must be called before loading KTX2 textures"). The hook fills it from Needle's CDN (`cdn.needle.tools/static/three/0.179.1/basis2/`). Decided in Phase 1: keep that default, since it is only fetched when a Needle-hosted model loads and so adds no availability domain beyond the model itself; revisit if we ever self-host the models.
- **Needle CLI (3.x):** command is `optimize`, not `upload`: `npx needle-cloud optimize <file.glb> --token <t> --progressive true --name <id>`. `NEEDLE_CLOUD_TOKEN` env var was read but rejected; `--token` works. `--usecase world` produced no `-world` variant, only `-product`. CLI prints only the edit URL; get the served URL from `needle-cloud list --token <t> --output json` (`url` field): `https://cloud.needle.tools/-/assets/<viewId>-product/file`, siblings `<viewId>-optimized/file` and `<viewId>/file` (original). Served with `access-control-allow-origin: *` and public cache headers despite `is_public: false`.
- **Threshold:** >10 MB may be too high; ~5 MB is plausible. Decide after processing a mid-size (5-15 MB) upload both ways (Needle vs existing client-side Draco+WebP).

## Phase 2 prep findings (2026-09-12)

- **Needle Cloud has no deletion API.** needle-cloud 2.5.0 (latest; there is no 3.x) has no delete command, its bundle makes no DELETE request, its MCP server exposes no content-management tool, and the docs describe no REST API beyond outgoing webhooks. Deleting an asset is web-UI only. **Decision proposed:** asset GC writes an orphan ledger for purged assets that have a Needle copy, and we ask Needle support about an API; the ledger is the manual purge list until then. Alternative (not recommended): gate the feature on deletion support.
- **`--usecase world` works** on a fresh `--name`; `list --output json` returns the `-world` URL in `url` (plus `identifier`, `title`, `is_public`). The spike's "product only" result was a name reuse. The worker reads the URL from `list` filtered by the name it passed to `optimize`.
- **Editor pass passed** with the world URL (numbers in the checklist below). The dev server on :3333 was a stale process from the night before; restart it after pulling.
- **Token handling:** the Needle token belongs in Secret Manager for the worker; rotate it before deploy. It is not in the repo.

## Plan in brief (details in the doc)

Needle's progressive output becomes the "optimized variant" for large GLBs, mirroring the RAD splat pipeline: `onCreate` asset trigger -> `generationJobs` doc (`kind: 'glb-progressive'`, `provider: 'cloudrun'`, `tokenCost: 0`) -> Cloud Tasks -> small Node worker runs the Needle CLI -> writes `optimizedSourceUrl` / `optimizedSourceSize` / `optimizationMetadata` on the asset doc. No new asset-doc fields, no firestore.rules changes, no quota changes, `getServedUrl` untouched. Uploads >threshold skip the client-side gltf-transform pass. Runtime: hook loader only for Needle URLs, exclude progressive URLs from batching and the clone-template cache, fallback to `storageUrl` if the Needle CDN is unreachable.

## Next

- [x] Phase 1 runtime integration (predicate + loader hook, batching + clone-cache exclusions, fallback, KTX2 transcoder decision)
- [x] Phase 1 editor pass with the progressive-world URL: loaded in 608 ms at 58k tris, refined to 1.67M on close-up, 3 duplicates unbatched + uncached, clean delete, no WebGL/texture errors (details in the plan doc)
- [ ] CDN blocked → storageUrl fallback and save/reload, on dev once Phase 2 writes a real `optimizedSourceUrl`
- [ ] Threshold decision from a mid-size file
- [ ] **Kieran:** email Needle support about programmatic deletion; confirm the orphan-ledger GC approach
- [ ] Phase 2 pipeline: client-side split at 10 MB (`uploadAndPlaceAsset.js`), `progressive-dispatch.js` trigger + `generationJobs` doc (`kind: 'glb-progressive'`), `needle-uploader/` Cloud Run worker (pinned needle-cloud 2.5.0, `optimize --progressive true --usecase world --name <assetId>`, then `list --output json` for the URL), reconciler kind-aware re-enqueue, orphan ledger in `asset-gc.js`
- [ ] Phase 2 deploy needs from Kieran: Needle token in Secret Manager, Cloud Run deploy on dev
- [ ] Phase 3 UI polish + agent-context docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)




